### PR TITLE
Dedupe submit-on-demand by episode guid only

### DIFF
--- a/routes/agentChatRoutes.js
+++ b/routes/agentChatRoutes.js
@@ -531,14 +531,13 @@ function emitSubmitOnDemand(input, { emit, episodeCache, suggestedGuids, request
     return { emitted: false, missing, payload };
   }
 
-  if (suggestedGuids?.has(payload.guid) || (payload.feedId && suggestedGuids?.has(payload.feedId))) {
+  if (suggestedGuids?.has(payload.guid)) {
     console.log(`${prefix} SKIPPED (dedup) guid=${payload.guid} feedId=${payload.feedId}`);
     return { emitted: false, reason: 'dedup', payload };
   }
 
   if (suggestedGuids) {
     suggestedGuids.add(payload.guid);
-    if (payload.feedId) suggestedGuids.add(payload.feedId);
   }
 
   emit('suggested_action', payload);


### PR DESCRIPTION
## Summary
- loosen submit-on-demand dedupe logic to use episode `guid` only
- stop deduping by `feedId`, allowing multiple relevant episodes from the same podcast to be shown in one response
- preserve duplicate protection for repeated suggestions of the exact same episode

## Test plan
- [x] Query: \"what has Stacker News Live been talking about this month?\"
- [x] Verify multiple `submit-on-demand` suggested actions from the same feed are emitted (SNL #220/#219/#218/#217)
- [x] Verify duplicate episode GUIDs are still skipped


Made with [Cursor](https://cursor.com)