### PR TITLE
Podcast discovery, on-demand transcription enrichment, and OpenAPI updates

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -32,6 +32,14 @@
       "description": "Semantic search across podcast transcripts using vector embeddings."
     },
     {
+      "name": "Discovery",
+      "description": "LLM-assisted podcast feed and episode search across 4M+ podcasts via the Podcast Index. Routes natural language queries to the best search backends for people, topics, and shows."
+    },
+    {
+      "name": "On-Demand Transcription",
+      "description": "Submit podcast episodes for transcription, timestamped chaptering, keyword extraction, and permanent semantic indexing. Poll for job status and receive chapter data on completion. Once indexed, content is searchable via the Search endpoints."
+    },
+    {
       "name": "Research Sessions",
       "description": "Create, retrieve, share, and analyze research sessions — curated collections of podcast clips."
     },
@@ -704,6 +712,641 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/api/on-demand/submitOnDemandRun": {
+      "post": {
+        "tags": [
+          "On-Demand Transcription"
+        ],
+        "summary": "Submit a podcast episode for transcription, chaptering, and semantic indexing",
+        "description": "Submits a podcast episode for full transcription, timestamped chaptering, keyword extraction, and permanent semantic indexing. Returns a pollable job status URL. Once indexed, content is searchable via /api/search-quotes. L402 prepaid access limited to 1 episode per request. Use /api/discover-podcasts to find episode GUIDs.\\n\\nA metered free tier is available: send the header `X-Free-Tier: true` to use quota-based access without payment. Anonymous users get 2 transcriptions per week; registered users get 5 per month. Omit the header (or use L402 credentials) for paid access.",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "Transcribe latest episode from Bankless"
+                },
+                "parameters": {
+                  "type": "object",
+                  "properties": {}
+                },
+                "episodes": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "guid": {
+                        "type": "string",
+                        "example": "dd043afd-d7f8-4a96-97aa-a24a743fc219"
+                      },
+                      "feedGuid": {
+                        "type": "string",
+                        "example": "3d510171-b9ab-517c-bbf3-1fd5542479ad"
+                      },
+                      "feedId": {
+                        "type": "string",
+                        "example": "357756"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job submitted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "jobId": {
+                      "type": "string",
+                      "example": "6b2440adae3f806198eb56c0"
+                    },
+                    "totalEpisodes": {
+                      "type": "number",
+                      "example": 1
+                    },
+                    "totalFeeds": {
+                      "type": "number",
+                      "example": 1
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "On-demand run submitted successfully"
+                    },
+                    "nextSteps": {
+                      "type": "object",
+                      "properties": {
+                        "pollJobStatus": {
+                          "type": "object",
+                          "properties": {
+                            "description": {
+                              "type": "string",
+                              "example": "Poll until status is \"complete\". Typical transcription takes 30-120 seconds per episode."
+                            },
+                            "method": {
+                              "type": "string",
+                              "example": "GET"
+                            },
+                            "url": {
+                              "type": "string",
+                              "example": "/api/on-demand/getOnDemandJobStatus/6b2440adae3f806198eb56c0"
+                            },
+                            "pollIntervalSeconds": {
+                              "type": "number",
+                              "example": 15
+                            }
+                          }
+                        },
+                        "searchTranscripts": {
+                          "type": "object",
+                          "properties": {
+                            "description": {
+                              "type": "string",
+                              "example": "Once job is complete, search the transcribed content with semantic queries"
+                            },
+                            "method": {
+                              "type": "string",
+                              "example": "POST"
+                            },
+                            "url": {
+                              "type": "string",
+                              "example": "/api/search-quotes"
+                            },
+                            "body": {
+                              "type": "object",
+                              "properties": {
+                                "query": {
+                                  "type": "string",
+                                  "example": "..."
+                                },
+                                "feedIds": {
+                                  "type": "array",
+                                  "example": [
+                                    "357756"
+                                  ],
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "smartMode": {
+                                  "type": "boolean",
+                                  "example": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "jobId": {
+                      "type": "string",
+                      "example": "6b2440adae3f806198eb56c0"
+                    },
+                    "totalEpisodes": {
+                      "type": "number",
+                      "example": 1
+                    },
+                    "totalFeeds": {
+                      "type": "number",
+                      "example": 1
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "On-demand run submitted successfully"
+                    },
+                    "nextSteps": {
+                      "type": "object",
+                      "properties": {
+                        "pollJobStatus": {
+                          "type": "object",
+                          "properties": {
+                            "description": {
+                              "type": "string",
+                              "example": "Poll until status is \"complete\". Typical transcription takes 30-120 seconds per episode."
+                            },
+                            "method": {
+                              "type": "string",
+                              "example": "GET"
+                            },
+                            "url": {
+                              "type": "string",
+                              "example": "/api/on-demand/getOnDemandJobStatus/6b2440adae3f806198eb56c0"
+                            },
+                            "pollIntervalSeconds": {
+                              "type": "number",
+                              "example": 15
+                            }
+                          }
+                        },
+                        "searchTranscripts": {
+                          "type": "object",
+                          "properties": {
+                            "description": {
+                              "type": "string",
+                              "example": "Once job is complete, search the transcribed content with semantic queries"
+                            },
+                            "method": {
+                              "type": "string",
+                              "example": "POST"
+                            },
+                            "url": {
+                              "type": "string",
+                              "example": "/api/search-quotes"
+                            },
+                            "body": {
+                              "type": "object",
+                              "properties": {
+                                "query": {
+                                  "type": "string",
+                                  "example": "..."
+                                },
+                                "feedIds": {
+                                  "type": "array",
+                                  "example": [
+                                    "357756"
+                                  ],
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "smartMode": {
+                                  "type": "boolean",
+                                  "example": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error or L402 batch limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — returns Lightning invoice"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "example": "any"
+                  },
+                  "parameters": {
+                    "example": "any"
+                  },
+                  "episodes": {
+                    "example": "any"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/on-demand/getOnDemandJobStatus/{jobId}": {
+      "get": {
+        "tags": [
+          "On-Demand Transcription"
+        ],
+        "summary": "Get transcription job status with chapters on completion",
+        "description": "Returns job status and per-episode progress. When status is \"complete\", the response is enriched with chapter headlines, keywords, summaries, and timestamps for each successfully transcribed episode, plus a nextSteps block pointing to /api/search-quotes for semantic search across the newly indexed content. No authentication required — anyone with the jobId can poll.",
+        "parameters": [
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Job ID returned by submitOnDemandRun"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job status with optional chapter enrichment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "jobId": {
+                      "type": "string",
+                      "example": "6b2440adae3f806198eb56c0"
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "complete"
+                    },
+                    "stats": {
+                      "type": "object",
+                      "properties": {
+                        "totalEpisodes": {
+                          "type": "number",
+                          "example": 1
+                        },
+                        "totalFeeds": {
+                          "type": "number",
+                          "example": 1
+                        },
+                        "episodesProcessed": {
+                          "type": "number",
+                          "example": 1
+                        },
+                        "episodesSkipped": {
+                          "type": "number",
+                          "example": 0
+                        },
+                        "episodesFailed": {
+                          "type": "number",
+                          "example": 0
+                        }
+                      }
+                    },
+                    "episodes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "guid": {
+                            "type": "string",
+                            "example": "dd043afd-d7f8-4a96-97aa-a24a743fc219"
+                          },
+                          "feedId": {
+                            "type": "string",
+                            "example": "357756"
+                          },
+                          "status": {
+                            "type": "string",
+                            "example": "success"
+                          },
+                          "chapters": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "chapterNumber": {
+                                  "type": "number",
+                                  "example": 1
+                                },
+                                "headline": {
+                                  "type": "string",
+                                  "example": "SEC and CFTC Developments in Crypto"
+                                },
+                                "keywords": {
+                                  "type": "array",
+                                  "example": [
+                                    "SEC",
+                                    "CFTC",
+                                    "crypto regulations"
+                                  ],
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "summary": {
+                                  "type": "string",
+                                  "example": "Discussion on SEC and CFTC actions regarding crypto..."
+                                },
+                                "startTime": {
+                                  "type": "number",
+                                  "example": 0
+                                },
+                                "endTime": {
+                                  "type": "number",
+                                  "example": 159.48
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "nextSteps": {
+                      "type": "object",
+                      "properties": {
+                        "searchTranscripts": {
+                          "type": "object",
+                          "properties": {
+                            "description": {
+                              "type": "string",
+                              "example": "Semantic search across the newly transcribed content with timestamped deeplinks"
+                            },
+                            "method": {
+                              "type": "string",
+                              "example": "POST"
+                            },
+                            "url": {
+                              "type": "string",
+                              "example": "/api/search-quotes"
+                            },
+                            "body": {
+                              "type": "object",
+                              "properties": {
+                                "query": {
+                                  "type": "string",
+                                  "example": "..."
+                                },
+                                "feedIds": {
+                                  "type": "array",
+                                  "example": [
+                                    "357756"
+                                  ],
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "smartMode": {
+                                  "type": "boolean",
+                                  "example": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "jobId": {
+                      "type": "string",
+                      "example": "6b2440adae3f806198eb56c0"
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "complete"
+                    },
+                    "stats": {
+                      "type": "object",
+                      "properties": {
+                        "totalEpisodes": {
+                          "type": "number",
+                          "example": 1
+                        },
+                        "totalFeeds": {
+                          "type": "number",
+                          "example": 1
+                        },
+                        "episodesProcessed": {
+                          "type": "number",
+                          "example": 1
+                        },
+                        "episodesSkipped": {
+                          "type": "number",
+                          "example": 0
+                        },
+                        "episodesFailed": {
+                          "type": "number",
+                          "example": 0
+                        }
+                      }
+                    },
+                    "episodes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "guid": {
+                            "type": "string",
+                            "example": "dd043afd-d7f8-4a96-97aa-a24a743fc219"
+                          },
+                          "feedId": {
+                            "type": "string",
+                            "example": "357756"
+                          },
+                          "status": {
+                            "type": "string",
+                            "example": "success"
+                          },
+                          "chapters": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "chapterNumber": {
+                                  "type": "number",
+                                  "example": 1
+                                },
+                                "headline": {
+                                  "type": "string",
+                                  "example": "SEC and CFTC Developments in Crypto"
+                                },
+                                "keywords": {
+                                  "type": "array",
+                                  "example": [
+                                    "SEC",
+                                    "CFTC",
+                                    "crypto regulations"
+                                  ],
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "summary": {
+                                  "type": "string",
+                                  "example": "Discussion on SEC and CFTC actions regarding crypto..."
+                                },
+                                "startTime": {
+                                  "type": "number",
+                                  "example": 0
+                                },
+                                "endTime": {
+                                  "type": "number",
+                                  "example": 159.48
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "nextSteps": {
+                      "type": "object",
+                      "properties": {
+                        "searchTranscripts": {
+                          "type": "object",
+                          "properties": {
+                            "description": {
+                              "type": "string",
+                              "example": "Semantic search across the newly transcribed content with timestamped deeplinks"
+                            },
+                            "method": {
+                              "type": "string",
+                              "example": "POST"
+                            },
+                            "url": {
+                              "type": "string",
+                              "example": "/api/search-quotes"
+                            },
+                            "body": {
+                              "type": "object",
+                              "properties": {
+                                "query": {
+                                  "type": "string",
+                                  "example": "..."
+                                },
+                                "feedIds": {
+                                  "type": "array",
+                                  "example": [
+                                    "357756"
+                                  ],
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "smartMode": {
+                                  "type": "boolean",
+                                  "example": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "404": {
+            "description": "Job not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
           }
         }
       }
@@ -3640,6 +4283,63 @@
           },
           "503": {
             "description": "Service Unavailable"
+          }
+        }
+      }
+    },
+    "/api/discover-podcasts": {
+      "post": {
+        "tags": [
+          "Discovery"
+        ],
+        "summary": "LLM-assisted podcast discovery across the Podcast Index catalog",
+        "description": "Takes a natural language query, classifies intent via LLM, and routes to the appropriate Podcast Index search backends (byterm, byperson, trending). Returns matching podcasts enriched with transcript availability flags and actionable next-step endpoints. Use for deep research, person dossiers, prospecting prep, competitive intelligence, or topic exploration.\\n\\nA metered free tier is available: send the header `X-Free-Tier: true` to use quota-based access without payment. Anonymous users get 10 queries per week; registered users get 30 per month. Omit the header (or use L402 credentials) for paid access.",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "query": {
+                  "type": "string",
+                  "example": "bitcoin mining podcasts"
+                },
+                "limit": {
+                  "type": "number",
+                  "example": 10
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "example": "any"
+                  },
+                  "limit": {
+                    "example": "any"
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/routes/discoverRoutes.js
+++ b/routes/discoverRoutes.js
@@ -272,7 +272,7 @@ function buildNextSteps(feed, transcriptAvailable) {
 router.post('/discover-podcasts', serviceHmac({ optional: true }), createEntitlementMiddleware(ENTITLEMENT_TYPES.DISCOVER_PODCASTS), async (req, res) => {
   // #swagger.tags = ['Discovery']
   // #swagger.summary = 'LLM-assisted podcast discovery across the Podcast Index catalog'
-  // #swagger.description = 'Takes a natural language query, classifies intent, routes to the appropriate Podcast Index search backends (byterm, byperson, trending), and returns matching podcasts enriched with transcript availability flags and actionable next-step endpoints.'
+  // #swagger.description = 'Takes a natural language query, classifies intent via LLM, and routes to the appropriate Podcast Index search backends (byterm, byperson, trending). Returns matching podcasts enriched with transcript availability flags and actionable next-step endpoints. Use for deep research, person dossiers, prospecting prep, competitive intelligence, or topic exploration.\n\nA metered free tier is available: send the header `X-Free-Tier: true` to use quota-based access without payment. Anonymous users get 10 queries per week; registered users get 30 per month. Omit the header (or use L402 credentials) for paid access.'
   /* #swagger.parameters['body'] = {
     in: 'body',
     required: true,

--- a/routes/onDemandRuns.js
+++ b/routes/onDemandRuns.js
@@ -116,8 +116,56 @@ function isPeriodExpired(periodStart, periodLengthDays) {
  * Uses new entitlement middleware for authentication and quota management
  */
 router.post('/submitOnDemandRun', serviceHmac({ optional: true }), createEntitlementMiddleware(ENTITLEMENT_TYPES.SUBMIT_ON_DEMAND_RUN), async (req, res) => {
+    // #swagger.tags = ['On-Demand Transcription']
+    // #swagger.summary = 'Submit a podcast episode for transcription, chaptering, and semantic indexing'
+    // #swagger.description = 'Submits a podcast episode for full transcription, timestamped chaptering, keyword extraction, and permanent semantic indexing. Returns a pollable job status URL. Once indexed, content is searchable via /api/search-quotes. L402 prepaid access limited to 1 episode per request. Use /api/discover-podcasts to find episode GUIDs.\n\nA metered free tier is available: send the header `X-Free-Tier: true` to use quota-based access without payment. Anonymous users get 2 transcriptions per week; registered users get 5 per month. Omit the header (or use L402 credentials) for paid access.'
+    /* #swagger.parameters['body'] = {
+      in: 'body',
+      required: true,
+      schema: {
+        message: 'Transcribe latest episode from Bankless',
+        parameters: {},
+        episodes: [
+          {
+            guid: 'dd043afd-d7f8-4a96-97aa-a24a743fc219',
+            feedGuid: '3d510171-b9ab-517c-bbf3-1fd5542479ad',
+            feedId: '357756'
+          }
+        ]
+      }
+    } */
+    /* #swagger.responses[200] = {
+      description: 'Job submitted successfully',
+      schema: {
+        success: true,
+        jobId: '6b2440adae3f806198eb56c0',
+        totalEpisodes: 1,
+        totalFeeds: 1,
+        message: 'On-demand run submitted successfully',
+        nextSteps: {
+          pollJobStatus: {
+            description: 'Poll until status is "complete". Typical transcription takes 30-120 seconds per episode.',
+            method: 'GET',
+            url: '/api/on-demand/getOnDemandJobStatus/6b2440adae3f806198eb56c0',
+            pollIntervalSeconds: 15
+          },
+          searchTranscripts: {
+            description: 'Once job is complete, search the transcribed content with semantic queries',
+            method: 'POST',
+            url: '/api/search-quotes',
+            body: { query: '...', feedIds: ['357756'], smartMode: true }
+          }
+        }
+      }
+    } */
+    /* #swagger.responses[400] = {
+      description: 'Validation error or L402 batch limit exceeded',
+      schema: { $ref: '#/components/schemas/Error' }
+    } */
+    /* #swagger.responses[402] = {
+      description: 'Payment required — returns Lightning invoice'
+    } */
     try {
-        // Identity and entitlement already resolved by middleware
         const { identity, entitlement } = req;
 
         const { message, parameters, episodes } = req.body;
@@ -337,6 +385,44 @@ function formatChapter(doc) {
  * Get status of an on-demand job. When complete, includes chapter data and nextSteps.
  */
 router.get('/getOnDemandJobStatus/:jobId', async (req, res) => {
+    // #swagger.tags = ['On-Demand Transcription']
+    // #swagger.summary = 'Get transcription job status with chapters on completion'
+    // #swagger.description = 'Returns job status and per-episode progress. When status is "complete", the response is enriched with chapter headlines, keywords, summaries, and timestamps for each successfully transcribed episode, plus a nextSteps block pointing to /api/search-quotes for semantic search across the newly indexed content. No authentication required — anyone with the jobId can poll.'
+    /* #swagger.parameters['jobId'] = { in: 'path', required: true, type: 'string', description: 'Job ID returned by submitOnDemandRun' } */
+    /* #swagger.responses[200] = {
+      description: 'Job status with optional chapter enrichment',
+      schema: {
+        success: true,
+        jobId: '6b2440adae3f806198eb56c0',
+        status: 'complete',
+        stats: { totalEpisodes: 1, totalFeeds: 1, episodesProcessed: 1, episodesSkipped: 0, episodesFailed: 0 },
+        episodes: [{
+          guid: 'dd043afd-d7f8-4a96-97aa-a24a743fc219',
+          feedId: '357756',
+          status: 'success',
+          chapters: [{
+            chapterNumber: 1,
+            headline: 'SEC and CFTC Developments in Crypto',
+            keywords: ['SEC', 'CFTC', 'crypto regulations'],
+            summary: 'Discussion on SEC and CFTC actions regarding crypto...',
+            startTime: 0,
+            endTime: 159.48
+          }]
+        }],
+        nextSteps: {
+          searchTranscripts: {
+            description: 'Semantic search across the newly transcribed content with timestamped deeplinks',
+            method: 'POST',
+            url: '/api/search-quotes',
+            body: { query: '...', feedIds: ['357756'], smartMode: true }
+          }
+        }
+      }
+    } */
+    /* #swagger.responses[404] = {
+      description: 'Job not found',
+      schema: { $ref: '#/components/schemas/Error' }
+    } */
     try {
         const { jobId } = req.params;
 

--- a/swagger.js
+++ b/swagger.js
@@ -37,6 +37,14 @@ const doc = {
       description: 'Semantic search across podcast transcripts using vector embeddings.'
     },
     {
+      name: 'Discovery',
+      description: 'LLM-assisted podcast feed and episode search across 4M+ podcasts via the Podcast Index. Routes natural language queries to the best search backends for people, topics, and shows.'
+    },
+    {
+      name: 'On-Demand Transcription',
+      description: 'Submit podcast episodes for transcription, timestamped chaptering, keyword extraction, and permanent semantic indexing. Poll for job status and receive chapter data on completion. Once indexed, content is searchable via the Search endpoints.'
+    },
+    {
       name: 'Research Sessions',
       description: 'Create, retrieve, share, and analyze research sessions — curated collections of podcast clips.'
     },
@@ -227,7 +235,8 @@ const ALLOWED_TAGS = new Set([
   'Research Sessions',
   'Create',
   'Agent Auth',
-  'Discovery'
+  'Discovery',
+  'On-Demand Transcription'
 ]);
 
 swaggerAutogen(outputFile, routes, doc).then(({ success, data }) => {


### PR DESCRIPTION
## Summary

- **Podcast Discovery endpoint** (`POST /api/discover-podcasts`): LLM-assisted search across 4M+ podcasts via Podcast Index. Routes natural language queries to byterm, byperson, and trending backends. Includes 3-layer quality pipeline (refined LLM prompt, string-based name filter, LLM re-ranking). Results enriched with transcript availability from MongoDB and actionable nextSteps.
- **On-demand transcription enrichment**: `submitOnDemandRun` response now includes `nextSteps` with poll URL and pre-filled search-quotes body. `getOnDemandJobStatus` returns chapter headlines, keywords, summaries, and timestamps when job completes, plus nextSteps to search-quotes.
- **L402 billing fix**: Capped L402 prepaid transcription requests to 1 episode per request to prevent batch billing bypass.
- **Default invoice raised** from 500 to 1000 sats.
- **OpenAPI spec regenerated** with full annotations for Discovery (3 endpoints) and On-Demand Transcription (2 endpoints). Free tier documented with `X-Free-Tier` header and quota details.
- **402 Index registrations submitted** for Podcast Intelligence Search and Podcast Episode Transcription & Semantic Indexing (pending review).

## Test plan

- [x] Discover → Search Quotes flow (Elon Musk on JRE → scoped transcript search)
- [x] Discover → Get Episodes → Transcribe flow (Bankless → submit → poll → complete with chapters)
- [x] Search newly transcribed content (Bankless episode searchable immediately after indexing)
- [x] L402 batch limit enforcement (2 episodes rejected, 1 episode accepted)
- [x] 402 Index probe verification (both endpoints return healthy 402 with macaroon + invoice)


Made with [Cursor](https://cursor.com)