### PR TITLE
feat(agent): reliable clip citations via synthesis routing + model flexibility

### DIFF
--- a/constants/agentModels.js
+++ b/constants/agentModels.js
@@ -65,6 +65,21 @@ const HELPER_LLM_PRICES = {
     outputPer1M: parseFloat(process.env.ANTHROPIC_HAIKU_OUTPUT_PER_1M || '5.0'),
     label: 'Haiku 4.5',
   },
+  // Synthesis-only candidates — billed via addHelperLlmUsage when
+  // AGENT_SYNTHESIS_MODEL routes the final synthesis pass to one of these
+  // instead of the orchestrator. Pricing matches the AGENT_MODELS entries
+  // below; keys are the OpenRouter model IDs that costTracker looks up at
+  // runtime.
+  'google/gemma-4-31b-it': {
+    inputPer1M: parseFloat(process.env.OPENROUTER_GEMMA4_31B_INPUT_PER_1M || '0.13'),
+    outputPer1M: parseFloat(process.env.OPENROUTER_GEMMA4_31B_OUTPUT_PER_1M || '0.38'),
+    label: 'Gemma 4 31B (OpenRouter)',
+  },
+  'qwen/qwen3-next-80b-a3b-instruct': {
+    inputPer1M: parseFloat(process.env.OPENROUTER_QWEN3_80B_INPUT_PER_1M || '0.09'),
+    outputPer1M: parseFloat(process.env.OPENROUTER_QWEN3_80B_OUTPUT_PER_1M || '1.10'),
+    label: 'Qwen3 Next 80B (OpenRouter)',
+  },
 };
 
 const AGENT_MODELS = {
@@ -171,6 +186,26 @@ const AGENT_MODELS = {
     outputPer1M: parseFloat(process.env.DEEPSEEK_PRO_OUTPUT_PER_1M || '0.87'),
     label: 'DeepSeek V4-Pro (Direct)',
   },
+  // Synthesis-only candidates routed through OpenRouter. Cheap, instruction-
+  // tuned, no DSML in-band protocol — designed to be used as the final
+  // synthesis pass while DeepSeek drives tool calls. See
+  // AGENT_SYNTHESIS_MODEL handling in routes/agentChatRoutes.js.
+  'gemma4-31b-or': {
+    key: 'gemma4-31b-or',
+    provider: 'openrouter',
+    id: process.env.OPENROUTER_GEMMA4_31B_MODEL || 'google/gemma-4-31b-it',
+    inputPer1M: parseFloat(process.env.OPENROUTER_GEMMA4_31B_INPUT_PER_1M || '0.13'),
+    outputPer1M: parseFloat(process.env.OPENROUTER_GEMMA4_31B_OUTPUT_PER_1M || '0.38'),
+    label: 'Gemma 4 31B (OpenRouter)',
+  },
+  'qwen3-next-80b': {
+    key: 'qwen3-next-80b',
+    provider: 'openrouter',
+    id: process.env.OPENROUTER_QWEN3_80B_MODEL || 'qwen/qwen3-next-80b-a3b-instruct',
+    inputPer1M: parseFloat(process.env.OPENROUTER_QWEN3_80B_INPUT_PER_1M || '0.09'),
+    outputPer1M: parseFloat(process.env.OPENROUTER_QWEN3_80B_OUTPUT_PER_1M || '1.10'),
+    label: 'Qwen3 Next 80B (OpenRouter)',
+  },
 };
 
 // Default routing: hardcoded to 'quality' (currently the DeepSeek V4-Flash
