### PR TITLE
Improve discover recency coverage and upsell relevance

### DIFF
--- a/routes/agentChatRoutes.js
+++ b/routes/agentChatRoutes.js
@@ -7,6 +7,7 @@ const { SYSTEM_PROMPT, TOOL_DEFINITIONS } = require('../setup-agent');
 const { PROFILES, VALID_INTENTS, DEFAULT_INTENT, CLASSIFIER_PROMPT } = require('../setup-agent-profiles');
 const { executeAgentTool, TOOL_COSTS } = require('../utils/agentToolHandler');
 const JamieVectorMetadata = require('../models/JamieVectorMetadata');
+const { filterUpsellCandidates } = require('../utils/upsellRelevance');
 
 const AGENT_LOG_DIR = path.join(__dirname, '..', 'logs', 'agent');
 try { fs.mkdirSync(AGENT_LOG_DIR, { recursive: true }); } catch {}
@@ -82,8 +83,35 @@ function createCostTracker(modelConfig) {
 
 const SEARCH_QUOTES_KEEP = new Set(['quote', 'shareLink', 'episode', 'creator', 'date', 'summary', 'headline']);
 const FIND_PERSON_KEEP = new Set(['name', 'role', 'appearances', 'feeds', 'recentEpisodes']);
-const DISCOVER_KEEP_FEED = new Set(['title', 'feedId', 'feedGuid', 'transcriptAvailable', 'matchedEpisodes', 'nextSteps']);
-const DISCOVER_KEEP_EP = new Set(['title', 'guid', 'feedGuid', 'feedId', 'transcriptAvailable', 'image', 'publishedDate']);
+const DISCOVER_KEEP_FEED = new Set(['title', 'feedId', 'feedGuid', 'transcriptAvailable', 'matchedEpisodes', 'episodes', 'nextSteps']);
+const DISCOVER_AGENT_EP_DESC_MAX = 120;
+
+function stripDiscoverDescForAgent(text, maxLen) {
+  if (!text || typeof text !== 'string') return '';
+  const s = text.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+  if (s.length <= maxLen) return s;
+  return `${s.slice(0, maxLen)}…`;
+}
+
+/** Episodes the main agent sees from discover: title, transcript flag, short description, guests — full guid kept for suggest_action */
+function compactDiscoverEpisodeForAgent(ep) {
+  if (!ep) return ep;
+  const out = {
+    title: ep.title,
+    guid: ep.guid,
+    transcriptAvailable: !!ep.transcriptAvailable,
+    publishedDate: ep.publishedDate || ep.date || null,
+  };
+  const desc = stripDiscoverDescForAgent(ep.description || '', DISCOVER_AGENT_EP_DESC_MAX);
+  if (desc) out.description = desc;
+  if (Array.isArray(ep.guests) && ep.guests.length) {
+    out.guests = ep.guests.slice(0, 5);
+  }
+  if (ep.feedId != null) out.feedId = ep.feedId;
+  if (ep.feedGuid) out.feedGuid = ep.feedGuid;
+  if (ep.image) out.image = ep.image;
+  return out;
+}
 
 function compactSearchQuotesResult(r, i) {
   const c = { _i: i };
@@ -100,14 +128,8 @@ function compactSearchQuotesResult(r, i) {
 function compactDiscoverResult(r, i) {
   const c = { _i: i };
   for (const k of DISCOVER_KEEP_FEED) {
-    if (k === 'matchedEpisodes' && Array.isArray(r[k])) {
-      c[k] = r[k].map(ep => {
-        const slim = {};
-        for (const ek of DISCOVER_KEEP_EP) {
-          if (ep[ek] !== undefined) slim[ek] = ep[ek];
-        }
-        return slim;
-      });
+    if ((k === 'matchedEpisodes' || k === 'episodes') && Array.isArray(r[k])) {
+      c[k] = r[k].map(ep => compactDiscoverEpisodeForAgent(ep));
     } else if (r[k] !== undefined) {
       c[k] = r[k];
     }
@@ -1034,13 +1056,18 @@ function createAgentChatRoutes({ openai } = {}) {
       };
       writeAgentLog(requestId, sessionId, agentLog);
 
-      // Auto-upsell: surface untranscribed episodes from discover results the agent didn't suggest
+      // Auto-upsell: surface untranscribed episodes from discover results the agent didn't suggest.
+      // Before emitting, run each candidate through a tiered relevance filter
+      // (language + token overlap, then optional gpt-4o-mini batch classification)
+      // to avoid surfacing irrelevant shows (e.g. a Spanish-language podcast for an English query).
       const AUTO_UPSELL_MAX = 2;
       let autoUpsellEmitted = 0;
       let autoUpsellAttempted = 0;
       let autoUpsellDropped = 0;
       let autoUpsellDeduped = 0;
-      outer: for (const feed of discoverResults) {
+
+      const allCandidates = [];
+      for (const feed of discoverResults) {
         const feedFallback = {
           feedGuid: feed.feedGuid || feed.podcastGuid || null,
           feedId: feed.feedId != null ? String(feed.feedId) : null,
@@ -1053,28 +1080,67 @@ function createAgentChatRoutes({ openai } = {}) {
           ...(feed.episodes || []),
         ];
         for (const ep of candidateEpisodes) {
-          if (autoUpsellEmitted >= AUTO_UPSELL_MAX) break outer;
-          autoUpsellAttempted++;
-          const result = emitSubmitOnDemand(
-            {
-              reason: `${feed.title || 'This show'} has untranscribed episodes that may be relevant.`,
-              guid: ep.guid || null,
-              feedGuid: ep.feedGuid || null,
-              feedId: ep.feedId != null ? String(ep.feedId) : null,
-              episodeTitle: ep.title || null,
-              image: ep.image || null,
-            },
-            { emit, episodeCache, suggestedGuids, requestId, feedFallback, origin: 'auto-upsell' },
-          );
-          if (result.emitted) autoUpsellEmitted++;
-          else if (result.reason === 'dedup') autoUpsellDeduped++;
-          else autoUpsellDropped++;
+          allCandidates.push({ feed, episode: ep, feedFallback });
         }
       }
-      if (autoUpsellAttempted > 0) {
-        printLog(`[${requestId}] Auto-upsell summary: attempted=${autoUpsellAttempted} emitted=${autoUpsellEmitted} dropped=${autoUpsellDropped} deduped=${autoUpsellDeduped} (max=${AUTO_UPSELL_MAX}, from ${discoverResults.length} discover feed(s))`);
+
+      let filterResult = {
+        approved: allCandidates,
+        totalCandidates: allCandidates.length,
+        filteredByLang: 0,
+        filteredByOverlap: 0,
+        filteredByLLM: 0,
+        llmSkipped: true,
+        llmReason: 'no-candidates',
+        latencyMs: 0,
+      };
+      if (allCandidates.length > 0) {
+        filterResult = await filterUpsellCandidates({
+          query: message,
+          candidates: allCandidates,
+          openai,
+          requestId,
+        });
+      }
+
+      for (const cand of filterResult.approved) {
+        if (autoUpsellEmitted >= AUTO_UPSELL_MAX) break;
+        autoUpsellAttempted++;
+        const feed = cand.feed || {};
+        const ep = cand.episode || {};
+        const result = emitSubmitOnDemand(
+          {
+            reason: `${feed.title || 'This show'} has untranscribed episodes that may be relevant.`,
+            guid: ep.guid || null,
+            feedGuid: ep.feedGuid || null,
+            feedId: ep.feedId != null ? String(ep.feedId) : null,
+            episodeTitle: ep.title || null,
+            image: ep.image || null,
+          },
+          { emit, episodeCache, suggestedGuids, requestId, feedFallback: cand.feedFallback, origin: 'auto-upsell' },
+        );
+        if (result.emitted) autoUpsellEmitted++;
+        else if (result.reason === 'dedup') autoUpsellDeduped++;
+        else autoUpsellDropped++;
+      }
+
+      const anyFilterActivity = filterResult.filteredByLang || filterResult.filteredByOverlap || filterResult.filteredByLLM;
+      if (autoUpsellAttempted > 0 || anyFilterActivity) {
+        console.log(
+          `[${requestId}] Auto-upsell summary: ` +
+          `totalCandidates=${filterResult.totalCandidates} ` +
+          `filteredByLang=${filterResult.filteredByLang} ` +
+          `filteredByOverlap=${filterResult.filteredByOverlap} ` +
+          `filteredByLLM=${filterResult.filteredByLLM} ` +
+          `approved=${filterResult.approved.length} ` +
+          `attempted=${autoUpsellAttempted} emitted=${autoUpsellEmitted} ` +
+          `dropped=${autoUpsellDropped} deduped=${autoUpsellDeduped} ` +
+          `llmSkipped=${filterResult.llmSkipped}${filterResult.llmReason ? `(${filterResult.llmReason})` : ''} ` +
+          `filterMs=${filterResult.latencyMs} ` +
+          `(max=${AUTO_UPSELL_MAX}, from ${discoverResults.length} discover feed(s))`
+        );
       } else if (discoverResults.length > 0) {
-        printLog(`[${requestId}] Auto-upsell: 0 candidates from ${discoverResults.length} discover feed(s) — no untranscribed matchedEpisodes`);
+        console.log(`[${requestId}] Auto-upsell: 0 candidates from ${discoverResults.length} discover feed(s) — no untranscribed matchedEpisodes`);
       }
 
       emit('done', {

--- a/routes/discoverRoutes.js
+++ b/routes/discoverRoutes.js
@@ -12,7 +12,12 @@ const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 const RSS_EXTRACTOR_BASE = 'https://rss-extractor-app-yufbq.ondigitalocean.app';
 const RSS_TIMEOUT_MS = 10000;
-const MAX_EPISODE_FETCH_FEEDS = 2;
+/** Max feeds per bucket (untranscribed vs transcribed-gap) for RSS episode fetch in one discover call */
+const MAX_EPISODE_FETCH_FEEDS = 4;
+/** Newest episodes attached to transcribed feeds (corpus gap / upsell); keep small for latency + tokens */
+const MAX_TRANSCRIBED_FETCH_EPISODES = 5;
+/** Untranscribed feeds: slightly more context for the agent */
+const MAX_UNTRANSCRIBED_FETCH_EPISODES = 10;
 
 const RSS_HEADERS = {
   'accept': 'application/json',
@@ -222,6 +227,27 @@ function normalizeFeed(raw) {
     categories: raw.categories || {},
     trendScore: raw.trendScore || null
   };
+}
+
+function stripHtmlTruncate(text, maxLen) {
+  if (!text || typeof text !== 'string') return '';
+  const plain = text.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+  if (plain.length <= maxLen) return plain;
+  return `${plain.slice(0, maxLen)}…`;
+}
+
+function extractEpisodeGuests(ep) {
+  const raw =
+    ep.guests ||
+    ep.itunesGuests ||
+    ep.persons ||
+    ep.dcCreator ||
+    ep.author;
+  if (Array.isArray(raw)) {
+    return raw.map(g => (typeof g === 'string' ? g : g?.name || g?.title || '')).filter(Boolean).slice(0, 8);
+  }
+  if (typeof raw === 'string' && raw.trim()) return [raw.trim()];
+  return [];
 }
 
 function normalizePersonEpisode(item) {
@@ -494,10 +520,8 @@ async function discoverPodcasts({ query, limit = 10 }) {
     printLog(`[${requestId}] LLM filter pass (${timings.filter}ms)`);
   }
 
-  const hasBypersonQuery = bypersonQueries.length > 0;
   const needsUntranscribedFetch = results.some(r => !r.transcriptAvailable && !r.matchedEpisodes);
-  const needsTranscribedGapFetch = hasBypersonQuery &&
-    results.some(r => r.transcriptAvailable && !r.matchedEpisodes);
+  const needsTranscribedGapFetch = results.some(r => r.transcriptAvailable && !r.matchedEpisodes);
   const shouldFetchEpisodes = routing.fetch_episodes || needsUntranscribedFetch || needsTranscribedGapFetch;
 
   if (shouldFetchEpisodes) {
@@ -505,11 +529,9 @@ async function discoverPodcasts({ query, limit = 10 }) {
       .filter(r => !r.transcriptAvailable && !r.matchedEpisodes)
       .slice(0, MAX_EPISODE_FETCH_FEEDS);
 
-    const transcribedGapToFetch = hasBypersonQuery
-      ? results
-          .filter(r => r.transcriptAvailable && !r.matchedEpisodes)
-          .slice(0, MAX_EPISODE_FETCH_FEEDS)
-      : [];
+    const transcribedGapToFetch = results
+      .filter(r => r.transcriptAvailable && !r.matchedEpisodes)
+      .slice(0, MAX_EPISODE_FETCH_FEEDS);
 
     const allToFetch = [...untranscribedToFetch, ...transcribedGapToFetch];
 
@@ -531,19 +553,30 @@ async function discoverPodcasts({ query, limit = 10 }) {
         if (!feedResult || episodes.length === 0) { normalizedByIndex.push(null); continue; }
         if (!feedResult.feedGuid && feedGuid) feedResult.feedGuid = feedGuid;
 
-        const normalizedEpisodes = episodes.slice(0, 10).map(ep => ({
-          guid: ep.episodeGUID || ep.enclosureUrl || ep.itemUUID,
-          title: ep.itemTitle || ep.title || 'Untitled',
-          date: ep.publishedDate
-            ? new Date(ep.publishedDate * 1000).toISOString().split('T')[0]
-            : null,
-          duration: ep.length || ep.duration || null,
-          feedGuid: feedResult.feedGuid,
-          feedId: feedResult.feedId,
-          image: ep.image || ep.feedImage || ep.artwork || '',
-          enclosureUrl: ep.enclosureUrl || '',
-          link: ep.link || '',
-        }));
+        const maxEp = feedResult.transcriptAvailable
+          ? MAX_TRANSCRIBED_FETCH_EPISODES
+          : MAX_UNTRANSCRIBED_FETCH_EPISODES;
+        const normalizedEpisodes = episodes.slice(0, maxEp).map(rawEp => {
+          const descRaw = rawEp.itemDescription || rawEp.description || rawEp.summary || '';
+          const guests = extractEpisodeGuests(rawEp);
+          const dateStr = rawEp.publishedDate
+            ? new Date(rawEp.publishedDate * 1000).toISOString().split('T')[0]
+            : null;
+          return {
+            guid: rawEp.episodeGUID || rawEp.enclosureUrl || rawEp.itemUUID,
+            title: rawEp.itemTitle || rawEp.title || 'Untitled',
+            date: dateStr,
+            publishedDate: dateStr,
+            description: stripHtmlTruncate(descRaw, 600),
+            guests,
+            duration: rawEp.length || rawEp.duration || null,
+            feedGuid: feedResult.feedGuid,
+            feedId: feedResult.feedId,
+            image: rawEp.image || rawEp.feedImage || rawEp.artwork || '',
+            enclosureUrl: rawEp.enclosureUrl || '',
+            link: rawEp.link || '',
+          };
+        });
         normalizedByIndex.push(normalizedEpisodes);
         for (const ep of normalizedEpisodes) {
           if (ep.guid) allFetchedGuids.push(ep.guid);

--- a/setup-agent.js
+++ b/setup-agent.js
@@ -53,13 +53,13 @@ PROMPT_SECTIONS.searchTools = `
 
 - **search_quotes**: Semantic vector search across all transcribed podcast content (Pinecone). This is your MOST POWERFUL tool — it finds relevant quotes even when exact keywords don't match. Always try this first for any topic query.
 - **search_chapters**: Keyword/regex search on chapter metadata (headlines, keywords, summaries). Good for structured segments but may miss content that search_quotes would find. Use short keyword phrases (1-3 words), not full sentences.
-- **discover_podcasts**: Searches the external Podcast Index (4M+ feeds) for podcasts by topic. Useful for finding shows the user might not know about. Does NOT search already-transcribed shows.
+- **discover_podcasts**: Searches the **live Podcast Index** (4M+ feeds) for podcasts by topic, name, or person. Returns each feed with an overall \`transcriptAvailable\` flag AND per-episode \`matchedEpisodes[].transcriptAvailable\` flags. Use it to find NEW shows **and** to probe a known/transcribed feed for RECENT un-ingested episodes (our corpus may be stale relative to the live RSS).
 - **find_person**: Looks up a person by name across indexed shows. Returns guest/creator appearances AND hostedFeeds — feeds where the person is a known host/owner. Each hosted feed includes feedId, feedType (interview/solo/panel/null), and hosts. Use hostedFeeds to split your search strategy (see SPLIT SEARCH STRATEGY rule).
 - **get_person_episodes**: Gets all episodes featuring a specific person.
 - **list_episode_chapters**: Fetches ALL chapters (table of contents) for specific episodes. Use after find_person/get_person_episodes to see what topics were covered, then craft targeted search_quotes queries from the chapter headlines.
 - **get_episode**: Fetch full metadata for a single episode by GUID. Use when you need episode details (title, date, guests, artwork) beyond what search_quotes returns.
 - **get_feed**: Fetch metadata for a podcast feed by ID. Returns feed name, episode count, artwork, description, hosts (array of host names), and feedType (interview/solo/panel/null when available).
-- **get_feed_episodes**: List episodes for a feed with optional date filtering. Use for "what has this show covered recently?" or browsing a feed's catalog.
+- **get_feed_episodes**: List episodes for a feed with optional date filtering — **scoped to our transcribed corpus only** (i.e. episodes we have already ingested). If this returns 0 for a date window but the feed is known to be active, the episodes likely exist on the live RSS but are un-ingested — in that case call \`discover_podcasts\` to surface them as transcription candidates.
 - **get_adjacent_paragraphs**: Expand context around a specific paragraph. Use when a search_quotes result looks promising but you need surrounding context to verify relevance or extract a longer passage. Pass the shareLink value from search_quotes results as the paragraphId.
 - **suggest_action**: Surface a transcription suggestion or follow-up option to the user. Three types: submit-on-demand (offer transcription of an untranscribed episode — only pass the episode guid, the server fills in the rest), create-clip (future), follow-up-message (pre-filled chat message with optional pre-resolved context). Does NOT execute the action.`;
 
@@ -112,6 +112,7 @@ After your search_quotes call, you MUST run discover_podcasts if ANY of these ar
 1. **User assumption mismatch**: The user asked about content on Show X, but your search results came from Show Y. Run discover_podcasts to check if Show X has the content untranscribed. Do NOT just offer to check — actually do it.
 2. **User names a show not in the Feed ID Lookup table** — they want content we likely don't have. Run discover_podcasts to find it.
 3. **search_quotes returned 0 results** for the user's intended source — the content may exist untranscribed.
+4. **Recency gap on a known feed**: The user asks what a show has covered in a recent time window ("in April", "this month", "last week", "latest"), and either search_quotes / get_feed_episodes returned 0 for that window OR the returned episodes are older than the requested window. Our corpus is NOT the live RSS — call discover_podcasts with the show name (or the show name + a topic term) to surface recent un-ingested episodes as submit-on-demand candidates.
 
 You SHOULD also run discover_podcasts (not mandatory, but strongly encouraged) when:
 - Your search results come from only 1-2 feeds and the topic is broadly discussed
@@ -273,7 +274,7 @@ const TOOL_DEFINITIONS = [
   },
   {
     name: 'discover_podcasts',
-    description: 'Search the external Podcast Index catalog (4M+ feeds) for podcasts by topic. Returns feeds with transcript availability flags. Use to find NEW shows, not to search existing transcripts.',
+    description: 'Search the live Podcast Index catalog (4M+ feeds) for podcasts by topic, show name, or person. Returns each feed with an overall transcriptAvailable flag and per-episode matchedEpisodes[].transcriptAvailable flags from the live RSS. Use to (a) find NEW shows the user may not know about, and (b) probe a known/transcribed feed for RECENT episodes that our corpus has not yet ingested (so they can be surfaced as transcription candidates).',
     input_schema: {
       type: 'object',
       properties: {
@@ -343,7 +344,7 @@ const TOOL_DEFINITIONS = [
   },
   {
     name: 'get_feed_episodes',
-    description: 'List episodes for a specific podcast feed with optional date filtering. Use for "what has show X covered recently?" queries or to browse a feed\'s catalog. Returns slim metadata by default (title, date, GUID, guests). Verbose mode adds descriptions but is capped at 5 episodes to control token cost.',
+    description: 'List episodes for a specific podcast feed **scoped to our transcribed corpus only** (NOT the live RSS). Use to browse what we have already ingested for a feed, or to confirm coverage within a date window. If minDate/maxDate returns 0 episodes for an active show, the episodes likely exist on the live RSS but are un-ingested — in that case call discover_podcasts to surface them as transcription candidates. Returns slim metadata by default (title, date, GUID, guests). Verbose mode adds descriptions but is capped at 5 episodes to control token cost.',
     input_schema: {
       type: 'object',
       properties: {

--- a/utils/upsellRelevance.js
+++ b/utils/upsellRelevance.js
@@ -1,0 +1,274 @@
+/**
+ * Relevance filter for auto-upsell suggestedActions.
+ *
+ * Roland's feedback (2026-04-23): the agent surfaced an irrelevant Spanish
+ * podcast as a submit-on-demand card because the upsell pass blindly iterates
+ * every feed returned by discover_podcasts during the session.
+ *
+ * This module prunes candidates in two tiers before they reach emitSubmitOnDemand:
+ *   Tier 1 (free, ~0ms):     language match + lexical token overlap.
+ *   Tier 2 (tiny LLM, ~300ms): one gpt-4o-mini batch call when 2+ candidates
+ *                              survive Tier 1. Prompt uses compact 0-based indices;
+ *                              model returns JSON { "keep": [0, 2, ...] } (indices only,
+ *                              no false entries) to minimize tokens.
+ *
+ * Failure-open: any LLM error or >3s timeout falls back to Tier-1 survivors
+ * rather than blocking the response.
+ */
+
+const { printLog } = require('../constants.js');
+
+const STOPWORDS = new Set([
+  'a', 'an', 'and', 'or', 'but', 'the', 'of', 'in', 'on', 'at', 'to', 'for',
+  'with', 'about', 'from', 'up', 'down', 'out', 'over', 'under', 'into',
+  'onto', 'off', 'as', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
+  'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'should',
+  'could', 'can', 'may', 'might', 'must', 'shall', 'that', 'this', 'these',
+  'those', 'it', 'its', 'i', 'you', 'he', 'she', 'we', 'they', 'me', 'him',
+  'her', 'us', 'them', 'my', 'your', 'his', 'our', 'their', 'what', 'which',
+  'who', 'whom', 'whose', 'when', 'where', 'why', 'how', 'if', 'then', 'so',
+  'than', 'because', 'while', 'just', 'only', 'not', 'no', 'yes', 'some',
+  'any', 'all', 'each', 'every', 'both', 'few', 'more', 'most', 'other',
+  'another', 'such', 'same', 'own', 'also', 'very', 'too', 'really', 'get',
+  'got', 'gets', 'said', 'say', 'says', 'like', 'one', 'two', 'still',
+  'even', 'back', 'ever', 'never', 'also', 'podcast', 'podcasts', 'show',
+  'shows', 'episode', 'episodes', 'ep', 'eps',
+]);
+
+const CJK_RE = /[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]/;
+const CYRILLIC_RE = /[\u0400-\u04ff]/;
+const ARABIC_RE = /[\u0600-\u06ff]/;
+const DEVANAGARI_RE = /[\u0900-\u097f]/;
+const HEBREW_RE = /[\u0590-\u05ff]/;
+const LATIN_DIACRITIC_RE = /[ñáéíóúüçàèìòùâêîôûÁÉÍÓÚÑÜÇÀÈÌÒÙÂÊÎÔÛ¿¡]/;
+
+/**
+ * Cheap language detection for short user queries.
+ * Intentionally coarse: we only need to distinguish "English" from
+ * "clearly-not-English" to drop mismatched podcasts.
+ */
+function detectQueryLanguage(query) {
+  if (!query || typeof query !== 'string') return 'unknown';
+  if (CJK_RE.test(query)) return 'cjk';
+  if (CYRILLIC_RE.test(query)) return 'ru';
+  if (ARABIC_RE.test(query)) return 'ar';
+  if (DEVANAGARI_RE.test(query)) return 'hi';
+  if (HEBREW_RE.test(query)) return 'he';
+  if (LATIN_DIACRITIC_RE.test(query)) {
+    if (/ñ/i.test(query)) return 'es';
+    return 'latin-other';
+  }
+  return 'en';
+}
+
+/**
+ * Does a PodcastIndex `language` field match the detected query language?
+ * Empty/missing candidate languages are treated as unknown and kept
+ * (PodcastIndex data is frequently missing this field).
+ */
+function languageMatches(candidateLang, queryLang) {
+  if (!candidateLang) return true;
+  const c = String(candidateLang).toLowerCase().trim();
+  if (!c) return true;
+  if (queryLang === 'en') return c.startsWith('en');
+  if (queryLang === 'es') return c.startsWith('es');
+  if (queryLang === 'cjk') {
+    return c.startsWith('zh') || c.startsWith('ja') || c.startsWith('ko');
+  }
+  if (queryLang === 'ru') return c.startsWith('ru');
+  if (queryLang === 'ar') return c.startsWith('ar');
+  if (queryLang === 'hi') return c.startsWith('hi');
+  if (queryLang === 'he') return c.startsWith('he') || c.startsWith('iw');
+  return true;
+}
+
+function tokenize(text) {
+  if (!text || typeof text !== 'string') return [];
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter(t => t.length >= 2 && !STOPWORDS.has(t));
+}
+
+function hasTokenOverlap(queryTokens, candidateText) {
+  if (!queryTokens.length) return true;
+  const candTokens = new Set(tokenize(candidateText));
+  if (candTokens.size === 0) return false;
+  for (const q of queryTokens) {
+    if (candTokens.has(q)) return true;
+  }
+  return false;
+}
+
+function clamp(str, max) {
+  if (!str) return '';
+  const s = String(str).replace(/\s+/g, ' ').trim();
+  return s.length > max ? s.slice(0, max) : s;
+}
+
+/**
+ * Filter untranscribed-episode upsell candidates by relevance to the user query.
+ *
+ * @param {object}   params
+ * @param {string}   params.query       - The user message driving this request.
+ * @param {Array<{feed: object, episode: object, feedFallback: object}>} params.candidates
+ * @param {object}   [params.openai]    - OpenAI client (if absent, Tier 2 is skipped).
+ * @param {string}   [params.requestId]
+ * @param {number}   [params.llmTimeoutMs=3000]
+ * @returns {Promise<{
+ *   approved: Array,
+ *   totalCandidates: number,
+ *   filteredByLang: number,
+ *   filteredByOverlap: number,
+ *   filteredByLLM: number,
+ *   llmSkipped: boolean,
+ *   llmReason: string|null,
+ *   latencyMs: number,
+ * }>}
+ */
+async function filterUpsellCandidates({
+  query,
+  candidates,
+  openai,
+  requestId = 'UPSELL',
+  llmTimeoutMs = 3000,
+}) {
+  const t0 = Date.now();
+  const result = {
+    approved: [],
+    totalCandidates: Array.isArray(candidates) ? candidates.length : 0,
+    filteredByLang: 0,
+    filteredByOverlap: 0,
+    filteredByLLM: 0,
+    llmSkipped: false,
+    llmReason: null,
+    latencyMs: 0,
+  };
+
+  if (!Array.isArray(candidates) || candidates.length === 0) {
+    result.llmSkipped = true;
+    result.llmReason = 'no-candidates';
+    return result;
+  }
+
+  const queryLang = detectQueryLanguage(query);
+  const queryTokens = tokenize(query || '');
+
+  // --- Tier 1: language + token overlap ---
+  const tier1Survivors = [];
+  for (const cand of candidates) {
+    const feed = cand.feed || {};
+    const ep = cand.episode || {};
+
+    if (!languageMatches(feed.language, queryLang)) {
+      result.filteredByLang++;
+      continue;
+    }
+
+    const guestStr = Array.isArray(ep.guests) ? ep.guests.join(' ') : '';
+    const haystack = [
+      feed.title || '',
+      feed.author || '',
+      feed.description || '',
+      ep.title || '',
+      ep.description || '',
+      guestStr,
+    ].join(' ');
+
+    if (!hasTokenOverlap(queryTokens, haystack)) {
+      result.filteredByOverlap++;
+      continue;
+    }
+
+    tier1Survivors.push(cand);
+  }
+
+  if (tier1Survivors.length === 0) {
+    result.llmSkipped = true;
+    result.llmReason = 'no-tier1-survivors';
+    result.latencyMs = Date.now() - t0;
+    return result;
+  }
+
+  // If only one candidate made it through Tier 1, the LLM call adds no value.
+  if (tier1Survivors.length === 1 || !openai) {
+    result.approved = tier1Survivors;
+    result.llmSkipped = true;
+    result.llmReason = !openai ? 'no-openai-client' : 'single-survivor';
+    result.latencyMs = Date.now() - t0;
+    return result;
+  }
+
+  // --- Tier 2: gpt-4o-mini batch relevance (compact index ids, reply with keep[] only) ---
+  const lines = tier1Survivors.map((cand, idx) => {
+    const feed = cand.feed || {};
+    const ep = cand.episode || {};
+    const desc = clamp(ep.description || feed.description || '', 160);
+    const guests = Array.isArray(ep.guests) && ep.guests.length
+      ? clamp(ep.guests.join(', '), 80)
+      : '';
+    const guestPart = guests ? ` | guests="${guests}"` : '';
+    return `[${idx}] feed="${clamp(feed.title || '', 70)}" | ep="${clamp(ep.title || '', 90)}" | lang=${feed.language || 'unknown'} | desc="${desc}"${guestPart}`;
+  }).join('\n');
+
+  const systemPrompt = 'You are a podcast-relevance classifier for transcription upsell suggestions. Reply ONLY with JSON: { "keep": [<indices>] } where keep is a list of 0-based candidate indices that are plausibly relevant to the user\'s specific query (not just the same broad topic). List ONLY indices to include — omit rejected candidates entirely. If none qualify, return {"keep":[]}.';
+  const userPrompt = `User query: ${JSON.stringify(query || '')}\n\nCandidates (use the number in brackets as the id):\n${lines}\n\nReturn JSON: {"keep":[...]} — only indices worth offering for transcription.`;
+
+  try {
+    const llmPromise = openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      temperature: 0,
+      max_tokens: 120,
+      response_format: { type: 'json_object' },
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userPrompt },
+      ],
+    });
+    const timeoutPromise = new Promise((_, reject) => {
+      setTimeout(() => reject(new Error(`gpt-4o-mini relevance timed out after ${llmTimeoutMs}ms`)), llmTimeoutMs);
+    });
+
+    const resp = await Promise.race([llmPromise, timeoutPromise]);
+    const raw = resp?.choices?.[0]?.message?.content || '{}';
+
+    let parsed;
+    try { parsed = JSON.parse(raw); } catch { parsed = {}; }
+
+    const keepIdx = new Set();
+    const rawKeep = parsed.keep ?? parsed.indices ?? parsed.include;
+    if (Array.isArray(rawKeep)) {
+      for (const x of rawKeep) {
+        const n = typeof x === 'number' ? x : parseInt(String(x), 10);
+        if (!Number.isFinite(n)) continue;
+        const i = Math.trunc(n);
+        if (i >= 0 && i < tier1Survivors.length) keepIdx.add(i);
+      }
+    }
+
+    const approved = [];
+    for (let i = 0; i < tier1Survivors.length; i++) {
+      if (keepIdx.has(i)) approved.push(tier1Survivors[i]);
+      else result.filteredByLLM++;
+    }
+    result.approved = approved;
+    result.latencyMs = Date.now() - t0;
+    return result;
+  } catch (err) {
+    printLog(`[${requestId}] upsell relevance Tier 2 fallback (${err.message}) — keeping ${tier1Survivors.length} Tier-1 survivor(s)`);
+    result.approved = tier1Survivors;
+    result.llmSkipped = true;
+    result.llmReason = `tier2-error: ${err.message}`;
+    result.latencyMs = Date.now() - t0;
+    return result;
+  }
+}
+
+module.exports = {
+  filterUpsellCandidates,
+  detectQueryLanguage,
+  languageMatches,
+  tokenize,
+  hasTokenOverlap,
+};


### PR DESCRIPTION
## Summary
- update discover/agent prompt guidance so the model treats `discover_podcasts` as live RSS coverage and `get_feed_episodes` as corpus-only coverage, including explicit recency-gap behavior
- fetch and enrich per-episode data for transcribed feed recency gaps in `discover_podcasts`, then expose compact episode context (title, transcript status, short description, guests) to the main agent loop
- add a tiered auto-upsell relevance filter (`utils/upsellRelevance.js`) that performs language/token pruning and a compact indexed `gpt-4o-mini` keep-list pass before emitting submit-on-demand suggestions

## Test plan
- [x] `node -c routes/discoverRoutes.js && node -c routes/agentChatRoutes.js && node -c utils/upsellRelevance.js`
- [x] Prompt: "recommend me some niche or lesser-known bitcoin or lightning network podcasts that cover technical deep dives" -> 2 `submit-on-demand` suggested actions
- [x] Prompt: "give me quick highlights from TFTC in the last couple weeks" -> 0 suggested actions
- [x] Prompt: "find podcasts discussing Lightning Network privacy and onion routing" -> 0 suggested actions
- [x] Prompt: "What has pleb underground been talking about in April 2026?" -> 1 `submit-on-demand` suggested action (recency gap case)


Made with [Cursor](https://cursor.com)