### PR TITLE
Fix: default post status to scheduled, unsigned only for nostr drafts

### DIFF
--- a/models/SocialPost.js
+++ b/models/SocialPost.js
@@ -66,7 +66,7 @@ const SocialPostSchema = new mongoose.Schema({
   status: {
     type: String,
     enum: ['scheduled', 'processing', 'posted', 'failed', 'cancelled', 'unsigned'],
-    default: 'unsigned',
+    default: 'scheduled',
     index: true
   },
   

--- a/scripts/fix-unsigned-twitter.js
+++ b/scripts/fix-unsigned-twitter.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * One-off script: promote all unsigned Twitter posts to scheduled.
+ * Twitter has no signing concept — these were created with a bad default.
+ *
+ * Usage: node scripts/fix-unsigned-twitter.js [--dry-run]
+ */
+
+require('dotenv').config();
+const mongoose = require('mongoose');
+const SocialPost = require('../models/SocialPost');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+async function main() {
+    const mongoURI = process.env.DEBUG_MODE === 'true'
+        ? process.env.MONGO_DEBUG_URI
+        : process.env.MONGO_URI;
+
+    await mongoose.connect(mongoURI);
+    console.log('Connected to MongoDB');
+
+    const filter = { platform: 'twitter', status: 'unsigned' };
+    const count = await SocialPost.countDocuments(filter);
+    console.log(`Found ${count} unsigned Twitter post(s)`);
+
+    if (count === 0) {
+        console.log('Nothing to do.');
+        await mongoose.disconnect();
+        process.exit(0);
+    }
+
+    if (DRY_RUN) {
+        const posts = await SocialPost.find(filter).select('_id adminEmail scheduledFor content.text').lean();
+        posts.forEach(p => console.log(`  [DRY RUN] ${p._id} | ${p.adminEmail || 'no-email'} | ${p.scheduledFor} | "${(p.content?.text || '').slice(0, 60)}"`));
+        console.log(`\nDry run complete. ${count} post(s) would be updated. Re-run without --dry-run to apply.`);
+    } else {
+        const result = await SocialPost.updateMany(filter, { $set: { status: 'scheduled' } });
+        console.log(`Updated ${result.modifiedCount} Twitter post(s) from "unsigned" -> "scheduled"`);
+    }
+
+    await mongoose.disconnect();
+    console.log('Done.');
+}
+
+main().catch(err => {
+    console.error('Error:', err);
+    process.exit(1);
+});

--- a/utils/SocialPostService.js
+++ b/utils/SocialPostService.js
@@ -50,7 +50,7 @@ function validateSignedEvent(signedEvent) {
  * @param {string} [params.timezone='America/Chicago']
  * @param {Object} [params.platformData]
  * @param {string} [params.scheduledPostSlotId]
- * @param {string} [params.status='unsigned'] - 'unsigned' (default, safe for drafts) or 'scheduled' (requires signedEvent for nostr)
+ * @param {string} [params.status] - 'scheduled' (default) or 'unsigned' (nostr drafts only). Nostr auto-promotes to scheduled when signedEvent is valid.
  * @returns {Promise<Array>} created SocialPost documents
  */
 async function schedulePosts(params) {
@@ -64,7 +64,7 @@ async function schedulePosts(params) {
         timezone = 'America/Chicago',
         platformData: inputPlatformData = {},
         scheduledPostSlotId,
-        status: requestedStatus = 'unsigned'
+        status: requestedStatus
     } = params || {};
 
     // Require at least one identifier
@@ -75,8 +75,10 @@ async function schedulePosts(params) {
     assert(scheduledFor, 'Scheduled date/time is required');
     assert(Array.isArray(platforms) && platforms.length > 0, 'At least one platform must be specified');
 
-    const validStatuses = ['unsigned', 'scheduled'];
-    assert(validStatuses.includes(requestedStatus), `Invalid status: ${requestedStatus}. Must be one of: ${validStatuses.join(', ')}`);
+    if (requestedStatus) {
+        const validStatuses = ['unsigned', 'scheduled'];
+        assert(validStatuses.includes(requestedStatus), `Invalid status: ${requestedStatus}. Must be one of: ${validStatuses.join(', ')}`);
+    }
 
     const validPlatforms = SocialPost.getPlatformOptions();
     const invalidPlatforms = platforms.filter(p => !validPlatforms.includes(p));
@@ -91,11 +93,16 @@ async function schedulePosts(params) {
             platformData.twitterTokens = inputPlatformData.twitterTokens;
         }
 
+        let effectiveStatus = requestedStatus || 'scheduled';
+
         if (platform === 'nostr') {
-            if (requestedStatus === 'scheduled') {
+            if (platformData.signedEvent) {
                 validateSignedEvent(platformData.signedEvent);
-            } else if (platformData.signedEvent) {
-                validateSignedEvent(platformData.signedEvent);
+                effectiveStatus = requestedStatus || 'scheduled';
+            } else if (effectiveStatus === 'scheduled') {
+                // Nostr post wants to be scheduled but has no signedEvent -- downgrade to unsigned
+                effectiveStatus = 'unsigned';
+                console.log(`Nostr post has no signedEvent, setting status to unsigned`);
             }
 
             if (!platformData.nostrRelays || platformData.nostrRelays.length === 0) {
@@ -116,7 +123,7 @@ async function schedulePosts(params) {
                 mediaUrl: hasMedia ? String(mediaUrl) : null
             },
             platformData,
-            status: requestedStatus
+            status: effectiveStatus
         });
 
         await socialPost.save();


### PR DESCRIPTION
## Summary
- Twitter posts (and all non-nostr platforms) were incorrectly defaulting to `unsigned` status, preventing the cron processor from picking them up
- Changed default status back to `scheduled` for all platforms; only nostr posts without a `signedEvent` are downgraded to `unsigned`
- Nostr posts with a valid `signedEvent` auto-promote to `scheduled` regardless of whether the client sends `status`
- Includes one-off migration script (`scripts/fix-unsigned-twitter.js`) to fix existing unsigned Twitter posts in the DB

## Test plan
- [x] Twitter POST without `status` param returns `scheduled`
- [x] Nostr POST with valid `signedEvent` returns `scheduled`
- [x] Nostr POST without `signedEvent` returns `unsigned`
- [x] Processor picks up and posts scheduled Twitter posts
- [x] Migration script dry-run + apply verified against production DB

Made with [Cursor](https://cursor.com)