@@ -214,6 +249,11 @@ const LEGACY_MODEL_ALIASES = {
   'deepseek-direct': 'deepseek-v4-flash-direct',
   'deepseek-flash-direct': 'deepseek-v4-flash-direct',
   'deepseek-pro-direct': 'deepseek-v4-pro-direct',
+  'gemma4-or': 'gemma4-31b-or',
+  'gemma-4-or': 'gemma4-31b-or',
+  'qwen3-80b': 'qwen3-next-80b',
+  qwen3: 'qwen3-next-80b',
+  qwen: 'qwen3-next-80b',
 };
 
 /**
@@ -298,4 +338,5 @@ module.exports = {
   DEFAULT_EXECUTION_PROFILE,
   HELPER_LLM_PRICES,
   resolveModelSelection,
+  normalizeModelKey,
 };

--- a/constants/agentModels.js
+++ b/constants/agentModels.js
@@ -80,6 +80,11 @@ const HELPER_LLM_PRICES = {
     outputPer1M: parseFloat(process.env.OPENROUTER_QWEN3_80B_OUTPUT_PER_1M || '1.10'),
     label: 'Qwen3 Next 80B (OpenRouter)',
   },
+  'gpt-5-nano': {
+    inputPer1M: parseFloat(process.env.OPENAI_GPT5_NANO_INPUT_PER_1M || '0.05'),
+    outputPer1M: parseFloat(process.env.OPENAI_GPT5_NANO_OUTPUT_PER_1M || '0.40'),
+    label: 'GPT-5 nano (OpenAI)',
+  },
 };
 
 const AGENT_MODELS = {
@@ -206,6 +211,19 @@ const AGENT_MODELS = {
     outputPer1M: parseFloat(process.env.OPENROUTER_QWEN3_80B_OUTPUT_PER_1M || '1.10'),
     label: 'Qwen3 Next 80B (OpenRouter)',
   },
+  'gpt-5-nano': {
+    key: 'gpt-5-nano',
+    provider: 'openai',
+    id: process.env.OPENAI_GPT5_NANO_MODEL || 'gpt-5-nano',
+    inputPer1M: parseFloat(process.env.OPENAI_GPT5_NANO_INPUT_PER_1M || '0.05'),
+    outputPer1M: parseFloat(process.env.OPENAI_GPT5_NANO_OUTPUT_PER_1M || '0.40'),
+    label: 'GPT-5 nano (OpenAI)',
+    // nano has internal reasoning that eats into max_completion_tokens before
+    // producing visible output. Give it headroom and cap reasoning effort to
+    // 'low' so it doesn't spend the whole budget thinking before writing.
+    maxSynthesisTokens: parseInt(process.env.OPENAI_GPT5_NANO_MAX_SYNTHESIS_TOKENS || '32000', 10),
+    reasoningEffort: process.env.OPENAI_GPT5_NANO_REASONING_EFFORT || 'low',
+  },
 };
 
 // Default routing: hardcoded to 'quality' (currently the DeepSeek V4-Flash
@@ -253,6 +271,9 @@ const LEGACY_MODEL_ALIASES = {
   'gemma-4-or': 'gemma4-31b-or',
   'qwen3-80b': 'qwen3-next-80b',
   qwen3: 'qwen3-next-80b',
+  'gpt5-nano': 'gpt-5-nano',
+  'gpt5nano': 'gpt-5-nano',
+  nano: 'gpt-5-nano',
   qwen: 'qwen3-next-80b',
 };
 

--- a/constants/agentModels.js
+++ b/constants/agentModels.js
@@ -85,6 +85,11 @@ const HELPER_LLM_PRICES = {
     outputPer1M: parseFloat(process.env.OPENAI_GPT5_NANO_OUTPUT_PER_1M || '0.40'),
     label: 'GPT-5 nano (OpenAI)',
   },
+  'moonshotai/kimi-k2.6': {
+    inputPer1M: parseFloat(process.env.OPENROUTER_KIMI_K26_INPUT_PER_1M || '0.74'),
+    outputPer1M: parseFloat(process.env.OPENROUTER_KIMI_K26_OUTPUT_PER_1M || '3.49'),
+    label: 'Kimi K2.6 (OpenRouter)',
+  },
 };
 
 const AGENT_MODELS = {
@@ -224,6 +229,23 @@ const AGENT_MODELS = {
     maxSynthesisTokens: parseInt(process.env.OPENAI_GPT5_NANO_MAX_SYNTHESIS_TOKENS || '32000', 10),
     reasoningEffort: process.env.OPENAI_GPT5_NANO_REASONING_EFFORT || 'low',
   },
+  'kimi-k2-6-or': {
+    key: 'kimi-k2-6-or',
+    provider: 'openrouter',
+    id: process.env.OPENROUTER_KIMI_K26_MODEL || 'moonshotai/kimi-k2.6',
+    inputPer1M: parseFloat(process.env.OPENROUTER_KIMI_K26_INPUT_PER_1M || '0.74'),
+    outputPer1M: parseFloat(process.env.OPENROUTER_KIMI_K26_OUTPUT_PER_1M || '3.49'),
+    label: 'Kimi K2.6 (OpenRouter)',
+  },
+  'gpt-4o-mini': {
+    key: 'gpt-4o-mini',
+    provider: 'openai',
+    id: process.env.OPENAI_GPT4O_MINI_MODEL || 'gpt-4o-mini',
+    inputPer1M: parseFloat(process.env.OPENAI_GPT4O_MINI_INPUT_PER_1M || '0.15'),
+    outputPer1M: parseFloat(process.env.OPENAI_GPT4O_MINI_OUTPUT_PER_1M || '0.60'),
+    label: 'GPT-4o mini (OpenAI)',
+    maxSynthesisTokens: parseInt(process.env.OPENAI_GPT4O_MINI_MAX_SYNTHESIS_TOKENS || '4096', 10),
+  },
 };
 
 // Default routing: hardcoded to 'quality' (currently the DeepSeek V4-Flash
@@ -275,6 +297,12 @@ const LEGACY_MODEL_ALIASES = {
   'gpt5nano': 'gpt-5-nano',
   nano: 'gpt-5-nano',
   qwen: 'qwen3-next-80b',
+  'gpt4o-mini': 'gpt-4o-mini',
+  'gpt4omini': 'gpt-4o-mini',
+  mini: 'gpt-4o-mini',
+  'kimi-k2.6-or': 'kimi-k2-6-or',
+  'kimi-or': 'kimi-k2-6-or',
+  'kimi-openrouter': 'kimi-k2-6-or',
 };
 
 /**

--- a/routes/agentChatRoutes.js
+++ b/routes/agentChatRoutes.js
@@ -11,7 +11,7 @@ const {
   TIER3_FALLBACK_MESSAGE,
 } = require('../setup-agent');
 const { PROFILES, VALID_INTENTS, DEFAULT_INTENT, CLASSIFIER_PROMPT } = require('../setup-agent-profiles');
-const { resolveModelSelection, AGENT_MODELS, HELPER_LLM_PRICES } = require('../constants/agentModels');
+const { resolveModelSelection, AGENT_MODELS, HELPER_LLM_PRICES, normalizeModelKey } = require('../constants/agentModels');
 const { executeAgentTool } = require('../utils/agentToolHandler');
 const JamieVectorMetadata = require('../models/JamieVectorMetadata');
 const { filterUpsellCandidates } = require('../utils/upsellRelevance');
@@ -879,6 +879,44 @@ function createAgentChatRoutes({ openai } = {}) {
       });
     }
 
+    // Synthesis routing: when AGENT_SYNTHESIS_MODEL is set, the final
+    // synthesis pass (and Tier 1 strict re-synthesis) runs on a different
+    // model than the orchestrator. Tool calls still flow through the
+    // orchestrator (DeepSeek today); only the prose-composition step swaps.
+    // When unset, synthesisProviderClient === providerClient and the cost
+    // tracker bills synthesis at the orchestrator rate as before. See
+    // docs/AGENT_SYNTHESIS_PASS.md for the rationale.
+    let synthesisModelKey = null;
+    let synthesisModelConfig = modelConfig;
+    let synthesisProviderClient = providerClient;
+    let synthesisIsDistinct = false;
+    if (process.env.AGENT_SYNTHESIS_MODEL) {
+      const resolved = normalizeModelKey(process.env.AGENT_SYNTHESIS_MODEL);
+      if (resolved && AGENT_MODELS[resolved]) {
+        synthesisModelKey = resolved;
+        synthesisModelConfig = AGENT_MODELS[resolved];
+        synthesisIsDistinct = synthesisModelConfig.id !== modelConfig.id;
+        if (synthesisIsDistinct) {
+          synthesisProviderClient = createProvider(synthesisModelConfig.provider);
+          const synthReady = await synthesisProviderClient.validate();
+          if (!synthReady) {
+            const envKeyByProvider = {
+              tinfoil: 'TINFOIL_API_KEY',
+              openrouter: 'OPENROUTER_API_KEY',
+              deepseek: 'DEEPSEEK_API_KEY',
+              anthropic: 'ANTHROPIC_API_KEY',
+            };
+            const envKey = envKeyByProvider[synthesisModelConfig.provider] || 'ANTHROPIC_API_KEY';
+            return res.status(503).json({
+              error: `synthesis provider ${synthesisModelConfig.provider} is not configured or unavailable. Check ${envKey} in .env (AGENT_SYNTHESIS_MODEL=${process.env.AGENT_SYNTHESIS_MODEL})`,
+            });
+          }
+        }
+      } else {
+        console.warn(`[${requestId}] AGENT_SYNTHESIS_MODEL="${process.env.AGENT_SYNTHESIS_MODEL}" did not resolve to a registered model — using orchestrator (${modelConfig.label}) for synthesis`);
+      }
+    }
+
     const rawHistory = req.body.history || [];
     const history = Array.isArray(rawHistory)
       ? rawHistory
@@ -1112,6 +1150,8 @@ function createAgentChatRoutes({ openai } = {}) {
       };
       agentLog = {
         requestId, sessionId, model: modelConfig.label, intent,
+        synthesisModel: synthesisIsDistinct ? synthesisModelConfig.label : null,
+        synthesisModelKey: synthesisIsDistinct ? synthesisModelKey : null,
         query: message, startedAt: new Date().toISOString(),
         classifierTokens,
         rounds: [],
@@ -1465,11 +1505,24 @@ function createAgentChatRoutes({ openai } = {}) {
           // earlier rounds — empirically critical to stop it from inlining
           // its native DSML tool-call markup. See docs/AGENT_SYNTHESIS_PASS.md.
           const synthesisSystemPrompt = buildSynthesisPrompt(intent, synthesisGuidance);
-          const synthesisResponse = await providerClient.createResponse({
-            model: modelConfig.id,
+          // Cross-provider synthesis: when AGENT_SYNTHESIS_MODEL routes the
+          // synthesis pass to a different provider than the orchestrator,
+          // the conversation history may carry provider-private content
+          // blocks (DeepSeek `thinking`) that the synthesizer's API can
+          // reject. The Tier 2 sanitizer is Anthropic-shaped but the rule
+          // is the same for every cross-vendor hop: keep only the OAI/
+          // Anthropic-common block types. Apply when the provider differs.
+          const synthesisMessages = (synthesisIsDistinct && synthesisModelConfig.provider !== modelConfig.provider)
+            ? sanitizeMessagesForAnthropic(messages)
+            : messages;
+          if (synthesisIsDistinct) {
+            console.log(`[${requestId}] Synthesis routing: orchestrator=${modelConfig.label} → synthesizer=${synthesisModelConfig.label} (provider=${synthesisModelConfig.provider})`);
+          }
+          const synthesisResponse = await synthesisProviderClient.createResponse({
+            model: synthesisModelConfig.id,
             maxTokens: parseInt(process.env.AGENT_SYNTHESIS_MAX_TOKENS || '4096', 10),
             system: synthesisSystemPrompt,
-            messages,
+            messages: synthesisMessages,
             tools: effectiveTools,
             toolChoice: 'none',
             aborted: synthesisAborted,
@@ -1481,10 +1534,22 @@ function createAgentChatRoutes({ openai } = {}) {
             requestId,
           });
 
-          costs.addLlmUsage(
-            synthesisResponse.usage?.input_tokens || 0,
-            synthesisResponse.usage?.output_tokens || 0,
-          );
+          // Cost: if synthesis is on a distinct model, bill it through the
+          // helpers channel (same pattern as Tier 2 Haiku) so the dollar
+          // total reflects per-model pricing instead of pricing the
+          // synthesizer's tokens at the orchestrator's rate.
+          if (synthesisIsDistinct) {
+            costs.addHelperLlmUsage(
+              synthesisModelConfig.id,
+              synthesisResponse.usage?.input_tokens || 0,
+              synthesisResponse.usage?.output_tokens || 0,
+            );
+          } else {
+            costs.addLlmUsage(
+              synthesisResponse.usage?.input_tokens || 0,
+              synthesisResponse.usage?.output_tokens || 0,
+            );
+          }
           primaryOutputTokens = synthesisResponse.usage?.output_tokens || 0;
 
           // Some providers (e.g. DeepSeek non-streaming) don't fire onTextDelta;
@@ -1504,6 +1569,8 @@ function createAgentChatRoutes({ openai } = {}) {
             type: 'synthesis',
             tokens: synthesisResponse.usage,
             reason: synthesisExitReason,
+            model: synthesisModelConfig.id,
+            provider: synthesisModelConfig.provider,
           });
         } catch (err) {
           primarySynthesisError = err;
@@ -1555,10 +1622,12 @@ function createAgentChatRoutes({ openai } = {}) {
           console.log(`[${requestId}] Synthesis quality FAILED: trigger=${primaryQuality.trigger}, reason=${primaryQuality.reason}, tokens=${primaryOutputTokens}, len=${sanitizedPrimary.length}`);
           emit('status', { message: 'Refining your answer...', sessionId });
 
-          // ===== Tier 1: strict re-synthesis on the same provider =====
-          // Same model, hardened prompt, temperature: 0 for determinism,
-          // halved time budget, tool_choice still 'none'. Silent — no
-          // text_delta emits, just collect text and evaluate.
+          // ===== Tier 1: strict re-synthesis on the same synthesizer =====
+          // Same model that ran the primary synthesis (orchestrator by
+          // default; AGENT_SYNTHESIS_MODEL when set), hardened prompt,
+          // temperature: 0 for determinism, halved time budget,
+          // tool_choice still 'none'. Silent — no text_delta emits, just
+          // collect text and evaluate.
           const tier1Start = Date.now();
           const tier1Budget = Math.max(5000, Math.floor(synthesisBudgetMs / 2));
           const tier1Deadline = Date.now() + tier1Budget;
@@ -1570,12 +1639,16 @@ function createAgentChatRoutes({ openai } = {}) {
           let tier1Text = '';
           let tier1OutputTokens = 0;
           let tier1Error = null;
+          // Same cross-provider sanitization as the primary synthesis call.
+          const tier1Messages = (synthesisIsDistinct && synthesisModelConfig.provider !== modelConfig.provider)
+            ? sanitizeMessagesForAnthropic(messages)
+            : messages;
           try {
-            const tier1Resp = await providerClient.createResponse({
-              model: modelConfig.id,
+            const tier1Resp = await synthesisProviderClient.createResponse({
+              model: synthesisModelConfig.id,
               maxTokens: parseInt(process.env.AGENT_SYNTHESIS_MAX_TOKENS || '4096', 10),
               system: buildStrictSynthesisPrompt(intent, tier1Guidance),
-              messages,
+              messages: tier1Messages,
               tools: effectiveTools,
               toolChoice: 'none',
               temperature: 0,
@@ -1584,10 +1657,18 @@ function createAgentChatRoutes({ openai } = {}) {
               onTextDelta: () => { /* silent */ },
               requestId,
             });
-            costs.addLlmUsage(
-              tier1Resp.usage?.input_tokens || 0,
-              tier1Resp.usage?.output_tokens || 0,
-            );
+            if (synthesisIsDistinct) {
+              costs.addHelperLlmUsage(
+                synthesisModelConfig.id,
+                tier1Resp.usage?.input_tokens || 0,
+                tier1Resp.usage?.output_tokens || 0,
+              );
+            } else {
+              costs.addLlmUsage(
+                tier1Resp.usage?.input_tokens || 0,
+                tier1Resp.usage?.output_tokens || 0,
+              );
+            }
             tier1OutputTokens = tier1Resp.usage?.output_tokens || 0;
             tier1Text = sanitizeAgentText(
               (tier1Resp.content || [])
@@ -1609,7 +1690,8 @@ function createAgentChatRoutes({ openai } = {}) {
             outputTokens: tier1OutputTokens,
             textLen: tier1Text.length,
             elapsedMs: Date.now() - tier1Start,
-            model: modelConfig.id,
+            model: synthesisModelConfig.id,
+            provider: synthesisModelConfig.provider,
           };
           agentLog.rounds.push({
             round: round + 1,
@@ -1618,6 +1700,8 @@ function createAgentChatRoutes({ openai } = {}) {
             trigger: tier1Quality.trigger || null,
             outputTokens: tier1OutputTokens,
             elapsedMs: Date.now() - tier1Start,
+            model: synthesisModelConfig.id,
+            provider: synthesisModelConfig.provider,
           });
 
           if (tier1Quality.ok) {

--- a/routes/agentChatRoutes.js
+++ b/routes/agentChatRoutes.js
@@ -16,7 +16,7 @@ const { executeAgentTool } = require('../utils/agentToolHandler');
 const JamieVectorMetadata = require('../models/JamieVectorMetadata');
 const { filterUpsellCandidates } = require('../utils/upsellRelevance');
 const { createProvider } = require('../utils/agent/providers');
-const { sanitizeAgentText, hasToolCallMarkup, createStreamSanitizer } = require('../utils/agent/sanitizeOutput');
+const { sanitizeAgentText, hasToolCallMarkup, createStreamSanitizer, scrubClipIds } = require('../utils/agent/sanitizeOutput');
 const { evaluateSynthesisOutput } = require('../utils/agent/synthesisQuality');
 
 const AGENT_LOG_DIR = path.join(__dirname, '..', 'logs', 'agent');
@@ -950,6 +950,11 @@ function createAgentChatRoutes({ openai } = {}) {
         'Connection': 'keep-alive',
         'X-Accel-Buffering': 'no',
       });
+      // Disable Nagle's algorithm so each res.write() flushes its own TCP
+      // packet immediately rather than being coalesced with subsequent writes.
+      // Without this, synthesis tokens (which arrive via async for-await) still
+      // get bundled into one burst before being sent to the client.
+      res.socket?.setNoDelay(true);
     }
 
     // Non-streaming accumulator. Populated by emit() when !streaming.
@@ -1132,9 +1137,9 @@ function createAgentChatRoutes({ openai } = {}) {
       // The cap is a hard ceiling that doesn't depend on prompt
       // compliance: once exhausted, calls return a "blocked" stub instead
       // of executing, which both saves time and signals to the model to
-      // synthesize. Most clean queries used 0-3 expansions, so 4 is
-      // generous; tune via env if needed.
-      const adjacentParagraphCap = parseInt(process.env.AGENT_ADJACENT_PARAGRAPHS_CAP || '4', 10);
+      // synthesize. Complex research queries can justify more expansions
+      // when DeepSeek issues parallel batches; tune via env if needed.
+      const adjacentParagraphCap = parseInt(process.env.AGENT_ADJACENT_PARAGRAPHS_CAP || '12', 10);
       let adjacentParagraphCount = 0;
 
       const cacheEpisode = (ep, feedFallback = {}) => {
@@ -1196,11 +1201,12 @@ function createAgentChatRoutes({ openai } = {}) {
         // calls, then synthesis runs on 15s and truncates mid-sentence.
         const roundSystemPrompt = effectiveSystemPrompt + latency.budgetHeader() + latency.budgetNote();
 
-        // Buffer text_delta chunks during the round; only forward to the client
-        // if this turns out to be a final response (stop_reason !== 'tool_use').
-        // DeepSeek frequently emits transitional narration ("Let me dig deeper…")
-        // before issuing tool calls. Streaming that narration live would show the
-        // user sycophantic filler that gets discarded once the tool calls execute.
+        // Buffer all text deltas for this round. We never stream the orchestrator
+        // live because we need to inspect the full text before deciding what to do:
+        //   • Tool-use rounds: discard (it's all narration — "Let me search for…")
+        //   • Final round with clips: trickle to client then emit text_done
+        //   • Final round without clips (but search evidence exists): route to
+        //     synthesis so the dedicated model can cite clips properly
         const roundTextDeltaBuffer = [];
         const response = await providerClient.createResponse({
           model: modelConfig.id,
@@ -1223,14 +1229,6 @@ function createAgentChatRoutes({ openai } = {}) {
 
         const isFinalResponse = response.stop_reason !== 'tool_use';
 
-        // Flush buffered text_delta events to the client only for final rounds.
-        // For tool_use rounds the buffer is silently discarded.
-        if (isFinalResponse && roundTextDeltaBuffer.length > 0) {
-          for (const chunk of roundTextDeltaBuffer) {
-            emit('text_delta', { text: chunk });
-          }
-        }
-
         const roundText = assistantContent
           .filter(b => b.type === 'text')
           .map(b => b.text)
@@ -1239,21 +1237,60 @@ function createAgentChatRoutes({ openai } = {}) {
           accumulatedTextByRound.push({ round, text: roundText });
         }
 
-        if (isFinalResponse) {
+        const toolUseBlocks = assistantContent.filter(b => b.type === 'tool_use');
+
+        // Short-circuit: if every tool call in this round is suggest_action
+        // (purely cosmetic — it just queues a follow-up chip in the UI), we
+        // should NOT spin up another LLM round. DeepSeek commonly writes a
+        // complete answer AND appends a suggest_action in the same response,
+        // which makes stop_reason='tool_use' even though the answer is done.
+        // Without this guard we buffer+discard the full answer and produce a
+        // much worse synthesis in the next round.
+        const onlySuggestActions = toolUseBlocks.length > 0
+          && toolUseBlocks.every(b => b.name === 'suggest_action');
+
+        // effectiveFinal: treat as the last round if the model stopped cleanly
+        // OR if the only remaining tool calls are decorative suggest_actions.
+        const effectiveFinal = isFinalResponse || (onlySuggestActions && roundText.length > 200);
+
+        if (effectiveFinal) {
+          // Execute any suggest_action calls inline (they just emit UI chips).
+          if (onlySuggestActions) {
+            for (const toolUse of toolUseBlocks) {
+              handleSuggestAction(toolUse.input, emit, { episodeCache, suggestedGuids, requestId });
+            }
+          }
+
+          const hasClips = /\{\{clip:[^}]+\}\}/.test(roundText);
+          const hasSearchEvidence = clipCache.size > 0;
+
+          // If search evidence exists but DeepSeek didn't produce any clip
+          // tokens, route to synthesis instead of emitting clip-free prose.
+          if (!hasClips && hasSearchEvidence && synthesisIsDistinct) {
+            naturalCompletion = false;
+            console.log(`[${requestId}] Final text has no clips (${roundText.length} chars, ${clipCache.size} cached clips) → routing to synthesis`);
+            agentLog.rounds.push({ round, type: 'final_rerouted', tokens: response.usage });
+            break;
+          }
+
+          // Trickle-emit the buffered chunks so the client sees progressive
+          // output rather than a single mag-dump. setImmediate yields the event
+          // loop between chunks so TCP can flush each write individually.
           naturalCompletion = true;
-          const fullText = accumulatedTextByRound.map(r => r.text).join('\n\n');
-          console.log(`[${requestId}] Final text streamed: ${fullText.length} chars across ${accumulatedTextByRound.length} round(s) (round ${round} contributed ${roundText.length} chars)`);
-          agentLog.rounds.push({ round, type: 'final', tokens: response.usage });
-          agentLog.finalText = fullText;
-          emit('text_done', { text: fullText });
+          console.log(`[${requestId}] Final text trickle-emit: ${roundText.length} chars, ${roundTextDeltaBuffer.length} chunks, effectiveFinal=${effectiveFinal} (round ${round})`);
+          agentLog.rounds.push({ round, type: effectiveFinal && !isFinalResponse ? 'final_suggest_shortcircuit' : 'final', tokens: response.usage });
+          agentLog.finalText = roundText;
+          for (const chunk of roundTextDeltaBuffer) {
+            emit('text_delta', { text: chunk });
+            await new Promise(resolve => setImmediate(resolve));
+          }
+          emit('text_done', { text: roundText });
           break;
         }
 
         if (roundText.length > 0) {
-          console.log(`[${requestId}] Intermediate text captured (${roundText.length} chars) for final text_done: "${roundText.substring(0, 80)}..."`);
+          console.log(`[${requestId}] Intermediate text (${roundText.length} chars) buffered+discarded: "${roundText.substring(0, 80)}..."`);
         }
-
-        const toolUseBlocks = assistantContent.filter(b => b.type === 'tool_use');
         console.log(`[${requestId}] ${toolUseBlocks.length} tool_use blocks to execute`);
         hasExecutedTools = true;
         const toolResults = [];
@@ -1518,7 +1555,7 @@ function createAgentChatRoutes({ openai } = {}) {
           // invocation while keeping the request shape consistent with
           // earlier rounds — empirically critical to stop it from inlining
           // its native DSML tool-call markup. See docs/AGENT_SYNTHESIS_PASS.md.
-          const synthesisSystemPrompt = buildSynthesisPrompt(intent, synthesisGuidance);
+          const synthesisSystemPrompt = buildSynthesisPrompt(intent, synthesisGuidance, clipCache);
           console.log(`[${requestId}] SYNTHESIS PROMPT (${synthesisSystemPrompt.length}c):\n${synthesisSystemPrompt}\n--- END SYNTHESIS PROMPT ---`);
           // Cross-provider synthesis: when AGENT_SYNTHESIS_MODEL routes the
           // synthesis pass to a different provider than the orchestrator,
@@ -1602,7 +1639,7 @@ function createAgentChatRoutes({ openai } = {}) {
         // Recovery passes are silent (no text_delta) so the canonical
         // `text_done` payload is what matters for clients that re-render on
         // text_done. See docs/WIP/SYNTHESIS_FAILURE_RECOVERY_PLAN.md.
-        const sanitizedPrimary = sanitizeAgentText(streamedSynthesis);
+        const sanitizedPrimary = scrubClipIds(sanitizeAgentText(streamedSynthesis), clipCache);
 
         // When primary synthesis throws (typically the synthesis-budget
         // timeout firing mid-stream), we may still have substantial clean
@@ -1687,12 +1724,12 @@ function createAgentChatRoutes({ openai } = {}) {
               );
             }
             tier1OutputTokens = tier1Resp.usage?.output_tokens || 0;
-            tier1Text = sanitizeAgentText(
+            tier1Text = scrubClipIds(sanitizeAgentText(
               (tier1Resp.content || [])
                 .filter(b => b.type === 'text')
                 .map(b => b.text)
                 .join('')
-            );
+            ), clipCache);
           } catch (err) {
             tier1Error = err;
             console.error(`[${requestId}] Tier 1 re-synthesis FAILED: ${err.message}`);
@@ -1779,12 +1816,12 @@ function createAgentChatRoutes({ openai } = {}) {
                 tier2Resp.usage?.output_tokens || 0,
               );
               tier2OutputTokens = tier2Resp.usage?.output_tokens || 0;
-              tier2Text = sanitizeAgentText(
+              tier2Text = scrubClipIds(sanitizeAgentText(
                 (tier2Resp.content || [])
                   .filter(b => b.type === 'text')
                   .map(b => b.text)
                   .join('')
-              );
+              ), clipCache);
             } catch (err) {
               tier2Error = err;
               console.error(`[${requestId}] Tier 2 cross-provider FAILED: ${err.message}`);

--- a/routes/agentChatRoutes.js
+++ b/routes/agentChatRoutes.js
@@ -1168,7 +1168,7 @@ function createAgentChatRoutes({ openai } = {}) {
         console.log(`[${requestId}] === ROUND ${round} START === (elapsed ${latency.elapsedMs()}ms)`);
 
         if (hasExecutedTools) {
-          emit('status', { message: 'Composing your answer...', sessionId });
+          emit('status', { message: 'Thinking & Researching...', sessionId });
         }
 
         const msgMetrics = measureMessages(messages);
@@ -1196,6 +1196,12 @@ function createAgentChatRoutes({ openai } = {}) {
         // calls, then synthesis runs on 15s and truncates mid-sentence.
         const roundSystemPrompt = effectiveSystemPrompt + latency.budgetHeader() + latency.budgetNote();
 
+        // Buffer text_delta chunks during the round; only forward to the client
+        // if this turns out to be a final response (stop_reason !== 'tool_use').
+        // DeepSeek frequently emits transitional narration ("Let me dig deeper…")
+        // before issuing tool calls. Streaming that narration live would show the
+        // user sycophantic filler that gets discarded once the tool calls execute.
+        const roundTextDeltaBuffer = [];
         const response = await providerClient.createResponse({
           model: modelConfig.id,
           maxTokens: 4096,
@@ -1203,7 +1209,7 @@ function createAgentChatRoutes({ openai } = {}) {
           messages,
           tools: effectiveTools,
           aborted,
-          onTextDelta: (text) => emit('text_delta', { text }),
+          onTextDelta: (text) => roundTextDeltaBuffer.push(text),
           requestId,
         });
 
@@ -1216,6 +1222,14 @@ function createAgentChatRoutes({ openai } = {}) {
         messages.push({ role: 'assistant', content: assistantContent });
 
         const isFinalResponse = response.stop_reason !== 'tool_use';
+
+        // Flush buffered text_delta events to the client only for final rounds.
+        // For tool_use rounds the buffer is silently discarded.
+        if (isFinalResponse && roundTextDeltaBuffer.length > 0) {
+          for (const chunk of roundTextDeltaBuffer) {
+            emit('text_delta', { text: chunk });
+          }
+        }
 
         const roundText = assistantContent
           .filter(b => b.type === 'text')
@@ -1469,11 +1483,11 @@ function createAgentChatRoutes({ openai } = {}) {
         //      preserved and the loop exits cleanly.
         //   2. `timeoutMs` passed to the provider, which becomes the fetch's
         //      AbortController timeout, killing non-streaming or hung calls.
-        // DIAGNOSTIC (2026-04-28): default raised from 15s to 300s so primary
-        // synthesis always runs to completion when measuring true wall-clock
-        // performance under unbounded loop budgets. Bring this back to ~15s
-        // once we have baselines and have decided on per-intent budgets.
-        const synthesisBudgetMs = parseInt(process.env.AGENT_SYNTHESIS_BUDGET_MS || '300000', 10);
+        // Default 45s: enough for Qwen3 to stream a complete synthesis even on
+        // large contexts (40+ tool-call rounds), without holding the user hostage
+        // for a non-answer. The diagnostic 300s value was for benchmarking only.
+        // Override via AGENT_SYNTHESIS_BUDGET_MS if you need a different ceiling.
+        const synthesisBudgetMs = parseInt(process.env.AGENT_SYNTHESIS_BUDGET_MS || '45000', 10);
         const synthesisDeadlineMs = Date.now() + synthesisBudgetMs;
         const synthesisAborted = () => _aborted || Date.now() >= synthesisDeadlineMs;
 
@@ -1505,6 +1519,7 @@ function createAgentChatRoutes({ openai } = {}) {
           // earlier rounds — empirically critical to stop it from inlining
           // its native DSML tool-call markup. See docs/AGENT_SYNTHESIS_PASS.md.
           const synthesisSystemPrompt = buildSynthesisPrompt(intent, synthesisGuidance);
+          console.log(`[${requestId}] SYNTHESIS PROMPT (${synthesisSystemPrompt.length}c):\n${synthesisSystemPrompt}\n--- END SYNTHESIS PROMPT ---`);
           // Cross-provider synthesis: when AGENT_SYNTHESIS_MODEL routes the
           // synthesis pass to a different provider than the orchestrator,
           // the conversation history may carry provider-private content
@@ -1520,13 +1535,14 @@ function createAgentChatRoutes({ openai } = {}) {
           }
           const synthesisResponse = await synthesisProviderClient.createResponse({
             model: synthesisModelConfig.id,
-            maxTokens: parseInt(process.env.AGENT_SYNTHESIS_MAX_TOKENS || '4096', 10),
+            maxTokens: synthesisModelConfig.maxSynthesisTokens || parseInt(process.env.AGENT_SYNTHESIS_MAX_TOKENS || '4096', 10),
             system: synthesisSystemPrompt,
             messages: synthesisMessages,
             tools: effectiveTools,
             toolChoice: 'none',
             aborted: synthesisAborted,
             timeoutMs: synthesisBudgetMs,
+            ...(synthesisModelConfig.reasoningEffort ? { reasoningEffort: synthesisModelConfig.reasoningEffort } : {}),
             onTextDelta: (text) => {
               streamedSynthesis += text;
               emit('text_delta', { text });
@@ -1646,7 +1662,7 @@ function createAgentChatRoutes({ openai } = {}) {
           try {
             const tier1Resp = await synthesisProviderClient.createResponse({
               model: synthesisModelConfig.id,
-              maxTokens: parseInt(process.env.AGENT_SYNTHESIS_MAX_TOKENS || '4096', 10),
+              maxTokens: synthesisModelConfig.maxSynthesisTokens || parseInt(process.env.AGENT_SYNTHESIS_MAX_TOKENS || '4096', 10),
               system: buildStrictSynthesisPrompt(intent, tier1Guidance),
               messages: tier1Messages,
               tools: effectiveTools,
@@ -1654,6 +1670,7 @@ function createAgentChatRoutes({ openai } = {}) {
               temperature: 0,
               aborted: tier1Aborted,
               timeoutMs: tier1Budget,
+              ...(synthesisModelConfig.reasoningEffort ? { reasoningEffort: synthesisModelConfig.reasoningEffort } : {}),
               onTextDelta: () => { /* silent */ },
               requestId,
             });
@@ -1741,7 +1758,7 @@ function createAgentChatRoutes({ openai } = {}) {
               }
               const tier2Resp = await haikuClient.createResponse({
                 model: haikuConfig.id,
-                maxTokens: parseInt(process.env.AGENT_SYNTHESIS_MAX_TOKENS || '4096', 10),
+                maxTokens: synthesisModelConfig.maxSynthesisTokens || parseInt(process.env.AGENT_SYNTHESIS_MAX_TOKENS || '4096', 10),
                 system: buildStrictSynthesisPrompt(intent, tier2Guidance),
                 messages: tier2Messages,
                 tools: effectiveTools,

--- a/server.js
+++ b/server.js
@@ -2165,7 +2165,7 @@ app.listen(PORT, async () => {
     // High-visibility banner showing what the /api/chat/workflow ("pull") agent
     // will route to by default.
     try {
-      const { AGENT_MODELS, DEFAULT_AGENT_MODEL, EXECUTION_PROFILES, DEFAULT_EXECUTION_PROFILE } = require('./constants/agentModels');
+      const { AGENT_MODELS, DEFAULT_AGENT_MODEL, EXECUTION_PROFILES, DEFAULT_EXECUTION_PROFILE, normalizeModelKey } = require('./constants/agentModels');
       const m = AGENT_MODELS[DEFAULT_AGENT_MODEL];
       const p = EXECUTION_PROFILES[DEFAULT_EXECUTION_PROFILE];
       const envRaw = process.env.AGENT_MODEL;
@@ -2174,12 +2174,19 @@ app.listen(PORT, async () => {
         : `\x1b[33m${envRaw} (DEPRECATED — ignored, please remove from .env)\x1b[0m`;
       const cyan = (s) => `\x1b[36m${s}\x1b[0m`;
       const bold = (s) => `\x1b[1m${s}\x1b[0m`;
+      const synthEnvRaw = process.env.AGENT_SYNTHESIS_MODEL;
+      const synthKey = synthEnvRaw ? normalizeModelKey(synthEnvRaw) : null;
+      const synthModel = synthKey ? AGENT_MODELS[synthKey] : null;
+      const synthLine = synthModel
+        ? `${bold(synthModel.label)}  [${synthKey}]  $${synthModel.inputPer1M}/M in, $${synthModel.outputPer1M}/M out`
+        : `\x1b[2msame as orchestrator (not set)\x1b[0m`;
       console.log('');
       console.log(cyan('┌─ Pull agent default ───────────────────────────────────────────'));
-      console.log(`${cyan('│')} Model:    ${bold(m.label)}  [${m.key}]`);
-      console.log(`${cyan('│')} Provider: ${m.provider}  (model id: ${m.id})`);
-      console.log(`${cyan('│')} Pricing:  $${m.inputPer1M}/M in, $${m.outputPer1M}/M out`);
-      console.log(`${cyan('│')} Profile:  ${p.label}  rounds≤${p.maxToolRounds}, cost≤$${p.costBudgetHard}, latency≤${p.latencyBudgetHardMs}ms`);
+      console.log(`${cyan('│')} Model:     ${bold(m.label)}  [${m.key}]`);
+      console.log(`${cyan('│')} Provider:  ${m.provider}  (model id: ${m.id})`);
+      console.log(`${cyan('│')} Pricing:   $${m.inputPer1M}/M in, $${m.outputPer1M}/M out`);
+      console.log(`${cyan('│')} Profile:   ${p.label}  rounds≤${p.maxToolRounds}, cost≤$${p.costBudgetHard}, latency≤${p.latencyBudgetHardMs}ms`);
+      console.log(`${cyan('│')} Synthesis: ${synthLine}`);
       console.log(`${cyan('│')} AGENT_MODEL env: ${envState}`);
       console.log(cyan('└────────────────────────────────────────────────────────────────'));
       console.log('');

--- a/setup-agent-profiles.js
+++ b/setup-agent-profiles.js
@@ -104,7 +104,7 @@ const DEFAULT_INTENT = 'search';
 const CLASSIFIER_PROMPT = `Classify the user's intent into exactly one category. Respond with ONLY a JSON object: {"intent":"<value>"}
 
 Categories:
-- "research_session": The user wants a **curated multi-clip or multi-episode artifact** they can keep, revisit, or share — not a one-off answer. Treat as research_session when they ask to **build, make, create, put together, compile, bundle, curate, aggregate, assemble, collect, line up, queue, or give** a **playlist, research session, clip pack, supercut, highlight reel, binge list, anthology, reading/listening list of clips, digest of clips, or "episodes to watch/listen"** for a topic or show (optionally with a time window: "this month", "last month", "recent", "latest episodes"). Phrases like **"for my team"**, **"I can send to a friend"**, **"shareable"**, **"save this"** (when tied to multiple clips/episodes) also count. **Err on the side of research_session** when the deliverable sounds like **more than a single narrative answer** — e.g. ordered list of episodes with clips to explore in-app.
+- "research_session": The user wants a **curated multi-clip or multi-episode artifact** they can keep, revisit, or share — not a one-off answer. Treat as research_session when they ask to **build, make, create, put together, bundle, curate, aggregate, assemble, collect, line up, queue, or give** a **playlist, research session, clip pack, supercut, highlight reel, binge list, anthology, reading/listening list of clips, digest of clips, or "episodes to watch/listen"** for a topic or show (optionally with a time window: "this month", "last month", "recent", "latest episodes"). Phrases like **"for my team"**, **"I can send to a friend"**, **"shareable"**, **"save this"** (when tied to multiple clips/episodes) also count. **Do NOT classify as research_session** when the user asks to compile, compare, summarize, or analyze views/opinions/positions — those are analytical questions that want a written answer with quotes, not a saved artifact.
 - "transcribe": User explicitly asks to TRANSCRIBE, INGEST, or ADD a podcast/episode. Must be an explicit FUTURE-TENSE transcription request (imperative: "transcribe X", "ingest Y", "get Z transcribed"). Past-tense mentions ("I transcribed", "already transcribed", "just transcribed") are NOT transcribe intent — they're context for a follow-up search. If the same message contains a follow-up question ("what did they say", "summarize", "tell me about"), always prefer "search".
 - "search": Single-pass questions — explain, compare, summarize, "what did X say about Y", topic exploration, one episode deep dive, or a follow-up after transcription **without** asking for a saved playlist/session/clip bundle. This is the default when unsure **unless** the user clearly wants a **multi-item curated artifact** as above.
 
@@ -125,6 +125,9 @@ Examples:
 - "Already transcribed that one — now tell me the top takeaways" → {"intent":"search"}
 - "What did Huberman say about creatine?" → {"intent":"search"}
 - "Palmer Luckey on Joe Rogan" → {"intent":"search"}
-- "Compare Bitcoin views on TFTC vs WBD" → {"intent":"search"}`;
+- "Compare Bitcoin views on TFTC vs WBD" → {"intent":"search"}
+- "Compile each host's position on AI regulation and note where they've changed their mind" → {"intent":"search"}
+- "Summarize and compile what all four All-In hosts have said about crypto" → {"intent":"search"}
+- "Aggregate every macro analyst view on GDP growth in 2026" → {"intent":"search"}`;
 
 module.exports = { PROFILES, VALID_INTENTS, DEFAULT_INTENT, CLASSIFIER_PROMPT };

--- a/setup-agent.js
+++ b/setup-agent.js
@@ -361,7 +361,7 @@ PROMPT_SECTIONS.synthesisGuard = `
 Tool execution has ended for this turn. Your only job now is to write the final answer to the user using the evidence already in this conversation.
 
 1. **NEVER emit tool calls or tool-call markup.** No \`<invoke>\`, \`<tool_call>\`, \`<tool_calls>\`, \`<function_call>\`, \`<function_calls>\`, \`<parameter>\`, \`<｜DSML｜...>\`, or any XML / tagged structure that resembles a function invocation. The orchestrator will discard such output and the user will see garbage. Output plain prose only.
-2. **Cite only what you have.** Use quotes, episodes, and shareLinks from earlier tool results above. Format clips per the response-format rules below when you have them. If there are zero usable quotes from this turn's tool results, omit \`{{clip:...}}\` entirely — do NOT fabricate. The minimum-clip floor is suspended when you have nothing to cite.
+2. **Cite only what you have.** For every direct quote you include, you MUST place a \`{{clip:PARAGRAPH_ID}}\` token on its own line immediately before the blockquote — where PARAGRAPH_ID is the shareLink from the search result (e.g. \`{{clip:abc123-..._p42}}\`). Do NOT use plain markdown blockquotes (\`> "..."\`) without a preceding \`{{clip:...}}\` reference. Do NOT fabricate IDs. If you have no usable clips, write the answer in plain prose without blockquotes.
 3. **Be honest about gaps.** If the searches above returned little or nothing, say so plainly in user-facing language and suggest a podcast or person they could explore. Don't invent GUIDs, episode titles, dates, quotes, or shareLinks.
 4. **Never narrate the system.** No mention of tool calls, rounds, time, budgets, retries, "I tried searching", "no results were returned", "the corpus", limits, or new chats. Speak as a podcast research expert directly to the user.
 5. **Lead with the answer.** No "Based on the results", "Here's what I found", "Excellent", "Interesting", "Hmm", or commentary on your own process.`;
@@ -446,7 +446,7 @@ The first synthesis attempt did not produce usable output. This is your last cha
 
 1. **Output ONLY plain prose.** No tool-call markup of any kind. No \`<...>\` tags. No DSML, XML, JSON, or any structure that resembles a function invocation. If you emit anything that looks like a tool call, it will be discarded.
 2. **Do NOT narrate.** Forbidden openers: "Let me", "I'll", "Let's", "Now I'll", "Based on", "Here's what I found", "Excellent", "Interesting", "Hmm", "Perfect", "Great", "OK". Open with the substantive answer directly.
-3. **Cite only what is already in the conversation history above.** Use \`{{clip:shareLink}}\` tokens for clips you have, italicized show titles for episodes you've referenced. If you have nothing to cite, omit clips entirely and write the answer in plain prose. Do not fabricate.
+3. **Cite only what is already in the conversation history above.** For every direct quote, place \`{{clip:PARAGRAPH_ID}}\` on its own line immediately before the blockquote (PARAGRAPH_ID is the shareLink from the search result, e.g. \`{{clip:abc123-..._p42}}\`). Do NOT use plain blockquotes without a preceding \`{{clip:...}}\`. If you have nothing to cite, write plain prose with no blockquotes. Do not fabricate IDs.
 4. **If you genuinely cannot answer from the conversation history, output exactly this single line and nothing else:**
    \`No transcribed coverage found for this query.\`
 5. **No mention of tools, time limits, retries, or your own process.** Speak as a podcast research expert directly to the user.

--- a/setup-agent.js
+++ b/setup-agent.js
@@ -360,11 +360,12 @@ PROMPT_SECTIONS.synthesisGuard = `
 
 Tool execution has ended for this turn. Your only job now is to write the final answer to the user using the evidence already in this conversation.
 
-1. **NEVER emit tool calls or tool-call markup.** No \`<invoke>\`, \`<tool_call>\`, \`<tool_calls>\`, \`<function_call>\`, \`<function_calls>\`, \`<parameter>\`, \`<｜DSML｜...>\`, or any XML / tagged structure that resembles a function invocation. The orchestrator will discard such output and the user will see garbage. Output plain prose only.
-2. **Cite only what you have.** For every direct quote you include, you MUST place a \`{{clip:PARAGRAPH_ID}}\` token on its own line immediately before the blockquote — where PARAGRAPH_ID is the shareLink from the search result (e.g. \`{{clip:abc123-..._p42}}\`). Do NOT use plain markdown blockquotes (\`> "..."\`) without a preceding \`{{clip:...}}\` reference. Do NOT fabricate IDs. If you have no usable clips, write the answer in plain prose without blockquotes.
-3. **Be honest about gaps.** If the searches above returned little or nothing, say so plainly in user-facing language and suggest a podcast or person they could explore. Don't invent GUIDs, episode titles, dates, quotes, or shareLinks.
-4. **Never narrate the system.** No mention of tool calls, rounds, time, budgets, retries, "I tried searching", "no results were returned", "the corpus", limits, or new chats. Speak as a podcast research expert directly to the user.
-5. **Lead with the answer.** No "Based on the results", "Here's what I found", "Excellent", "Interesting", "Hmm", or commentary on your own process.`;
+1. **Use markdown formatting.** Use \`##\` headers to separate sections when the answer covers multiple distinct topics. Use **bold** for emphasis on key claims. Use \`> *"quote"*\` blockquotes for direct quotes. Markdown renders fully for the user — use it to make the answer readable and well-structured.
+2. **NEVER emit tool-call markup.** No \`<invoke>\`, \`<tool_call>\`, \`<tool_calls>\`, \`<function_call>\`, \`<function_calls>\`, \`<parameter>\`, \`<｜DSML｜...>\`, or any XML/tagged structure that resembles a function invocation. The orchestrator will discard it and the user will see garbage.
+3. **Cite only what you have.** For every direct quote you include, you MUST place a \`{{clip:PARAGRAPH_ID}}\` token on its own line immediately before the blockquote — where PARAGRAPH_ID is the shareLink from the search result (e.g. \`{{clip:abc123-..._p42}}\`). Do NOT use plain markdown blockquotes (\`> "..."\`) without a preceding \`{{clip:...}}\` reference. Do NOT fabricate IDs. If you have no usable clips, write the answer in plain prose without blockquotes.
+4. **Be honest about gaps.** If the searches above returned little or nothing, say so plainly in user-facing language and suggest a podcast or person they could explore. Don't invent GUIDs, episode titles, dates, quotes, or shareLinks.
+5. **Never narrate the system.** No mention of tool calls, rounds, time, budgets, retries, "I tried searching", "no results were returned", "the corpus", limits, or new chats. Speak as a podcast research expert directly to the user.
+6. **Lead with the answer.** No "Based on the results", "Here's what I found", "Excellent", "Interesting", "Hmm", or commentary on your own process.`;
 
 /**
  * Build a system prompt for the post-loop synthesis pass.
@@ -391,7 +392,27 @@ Tool execution has ended for this turn. Your only job now is to write the final 
  * `guidance` shape: { lengthHint: string, urgency: 'normal'|'tight'|'urgent' }.
  * Produced by latencyTracker.synthesisGuidance(synthesisBudgetMs).
  */
-function buildSynthesisPrompt(intent, guidance) {
+/**
+ * Build a condensed clip manifest from the agent's clipCache so the synthesis
+ * model has an explicit, scannable list of available IDs — instead of having
+ * to hunt for shareLinks buried in walls of raw tool-result JSON.
+ *
+ * Each line: {{clip:SHARE_LINK}} — "first 120 chars of quote…"
+ * Capped at 25 clips to stay within synthesis context budget.
+ */
+function buildClipManifest(clipCache) {
+  if (!clipCache || clipCache.size === 0) return '';
+  const entries = [...clipCache.entries()].slice(0, 25);
+  const lines = entries.map(([shareLink, meta]) => {
+    const quote = (meta.text || meta.quote || '').replace(/\s+/g, ' ').trim().substring(0, 120);
+    return `{{clip:${shareLink}}} — "${quote}${quote.length >= 120 ? '…' : ''}"`;
+  });
+  return `## Clips Available for Citation\n\nUse the exact \`{{clip:ID}}\` tokens below — these are real, playable audio links:\n\n${lines.join('\n')}`;
+}
+
+function buildSynthesisPrompt(intent, guidance, clipCache) {
+  const clipManifest = buildClipManifest(clipCache);
+
   // Research-session intent uses a dedicated strict-format prompt with
   // few-shot examples (see PROMPT_SECTIONS.researchSessionSynthesisGuard).
   // The generic responseFormat section is intentionally skipped because
@@ -402,6 +423,7 @@ function buildSynthesisPrompt(intent, guidance) {
       buildCurrentDateSection(),
       PROMPT_SECTIONS.researchSessionSynthesisGuard,
     ];
+    if (clipManifest) sections.push(clipManifest);
     if (guidance) sections.push(buildSynthesisLengthSection(guidance));
     return sections.join('\n');
   }
@@ -411,6 +433,7 @@ function buildSynthesisPrompt(intent, guidance) {
     buildCurrentDateSection(),
     PROMPT_SECTIONS.synthesisGuard,
   ];
+  if (clipManifest) sections.push(clipManifest);
   if (guidance) sections.push(buildSynthesisLengthSection(guidance));
   sections.push(PROMPT_SECTIONS.responseFormat);
   return sections.join('\n');
@@ -444,14 +467,15 @@ PROMPT_SECTIONS.strictSynthesisGuard = `
 
 The first synthesis attempt did not produce usable output. This is your last chance to write the answer to the user's question. Follow these rules absolutely — the orchestrator will discard your output and replace it with a hardcoded apology if you violate any of them:
 
-1. **Output ONLY plain prose.** No tool-call markup of any kind. No \`<...>\` tags. No DSML, XML, JSON, or any structure that resembles a function invocation. If you emit anything that looks like a tool call, it will be discarded.
-2. **Do NOT narrate.** Forbidden openers: "Let me", "I'll", "Let's", "Now I'll", "Based on", "Here's what I found", "Excellent", "Interesting", "Hmm", "Perfect", "Great", "OK". Open with the substantive answer directly.
-3. **Cite only what is already in the conversation history above.** For every direct quote, place \`{{clip:PARAGRAPH_ID}}\` on its own line immediately before the blockquote (PARAGRAPH_ID is the shareLink from the search result, e.g. \`{{clip:abc123-..._p42}}\`). Do NOT use plain blockquotes without a preceding \`{{clip:...}}\`. If you have nothing to cite, write plain prose with no blockquotes. Do not fabricate IDs.
-4. **If you genuinely cannot answer from the conversation history, output exactly this single line and nothing else:**
+1. **Use markdown formatting.** Use \`##\` headers for distinct topic sections. Use **bold** for key claims. Use \`> *"quote"*\` blockquotes for direct quotes. Do NOT output flat plain text — markdown renders fully for the user.
+2. **No tool-call markup.** No \`<...>\` tags, no DSML, XML, JSON, or any structure resembling a function invocation. If you emit anything that looks like a tool call, it will be discarded.
+3. **Do NOT narrate.** Forbidden openers: "Let me", "I'll", "Let's", "Now I'll", "Based on", "Here's what I found", "Excellent", "Interesting", "Hmm", "Perfect", "Great", "OK". Open with the substantive answer directly.
+4. **Cite only what is already in the conversation history above.** For every direct quote, place \`{{clip:PARAGRAPH_ID}}\` on its own line immediately before the blockquote (PARAGRAPH_ID is the shareLink from the search result, e.g. \`{{clip:abc123-..._p42}}\`). Do NOT use plain blockquotes without a preceding \`{{clip:...}}\`. If you have nothing to cite, write plain prose with no blockquotes. Do not fabricate IDs.
+5. **If you genuinely cannot answer from the conversation history, output exactly this single line and nothing else:**
    \`No transcribed coverage found for this query.\`
-5. **No mention of tools, time limits, retries, or your own process.** Speak as a podcast research expert directly to the user.
+6. **No mention of tools, time limits, retries, or your own process.** Speak as a podcast research expert directly to the user.
 
-Write the answer now. Plain prose only.`;
+Write the answer now.`;
 
 /**
  * Build the strict-synthesis system prompt used by the Tier 1 recovery pass

--- a/tests/agent-comparison.js
+++ b/tests/agent-comparison.js
@@ -218,6 +218,24 @@ const TEST_QUERIES = [
   // Adversarial — research-session shape with thin corpus / impossible cross-show
   { name: 'C9 Adv: thin corpus marble racing',       cohort: 'cohort9', task: 'compile a research session of marble racing podcast clips', mode: 'fast' },
   { name: 'C9 Adv: impossible Satoshi compilation',  cohort: 'cohort9', task: 'make a playlist of every Satoshi Nakamoto interview clip', mode: 'fast' },
+
+  // --- Cohort 10: DSML / synthesis stress (multi-step numerical + wide aggregation) ---
+  // Designed to maximize the conditions that historically push DeepSeek's
+  // synthesis pass into DSML in-band tool-call markup leakage:
+  //   (a) many tool calls before synthesis (search_quotes + adjacent_paragraphs fan-out)
+  //   (b) numerical reasoning / aggregation in the final prose
+  //   (c) tabulating multiple speakers with quantitative attributes
+  // Used to compare baseline DeepSeek synthesis vs. AGENT_SYNTHESIS_MODEL=
+  // gemma4-31b-or / qwen3-next-80b on the same workload.
+  { name: 'C10 BTC price prediction weighted',
+    cohort: 'cohort10',
+    task: 'Find all Bitcoin 2026 price predictions from podcasters, round each to the nearest $10k, then weight them by the relative follower counts or influence of each speaker and give me a weighted average prediction.' },
+  { name: 'C10 Macro consensus weighted',
+    cohort: 'cohort10',
+    task: 'Compile every macro analyst prediction for US GDP growth in 2026 mentioned on podcasts, note who said what, rank them by the seniority/prominence of the speaker, and give me a weighted consensus view.' },
+  { name: 'C10 AI timeline synthesis',
+    cohort: 'cohort10',
+    task: 'Gather every specific AGI or transformative-AI timeline prediction (year or decade) given by guests on Lex Fridman, All-In, and Dwarkesh Patel podcasts. Tabulate speaker, prediction, and year stated, then synthesize where the center of gravity is and who is the outlier.' },
 ];
 
 // ===== Helpers =====

--- a/tests/synthesis-smoke-test.js
+++ b/tests/synthesis-smoke-test.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+/**
+ * Synthesis Model Smoke Test
+ *
+ * Fires a minimal "Say hello." completion at each candidate synthesis
+ * model via OpenRouter to confirm the model ID + auth + upstream routing
+ * are all healthy before kicking off a multi-run benchmark.
+ *
+ * Why: the benchmark cohort takes ~10–15 minutes per run × 3 runs. A bad
+ * model ID or a flat OPENROUTER_API_KEY is much cheaper to discover here
+ * than mid-cohort.
+ *
+ * Usage:
+ *   node tests/synthesis-smoke-test.js
+ *
+ * Exits 0 on full success, 1 on any failure (so it can gate a CI job).
+ *
+ * Models tested are read from AGENT_MODELS (filtered to OpenRouter +
+ * the synthesis-only candidates we register in this branch). To extend
+ * the list, register the model in constants/agentModels.js and add its
+ * key to SYNTHESIS_MODEL_KEYS below.
+ */
+
+require('dotenv').config();
+
+const OpenRouterProvider = require('../utils/agent/providers/openRouterProvider');
+const { AGENT_MODELS } = require('../constants/agentModels');
+
+// Synthesis-only candidates being benchmarked. Keep this list narrow —
+// we only want to verify the models the benchmark will actually exercise.
+const SYNTHESIS_MODEL_KEYS = [
+  'gemma4-31b-or',
+  'qwen3-next-80b',
+];
+
+const HELLO_PROMPT = 'Reply with exactly the two words: hello world';
+
+async function smokeOne(provider, modelKey) {
+  const cfg = AGENT_MODELS[modelKey];
+  if (!cfg) {
+    return { modelKey, ok: false, error: `unknown model key in AGENT_MODELS: ${modelKey}` };
+  }
+
+  const started = Date.now();
+  try {
+    const resp = await provider.createResponse({
+      model: cfg.id,
+      maxTokens: 16,
+      system: 'You are a smoke test. Respond minimally.',
+      messages: [{ role: 'user', content: HELLO_PROMPT }],
+      tools: [],
+      requestId: `smoke-${modelKey}`,
+    });
+    const latencyMs = Date.now() - started;
+    const text = (resp.content || []).filter(b => b.type === 'text').map(b => b.text).join('').trim();
+    if (!text) {
+      return { modelKey, modelId: cfg.id, label: cfg.label, ok: false, latencyMs,
+        error: 'empty response (no text content blocks)' };
+    }
+    return {
+      modelKey,
+      modelId: cfg.id,
+      label: cfg.label,
+      ok: true,
+      latencyMs,
+      preview: text.substring(0, 80),
+      usage: resp.usage,
+    };
+  } catch (err) {
+    return {
+      modelKey,
+      modelId: cfg.id,
+      label: cfg.label,
+      ok: false,
+      latencyMs: Date.now() - started,
+      error: err.message,
+    };
+  }
+}
+
+async function main() {
+  if (!process.env.OPENROUTER_API_KEY) {
+    console.error('\x1b[31m✘ OPENROUTER_API_KEY is not set in env — smoke test cannot run\x1b[0m');
+    process.exit(1);
+  }
+
+  const provider = new OpenRouterProvider();
+  const validated = await provider.validate();
+  if (!validated) {
+    console.error('\x1b[31m✘ OpenRouter /models endpoint did not validate — check OPENROUTER_API_KEY\x1b[0m');
+    process.exit(1);
+  }
+
+  console.log('\n╔══════════════════════════════════════════════════════════╗');
+  console.log('║         Synthesis Model Smoke Test (OpenRouter)         ║');
+  console.log('╚══════════════════════════════════════════════════════════╝\n');
+  console.log(`Provider validated. Testing ${SYNTHESIS_MODEL_KEYS.length} model(s):\n`);
+
+  const results = [];
+  for (const key of SYNTHESIS_MODEL_KEYS) {
+    process.stdout.write(`  • ${key.padEnd(20)} `);
+    const r = await smokeOne(provider, key);
+    results.push(r);
+    if (r.ok) {
+      console.log(`\x1b[32m✔\x1b[0m  ${r.modelId} (${r.latencyMs}ms) — "${r.preview.replace(/\s+/g, ' ')}"`);
+    } else {
+      console.log(`\x1b[31m✘\x1b[0m  ${r.modelId || '?'} (${r.latencyMs || 0}ms) — ${r.error}`);
+    }
+  }
+
+  const failed = results.filter(r => !r.ok);
+  if (failed.length === 0) {
+    console.log('\n\x1b[32m✔ All synthesis models OK — safe to run benchmark.\x1b[0m\n');
+    process.exit(0);
+  } else {
+    console.log(`\n\x1b[31m✘ ${failed.length}/${results.length} model(s) failed — fix before running benchmark.\x1b[0m`);
+    for (const r of failed) {
+      console.log(`  - ${r.modelKey} (${r.modelId || '?'}): ${r.error}`);
+    }
+    console.log();
+    process.exit(1);
+  }
+}
+
+main().catch(err => {
+  console.error('\x1b[31mSmoke test crashed:\x1b[0m', err);
+  process.exit(1);
+});

--- a/utils/agent/providers/index.js
+++ b/utils/agent/providers/index.js
@@ -2,12 +2,13 @@ const AnthropicProvider = require('./anthropicProvider');
 const TinfoilProvider = require('./tinfoilProvider');
 const OpenRouterProvider = require('./openRouterProvider');
 const DeepSeekProvider = require('./deepSeekProvider');
+const OpenAIProvider = require('./openAIProvider');
 
 // Supported provider IDs. Each model entry in constants/agentModels.js picks
 // one of these as its `provider`. Same model can appear under multiple
 // providers (e.g. deepseek-v4-flash via openrouter today, via tinfoil later)
 // as separate registry entries with distinct keys.
-const SUPPORTED_PROVIDERS = ['anthropic', 'tinfoil', 'openrouter', 'deepseek'];
+const SUPPORTED_PROVIDERS = ['anthropic', 'tinfoil', 'openrouter', 'deepseek', 'openai'];
 
 const providerCache = new Map();
 
@@ -19,6 +20,7 @@ function createProvider(name) {
   else if (name === 'tinfoil') provider = new TinfoilProvider();
   else if (name === 'openrouter') provider = new OpenRouterProvider();
   else if (name === 'deepseek') provider = new DeepSeekProvider();
+  else if (name === 'openai') provider = new OpenAIProvider();
   else throw new Error(`Unknown provider: ${name}`);
 
   providerCache.set(name, provider);

--- a/utils/agent/providers/openAIProvider.js
+++ b/utils/agent/providers/openAIProvider.js
@@ -1,46 +1,15 @@
 /**
- * OpenRouter provider adapter (OpenAI-compatible chat completions).
+ * Direct OpenAI provider adapter (OpenAI chat completions).
  *
- * OpenRouter is a routing broker — it forwards requests to upstream providers
- * (Novita, Fireworks, DeepInfra, etc.) and passes pricing through. We use it
- * here as a way to access models like DeepSeek V4 that aren't yet hosted on
- * Tinfoil.
- *
- * Tradeoff vs Tinfoil: cheaper / earlier access to new models, but no
- * confidential-enclave guarantees — every request is plaintext-visible to
- * OpenRouter and the upstream provider it routes to. If the same model
- * eventually lands on Tinfoil, register it there as a separate model entry
- * (e.g. `deepseek-v4-flash-tinfoil`) so callers can pick the routing they want.
+ * Uses OPENAI_API_KEY directly — no intermediary broker. Supports streaming
+ * via the SSE-based chunk protocol and honors the same onTextDelta / aborted /
+ * timeoutMs interface as the other providers so the agent loop is agnostic.
  */
 
 const crypto = require('crypto');
 
-const DEFAULT_BASE_URL = process.env.OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1';
-const DEFAULT_REQUEST_TIMEOUT_MS = parseInt(process.env.OPENROUTER_REQUEST_TIMEOUT_MS || '90000', 10);
-const DEFAULT_REFERER = process.env.OPENROUTER_HTTP_REFERER || 'https://pullthatupjamie.ai';
-const DEFAULT_TITLE = process.env.OPENROUTER_X_TITLE || 'PullThatUpJamie';
-
-// Reasoning control for models that support inline reasoning (DeepSeek V4, etc.).
-// `exclude` drops the reasoning tokens from the response payload (we still pay for them).
-// Effort values supported by OpenRouter: 'low' | 'medium' | 'high'.
-const DEFAULT_REASONING_EFFORT = process.env.OPENROUTER_REASONING_EFFORT || null;
-const DEFAULT_REASONING_EXCLUDE = process.env.OPENROUTER_REASONING_EXCLUDE === 'true';
-
-// Upstream provider routing — OpenRouter brokers to multiple hosts (Together,
-// DeepInfra, Novita, etc.). Tool-call support varies by upstream and changes
-// over time; the public `supports_tool_parameter` flag is often wrong.
-// Empirical (2026-04 on DeepSeek V4 family):
-//   - Together hosts V4-Pro and accepts tools (404s for V4-Flash since it
-//     doesn't host that model — order naturally falls through).
-//   - DeepInfra hosts V4-Flash and tries tools but is chronically pool-limited.
-//   - Novita hosts V4-Flash but rejects tool requests.
-// Comma-separated env list controls preference; set OPENROUTER_PROVIDER_ONLY=true
-// to *only* use those hosts (no fallback chain).
-const PROVIDER_ORDER = (process.env.OPENROUTER_PROVIDER_ORDER || 'Together,DeepInfra,Novita,SiliconFlow')
-  .split(',')
-  .map(s => s.trim())
-  .filter(Boolean);
-const PROVIDER_ONLY = process.env.OPENROUTER_PROVIDER_ONLY === 'true';
+const DEFAULT_BASE_URL = process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1';
+const DEFAULT_REQUEST_TIMEOUT_MS = parseInt(process.env.OPENAI_REQUEST_TIMEOUT_MS || '90000', 10);
 
 function convertToolsToOpenAi(tools = []) {
   return tools.map(t => ({
@@ -111,8 +80,8 @@ function normalizeOpenAiResponse(payload) {
     content.push({ type: 'text', text: message.content });
   } else if (Array.isArray(message.content)) {
     const text = message.content
-      .filter(part => part?.type === 'text' && typeof part.text === 'string')
-      .map(part => part.text)
+      .filter(p => p?.type === 'text' && typeof p.text === 'string')
+      .map(p => p.text)
       .join('\n');
     if (text.trim()) content.push({ type: 'text', text });
   }
@@ -120,9 +89,7 @@ function normalizeOpenAiResponse(payload) {
   if (Array.isArray(message.tool_calls)) {
     for (const tc of message.tool_calls) {
       let parsedInput = {};
-      try {
-        parsedInput = JSON.parse(tc.function?.arguments || '{}');
-      } catch {}
+      try { parsedInput = JSON.parse(tc.function?.arguments || '{}'); } catch {}
       content.push({
         type: 'tool_use',
         id: tc.id || `tool_${crypto.randomUUID()}`,
@@ -142,26 +109,18 @@ function normalizeOpenAiResponse(payload) {
     usage: {
       input_tokens: payload?.usage?.prompt_tokens || 0,
       output_tokens: payload?.usage?.completion_tokens || 0,
-      // OpenRouter returns actual upstream cost in USD when available.
-      // We expose it for diagnostics; the route still recomputes from the rate card.
-      provider_reported_cost_usd: payload?.usage?.cost ?? null,
+      provider_reported_cost_usd: null,
       reasoning_tokens: payload?.usage?.completion_tokens_details?.reasoning_tokens ?? null,
     },
   };
 }
 
-/**
- * Parse an OpenAI-compatible SSE stream and return a normalized response.
- * Calls onTextDelta(chunk) for each text token as it arrives.
- * Respects the aborted() predicate — if it returns true mid-stream, stops
- * consuming and returns whatever was accumulated so far.
- */
 async function parseOpenAiStream(resp, onTextDelta, aborted) {
   const decoder = new TextDecoder();
   let sseBuffer = '';
 
   let fullText = '';
-  const toolCallAccumulator = {}; // keyed by index
+  const toolCallAccumulator = {};
   let finishReason = null;
   let usage = null;
 
@@ -170,8 +129,6 @@ async function parseOpenAiStream(resp, onTextDelta, aborted) {
       if (aborted && aborted()) break;
 
       sseBuffer += decoder.decode(rawChunk, { stream: true });
-
-      // SSE events are separated by \n\n; keep any partial line in the buffer.
       const events = sseBuffer.split('\n\n');
       sseBuffer = events.pop();
 
@@ -193,13 +150,11 @@ async function parseOpenAiStream(resp, onTextDelta, aborted) {
 
           const delta = choice.delta || {};
 
-          // Text token
           if (typeof delta.content === 'string' && delta.content) {
             fullText += delta.content;
             if (typeof onTextDelta === 'function') onTextDelta(delta.content);
           }
 
-          // Tool call token accumulation
           if (Array.isArray(delta.tool_calls)) {
             for (const tc of delta.tool_calls) {
               const idx = tc.index ?? 0;
@@ -215,11 +170,9 @@ async function parseOpenAiStream(resp, onTextDelta, aborted) {
       }
     }
   } catch (err) {
-    // Stream interrupted (abort / network error). Return whatever we have.
     if (err?.name !== 'AbortError') throw err;
   }
 
-  // Assemble normalized response
   const content = [];
   if (fullText.trim()) content.push({ type: 'text', text: fullText });
 
@@ -243,13 +196,13 @@ async function parseOpenAiStream(resp, onTextDelta, aborted) {
     usage: {
       input_tokens: usage?.prompt_tokens || 0,
       output_tokens: usage?.completion_tokens || 0,
-      provider_reported_cost_usd: usage?.cost ?? null,
+      provider_reported_cost_usd: null,
       reasoning_tokens: usage?.completion_tokens_details?.reasoning_tokens ?? null,
     },
   };
 }
 
-class OpenRouterProvider {
+class OpenAIProvider {
   constructor() {
     this.baseUrl = DEFAULT_BASE_URL.replace(/\/$/, '');
     this._validated = null;
@@ -257,33 +210,18 @@ class OpenRouterProvider {
 
   authHeaders() {
     return {
-      Authorization: `Bearer ${process.env.OPENROUTER_API_KEY || ''}`,
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY || ''}`,
       'Content-Type': 'application/json',
-      'HTTP-Referer': DEFAULT_REFERER,
-      'X-Title': DEFAULT_TITLE,
     };
   }
 
   async validate() {
     if (this._validated !== null) return this._validated;
-    if (!process.env.OPENROUTER_API_KEY) {
-      this._validated = false;
-      return this._validated;
-    }
-
-    try {
-      const resp = await fetch(`${this.baseUrl}/models`, {
-        method: 'GET',
-        headers: this.authHeaders(),
-      });
-      this._validated = resp.ok;
-    } catch {
-      this._validated = false;
-    }
+    this._validated = !!process.env.OPENAI_API_KEY;
     return this._validated;
   }
 
-  async createResponse({ model, maxTokens, system, messages, tools, toolChoice, onTextDelta, aborted, timeoutMs, requestId }) {
+  async createResponse({ model, maxTokens, system, messages, tools, toolChoice, onTextDelta, aborted, timeoutMs, reasoningEffort, requestId }) {
     const openAiMessages = [
       { role: 'system', content: system },
       ...convertMessagesToOpenAi(messages),
@@ -293,18 +231,15 @@ class OpenRouterProvider {
     const payload = {
       model,
       messages: openAiMessages,
-      max_tokens: maxTokens,
+      max_completion_tokens: maxTokens,
       stream: useStreaming,
-      // Ask OpenRouter to include token usage in the final stream chunk.
       ...(useStreaming ? { stream_options: { include_usage: true } } : {}),
+      // reasoning_effort caps internal chain-of-thought tokens, preventing the
+      // model from consuming the entire token budget on reasoning before writing
+      // any visible output. 'low' is fast and sufficient for synthesis tasks.
+      ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
     };
 
-    // See docs/AGENT_SYNTHESIS_PASS.md for the rationale:
-    //   • toolChoice === 'none' (synthesis pass): force `tool_choice: 'none'`
-    //     and include tool schemas so the model stays anchored to the same
-    //     tool-aware request shape it saw in earlier rounds.
-    //   • Otherwise: only attach tools+'auto' when at least one tool is
-    //     supplied (empty tools + 'auto' is rejected by upstream providers).
     const convertedTools = convertToolsToOpenAi(tools);
     if (toolChoice === 'none') {
       payload.tool_choice = 'none';
@@ -312,18 +247,6 @@ class OpenRouterProvider {
     } else if (convertedTools.length > 0) {
       payload.tools = convertedTools;
       payload.tool_choice = 'auto';
-    }
-
-    if (DEFAULT_REASONING_EFFORT || DEFAULT_REASONING_EXCLUDE) {
-      payload.reasoning = {};
-      if (DEFAULT_REASONING_EFFORT) payload.reasoning.effort = DEFAULT_REASONING_EFFORT;
-      if (DEFAULT_REASONING_EXCLUDE) payload.reasoning.exclude = true;
-    }
-
-    if (PROVIDER_ORDER.length > 0) {
-      payload.provider = PROVIDER_ONLY
-        ? { only: PROVIDER_ORDER }
-        : { order: PROVIDER_ORDER, allow_fallbacks: true };
     }
 
     const url = `${this.baseUrl}/chat/completions`;
@@ -343,7 +266,7 @@ class OpenRouterProvider {
     } catch (err) {
       clearTimeout(timeout);
       if (err?.name === 'AbortError') {
-        throw new Error(`OpenRouter request timed out after ${effectiveTimeout}ms (${requestId || 'no-req-id'})`);
+        throw new Error(`OpenAI request timed out after ${effectiveTimeout}ms (${requestId || 'no-req-id'})`);
       }
       throw err;
     }
@@ -351,7 +274,7 @@ class OpenRouterProvider {
 
     if (!resp.ok) {
       const body = await resp.text();
-      throw new Error(`OpenRouter request failed (${resp.status}) after ${Date.now() - started}ms: ${body.substring(0, 300)}`);
+      throw new Error(`OpenAI request failed (${resp.status}) after ${Date.now() - started}ms: ${body.substring(0, 300)}`);
     }
 
     if (!useStreaming) {
@@ -363,4 +286,4 @@ class OpenRouterProvider {
   }
 }
 
-module.exports = OpenRouterProvider;
+module.exports = OpenAIProvider;

--- a/utils/agent/sanitizeOutput.js
+++ b/utils/agent/sanitizeOutput.js
@@ -239,9 +239,124 @@ function createStreamSanitizer() {
   };
 }
 
+// Narration phrases that signal a model "thinking aloud" rather than answering.
+// Applied line-by-line to live token streams so sycophantic openers never reach
+// the client even when streaming directly (no buffer-then-flush).
+const NARRATION_LINE_RE = /^\s*(let me\b|i'?ll\b|i'?m going to\b|i'?m about to\b|now let me\b|first,? let me\b|allow me to\b|let'?s grab\b|let'?s see\b|let'?s look\b|let'?s \w|perfect[!.,]|great[!.,]|ok(?:ay)?[,!.]\s|excellent[!.,]|interesting[!.,]|hmm\b|based on (the|my|these|our)\b|here'?s what (i found|i have|we have)\b|now,?\s+i'?ve\b|i (can see|have found|have gathered|have compiled|now have|found)\b|i'?ve (found|gathered|compiled|now got)\b)/i;
+
+// How many characters to buffer at the start of each line before deciding
+// it is not narration. 60 chars covers all known narration openers and is
+// imperceptibly short for the user (~2–4 tokens at typical token sizes).
+const NARRATION_DETECT_WINDOW = 60;
+
+/**
+ * Create a streaming narration filter. Buffers the opening characters of each
+ * line to detect sycophantic/narration prefixes and drops those lines entirely.
+ * Non-narration content is forwarded to `onEmit` character-by-character as
+ * tokens arrive — no end-of-response flush required.
+ *
+ * @param {(text: string) => void} onEmit  called with safe text fragments
+ * @returns {{ feed(chunk: string): void, flush(): void }}
+ */
+function createNarrationFilter(onEmit) {
+  let lineBuf = '';     // characters buffered at line start for narration detection
+  let decided = false;  // true once we've resolved emit/suppress for the current line
+  let suppress = false; // true when current line is narration
+
+  return {
+    feed(chunk) {
+      for (const ch of chunk) {
+        if (ch === '\n') {
+          if (!suppress) {
+            if (lineBuf) onEmit(lineBuf);
+            onEmit('\n');
+          }
+          lineBuf = '';
+          decided = false;
+          suppress = false;
+          continue;
+        }
+
+        if (decided) {
+          if (!suppress) onEmit(ch);
+        } else {
+          lineBuf += ch;
+          if (NARRATION_LINE_RE.test(lineBuf)) {
+            suppress = true;
+            decided = true;
+            lineBuf = '';
+          } else if (lineBuf.length >= NARRATION_DETECT_WINDOW) {
+            // No narration pattern found in the detection window — safe to emit.
+            onEmit(lineBuf);
+            lineBuf = '';
+            decided = true;
+            suppress = false;
+          }
+        }
+      }
+    },
+
+    flush() {
+      if (!suppress && lineBuf) {
+        onEmit(lineBuf);
+        lineBuf = '';
+      }
+    },
+  };
+}
+
+/**
+ * Validate and correct {{clip:ID}} tokens in synthesis output against the
+ * known clipCache (shareLink → metadata map populated by search_quotes results).
+ *
+ * Models like nano occasionally:
+ *   1. Prepend whitespace inside the token: {{clip: https___...}}
+ *   2. Concatenate two paragraph IDs: {{clip:abc_p380_p368}} (hybrid of _p380 and _p368)
+ *   3. Fabricate IDs entirely
+ *
+ * Fix strategy per token:
+ *   a) Trim whitespace from the extracted ID.
+ *   b) If the trimmed ID exists in clipCache → emit as-is.
+ *   c) If not, repeatedly strip the last `_pN` segment and retry until a
+ *      valid prefix is found or we run out of segments.
+ *   d) If no match found → remove the {{clip:...}} token entirely (don't
+ *      silently emit a broken reference that renders as "Loading...").
+ *
+ * @param {string} text       Raw synthesis text containing {{clip:...}} tokens.
+ * @param {Map<string, *>} clipCache  shareLink → metadata from search_quotes.
+ * @returns {string}          Cleaned text with validated/corrected clip tokens.
+ */
+function scrubClipIds(text, clipCache) {
+  if (!clipCache || clipCache.size === 0) return text;
+
+  return text.replace(/\{\{clip:([^}]*)\}\}/g, (match, rawId) => {
+    const id = rawId.trim();
+    if (!id) return ''; // empty token
+
+    // Exact match
+    if (clipCache.has(id)) return `{{clip:${id}}}`;
+
+    // Try stripping trailing _pN segments (handles hybrid IDs like _p380_p368)
+    let candidate = id;
+    while (true) {
+      const stripped = candidate.replace(/_p\d+$/, '');
+      if (stripped === candidate) break; // no more _pN to strip
+      candidate = stripped;
+      if (clipCache.has(candidate)) {
+        return `{{clip:${candidate}}}`;
+      }
+    }
+
+    // No valid ID found — remove the token rather than emit a broken reference.
+    return '';
+  });
+}
+
 module.exports = {
   sanitizeAgentText,
   hasToolCallMarkup,
   sanitizeStreamDelta,
   createStreamSanitizer,
+  createNarrationFilter,
+  scrubClipIds,
 };

--- a/utils/agent/synthesisQuality.js
+++ b/utils/agent/synthesisQuality.js
@@ -57,6 +57,9 @@ const NARRATION_PREFIX_RE = /^\s*(let me\b|i'?ll\b|i'?m going to\b|i'?m about to
 // closing braces). Caused by maxTokens cutting the response mid-UUID.
 const TRUNCATED_CLIP_RE = /\{\{clip:[^}]*$/;
 
+// Clip-presence check. A completed clip token looks like {{clip:...}}.
+const CLIP_TOKEN_RE = /\{\{clip:[^}]+\}\}/;
+
 // Mid-prose truncation: text doesn't end with terminal punctuation, a
 // closing quote/bracket, or a markdown emphasis marker. Catches the
 // "...spending balloons during an" / "...the Syrian Empire," shape where


### PR DESCRIPTION
## Summary

- **Clip gate on natural completions**: DeepSeek frequently completed without `{{clip:...}}` tokens. Now when search evidence exists but no clips appear in the final round, the response is silently rerouted to the synthesis model instead of delivering bare prose to the client.
- **suggest_action short-circuit**: DeepSeek commonly writes a complete answer AND appends a `suggest_action` in the same round, making `stop_reason=tool_use` and causing the full answer to be discarded. Now those rounds execute the chips inline and break cleanly.
- **Clip manifest in synthesis prompt**: The synthesis model now receives an explicit `{{clip:ID}}` menu built from `clipCache` — no more hunting for shareLinks buried in tool-result JSON.
- **Trickle streaming**: Buffered final-round chunks are emitted via `setImmediate` to avoid mag-dumps; Nagle's algorithm disabled on the SSE socket.
- **New synthesis model options**: `gpt-4o-mini` (recommended, ~$0.008/call) and `kimi-k2-6-or` (OpenRouter) added as `AGENT_SYNTHESIS_MODEL` candidates alongside existing Tinfoil options.

## Test plan

- [ ] Set `AGENT_SYNTHESIS_MODEL=gpt-4o-mini`, run a topical query with multiple search rounds — verify clip pills appear
- [ ] Run a query where DeepSeek would normally complete with `suggest_action` — verify answer is preserved and not rerouted to synthesis
- [ ] Verify synthesis fallback fires on `max_rounds` exit and produces clips
- [ ] Confirm server banner shows correct synthesis model on startup

Made with [Cursor](https://cursor.com)