### PR TITLE
Block speaker misattribution from empty-guest podcasts

### DIFF
--- a/routes/agentChatRoutes.js
+++ b/routes/agentChatRoutes.js
@@ -1362,7 +1362,7 @@ function createAgentChatRoutes({ openai } = {}) {
             if (toolUse.name === 'suggest_action') {
               result = handleSuggestAction(toolUse.input, emit, { episodeCache, suggestedGuids, requestId });
             } else if (toolUse.name === 'create_research_session') {
-              result = await executeAgentTool(toolUse.name, toolUse.input, { openai, sessionId, req, clipCache, recordHelperLlmUsage });
+              result = await executeAgentTool(toolUse.name, toolUse.input, { openai, sessionId, req, clipCache, recordHelperLlmUsage, userMessage: message });
               if (result.sessionId && result.url) {
                 researchSessionUrl = result.url;
                 emit('session_created', { sessionId: result.sessionId, url: result.url, itemCount: result.itemCount });
@@ -1379,7 +1379,7 @@ function createAgentChatRoutes({ openai } = {}) {
               };
               console.log(`[${requestId}] get_adjacent_paragraphs BLOCKED — cap ${adjacentParagraphCap} reached`);
             } else {
-              result = await executeAgentTool(toolUse.name, toolUse.input, { openai, sessionId, req, clipCache, recordHelperLlmUsage });
+              result = await executeAgentTool(toolUse.name, toolUse.input, { openai, sessionId, req, clipCache, recordHelperLlmUsage, userMessage: message });
             }
           } catch (toolErr) {
             printLog(`[${requestId}] Tool ${toolUse.name} exception (recovered for LLM): ${toolErr.message}`);
@@ -1566,7 +1566,7 @@ function createAgentChatRoutes({ openai } = {}) {
             const sessionResult = await executeAgentTool(
               'create_research_session',
               { pineconeIds },
-              { openai, sessionId, req, clipCache, recordHelperLlmUsage }
+              { openai, sessionId, req, clipCache, recordHelperLlmUsage, userMessage: message }
             );
             if (sessionResult.sessionId && sessionResult.url) {
               researchSessionUrl = sessionResult.url;

--- a/scripts/trial-attribution.js
+++ b/scripts/trial-attribution.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Generic attribution probe — prints the full SSE-final text + clip list
+ * so we can eyeball whether the synthesizer is misattributing quotes.
+ *
+ * Usage:  node scripts/trial-attribution.js "<query>" [trials]
+ */
+
+const http = require('http');
+require('dotenv').config();
+
+const QUERY = process.argv[2] || 'Create a summary of Jim Carucci\'s latest podcast appearance';
+const TRIALS = parseInt(process.argv[3] || '2', 10);
+const PORT = 4132;
+const JWT = process.env.JWT_TEST_TOKEN;
+if (!JWT) {
+  console.error('JWT_TEST_TOKEN not set in .env — cannot run probe.');
+  process.exit(1);
+}
+
+function runTrial(trialNum) {
+  return new Promise((resolve) => {
+    const body = JSON.stringify({ message: QUERY, mode: 'deep' });
+    const options = {
+      hostname: 'localhost',
+      port: PORT,
+      path: '/api/pull',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+        Accept: 'text/event-stream',
+        Authorization: `Bearer ${JWT}`,
+      },
+    };
+
+    const result = {
+      trialNum,
+      toolCalls: [],
+      finalText: '',
+      requestId: null,
+      error: null,
+    };
+
+    const req = http.request(options, (res) => {
+      let buffer = '';
+      res.on('data', (chunk) => {
+        buffer += chunk.toString();
+        const blocks = buffer.split('\n\n');
+        buffer = blocks.pop();
+        for (const block of blocks) {
+          const lines = block.split('\n');
+          let eventType = null;
+          let dataRaw = null;
+          for (const line of lines) {
+            if (line.startsWith('event: ')) eventType = line.slice(7).trim();
+            else if (line.startsWith('data: ')) dataRaw = line.slice(6).trim();
+          }
+          if (!dataRaw || dataRaw === '[DONE]') continue;
+          let payload;
+          try { payload = JSON.parse(dataRaw); } catch { continue; }
+          const type = eventType || payload.type;
+          if (type === 'request_id') result.requestId = payload.requestId;
+          if (type === 'tool_call') {
+            result.toolCalls.push(`${payload.tool || payload.name}(${JSON.stringify(payload.input || {}).substring(0, 80)})`);
+          }
+          if (type === 'text_delta') result.finalText += payload.text || '';
+          if (type === 'text_done') result.finalText = payload.text || result.finalText;
+        }
+      });
+      res.on('end', () => resolve(result));
+    });
+
+    req.on('error', (e) => { result.error = e.message; resolve(result); });
+    req.setTimeout(180000, () => { result.error = 'timeout'; req.destroy(); });
+    req.write(body); req.end();
+  });
+}
+
+async function main() {
+  console.log(`\nQUERY: "${QUERY}"\n${'='.repeat(80)}`);
+  const promises = Array.from({ length: TRIALS }, (_, i) => runTrial(i + 1));
+  const results = await Promise.all(promises);
+  for (const r of results) {
+    console.log(`\n--- Trial ${r.trialNum} ---`);
+    if (r.error) { console.log('ERROR:', r.error); continue; }
+    console.log('Tool calls:');
+    for (const t of r.toolCalls) console.log('  ' + t);
+    console.log('\nFinal text:\n' + r.finalText);
+    const clips = (r.finalText.match(/\{\{clip:[^}]+\}\}/g) || []);
+    if (clips.length) {
+      console.log('\nClips cited (episode GUID prefix):');
+      for (const c of clips) {
+        const id = c.match(/\{\{clip:([^}]+)\}\}/)[1];
+        const ep = id.split('_p')[0];
+        console.log('  ' + ep);
+      }
+    }
+  }
+  console.log('\n' + '='.repeat(80));
+}
+
+main();

--- a/setup-agent.js
+++ b/setup-agent.js
@@ -364,9 +364,10 @@ Tool execution has ended for this turn. Your only job now is to write the final 
 2. **NEVER emit tool-call markup.** No \`<invoke>\`, \`<tool_call>\`, \`<tool_calls>\`, \`<function_call>\`, \`<function_calls>\`, \`<parameter>\`, \`<｜DSML｜...>\`, or any XML/tagged structure that resembles a function invocation. The orchestrator will discard it and the user will see garbage.
 3. **Cite clips with the EXACT token format.** For every direct quote you include, place a \`{{clip:PARAGRAPH_ID}}\` token on its own line immediately before the blockquote — PARAGRAPH_ID is the full shareLink from the search result (e.g. \`{{clip:abc123-..._p42}}\`). **NEVER use indexed formats** like \`[[CLIP:0]]\`, \`[CLIP:1]\`, \`(clip 2)\`, or any numbered reference. NEVER use plain markdown blockquotes without a preceding \`{{clip:...}}\` token. Do NOT fabricate IDs. If you have no usable clips, write the answer in plain prose without blockquotes.
 4. **Zero invention.** Only state facts, dates, episode titles, descriptions, and summaries that are explicitly present verbatim in the tool results above. Do NOT write episode descriptions, \"key thoughts\", or \"additional insights\" sections that go beyond what the search results directly contain. If a piece of information is not in the tool results, it does not go in the answer.
-5. **Be honest about gaps.** If the searches returned little usable content for the question, say so plainly — e.g. \"The indexed transcripts for this episode don't contain enough detail to summarize X.\" Don't paper over thin evidence with invented summaries. Suggest what they could explore instead.
-6. **Never narrate the system.** No mention of tool calls, rounds, time, budgets, retries, "I tried searching", "no results were returned", "the corpus", limits, or new chats. Speak as a podcast research expert directly to the user.
-7. **Lead with the answer.** No "Based on the results", "Here's what I found", "Excellent", "Interesting", "Hmm", or commentary on your own process. No closing remarks like "Enjoy!" or "Hope this helps!".`;
+5. **Speaker attribution requires evidence — never assume the asked-about person is the speaker.** Topical relevance is NOT speaker attribution. A clip about a topic the user named does NOT mean the user's named person is the one speaking. Attribute a quote to a named person ONLY when at least one of these is true: (a) the clip's manifest entry lists that person under \`[guests: ...]\`; (b) the search was scoped to that person's episode GUIDs (returned by find_person/get_person_episodes) and the result is from one of those GUIDs; or (c) the tool results contain explicit speaker metadata identifying the speaker. If a clip is marked \`[SPEAKER UNVERIFIED]\` or has no guest list and you cannot establish the speaker through (b) or (c), use neutral framing — "the discussion covers…", "in this episode the host explores…", "the conversation touches on…" — and DO NOT write "X said", "X explains", "X argues", "X discusses", or any phrase that puts words in a specific person's mouth. If the user asked what a specific person said and you have NO clips that meet (a)/(b)/(c), say plainly that the indexed transcripts don't contain a verifiable appearance for that person on this material — DO NOT fabricate one by stitching together topically-related quotes from episodes where they weren't a guest.
+6. **Be honest about gaps.** If the searches returned little usable content for the question, say so plainly — e.g. \"The indexed transcripts for this episode don't contain enough detail to summarize X.\" Don't paper over thin evidence with invented summaries. Suggest what they could explore instead.
+7. **Never narrate the system.** No mention of tool calls, rounds, time, budgets, retries, "I tried searching", "no results were returned", "the corpus", limits, or new chats. Speak as a podcast research expert directly to the user.
+8. **Lead with the answer.** No "Based on the results", "Here's what I found", "Excellent", "Interesting", "Hmm", or commentary on your own process. No closing remarks like "Enjoy!" or "Hope this helps!".`;
 
 /**
  * Build a system prompt for the post-loop synthesis pass.
@@ -404,6 +405,7 @@ Tool execution has ended for this turn. Your only job now is to write the final 
 function buildClipManifest(clipCache, episodeCache) {
   if (!clipCache || clipCache.size === 0) return '';
   const entries = [...clipCache.entries()].slice(0, 25);
+  let unverifiedCount = 0;
   const lines = entries.map(([shareLink, meta]) => {
     const quote = (meta.text || meta.quote || '').replace(/\s+/g, ' ').trim().substring(0, 120);
     // Extract episode GUID by stripping the _pN paragraph suffix
@@ -411,15 +413,27 @@ function buildClipManifest(clipCache, episodeCache) {
     const epMeta = episodeCache?.get(epGuid);
     const epTitle = epMeta?.episodeTitle || meta.episode || '';
     const guests = epMeta?.guests;
-    const guestStr = Array.isArray(guests) && guests.length
-      ? ` [guests: ${guests.slice(0, 3).join(', ')}]`
-      : '';
+    const hasGuests = Array.isArray(guests) && guests.length > 0;
+    // Empty/missing guests metadata means the episode has no tagged speakers
+    // and we cannot verify who actually said this paragraph. Flag it
+    // prominently — synthesis rules below forbid attributing these to a
+    // named person.
+    let guestStr;
+    if (hasGuests) {
+      guestStr = ` [guests: ${guests.slice(0, 3).join(', ')}]`;
+    } else {
+      guestStr = ' [SPEAKER UNVERIFIED — episode has no tagged guests; do NOT attribute this quote to any specific person by name]';
+      unverifiedCount++;
+    }
     const date = epMeta?.publishedDate || meta.date || '';
     const dateStr = date ? ` [${date}]` : '';
     const epStr = epTitle ? ` (${epTitle.substring(0, 70)})` : '';
     return `{{clip:${shareLink}}}${epStr}${guestStr}${dateStr} — "${quote}${quote.length >= 120 ? '…' : ''}"`;
   });
-  return `## Clips Available for Citation\n\nUse the exact \`{{clip:ID}}\` tokens below — these are real, playable audio links:\n\n${lines.join('\n')}`;
+  const header = unverifiedCount > 0
+    ? `## Clips Available for Citation\n\nUse the exact \`{{clip:ID}}\` tokens below — these are real, playable audio links.\n\n**${unverifiedCount} of ${lines.length} clips below are marked SPEAKER UNVERIFIED.** Those clips come from episodes with no tagged guest metadata, so the speaker is unknown. Follow the speaker-attribution rule in the SYNTHESIS PASS section above when citing them.`
+    : `## Clips Available for Citation\n\nUse the exact \`{{clip:ID}}\` tokens below — these are real, playable audio links:`;
+  return `${header}\n\n${lines.join('\n')}`;
 }
 
 function buildSynthesisPrompt(intent, guidance, clipCache, researchSessionUrl, episodeCache) {
@@ -487,9 +501,10 @@ The first synthesis attempt did not produce usable output. This is your last cha
 2. **No tool-call markup.** No \`<...>\` tags, no DSML, XML, JSON, or any structure resembling a function invocation. If you emit anything that looks like a tool call, it will be discarded.
 3. **Do NOT narrate.** Forbidden openers: "Let me", "I'll", "Let's", "Now I'll", "Based on", "Here's what I found", "Excellent", "Interesting", "Hmm", "Perfect", "Great", "OK". Open with the substantive answer directly.
 4. **Cite only what is already in the conversation history above.** For every direct quote, place \`{{clip:PARAGRAPH_ID}}\` on its own line immediately before the blockquote (PARAGRAPH_ID is the shareLink from the search result, e.g. \`{{clip:abc123-..._p42}}\`). Do NOT use plain blockquotes without a preceding \`{{clip:...}}\`. If you have nothing to cite, write plain prose with no blockquotes. Do not fabricate IDs.
-5. **If you genuinely cannot answer from the conversation history, output exactly this single line and nothing else:**
+5. **Speaker attribution requires evidence.** A clip's topical relevance to the user's question is NOT proof of who is speaking. Attribute a quote to a named person ONLY if the clip's manifest entry lists that person under \`[guests: ...]\`, OR the clip came from a person-scoped search (find_person → guids → search_quotes). For clips marked \`[SPEAKER UNVERIFIED]\` or lacking a guest list, use neutral framing ("the discussion covers…", "the host explores…") and never write "X said" / "X explains" / "X discusses". If the user asked what a specific person said and no clip ties to them via guest metadata or a person-scoped search, say plainly that the indexed transcripts don't contain a verifiable appearance — do not stitch topically-related quotes into a fake attribution.
+6. **If you genuinely cannot answer from the conversation history, output exactly this single line and nothing else:**
    \`No transcribed coverage found for this query.\`
-6. **No mention of tools, time limits, retries, or your own process.** Speak as a podcast research expert directly to the user.
+7. **No mention of tools, time limits, retries, or your own process.** Speak as a podcast research expert directly to the user.
 
 Write the answer now.`;
 

--- a/utils/agentToolHandler.js
+++ b/utils/agentToolHandler.js
@@ -21,6 +21,7 @@ const {
 const { getAdjacentParagraphs } = require('../agent-tools/pineconeTools.js');
 const { createResearchSessionDirect } = require('../services/researchSessionService');
 const { resolveOwner } = require('../utils/resolveOwner');
+const JamieVectorMetadata = require('../models/JamieVectorMetadata');
 
 // Removed 2026-04-28: per-tool flat-fee table previously fed createCostTracker.
 // Internal infra (Pinecone, MongoDB, Atlas, our HTTP services) is $0 marginal —
@@ -117,7 +118,7 @@ function truncateResults(data) {
 
 // --- Per-tool dispatch ---
 
-async function handleSearchQuotes(input, { openai, recordHelperLlmUsage }) {
+async function handleSearchQuotes(input, { openai, recordHelperLlmUsage, userMessage }) {
   const { query, guid, guids, feedIds, limit, minDate, maxDate } = input;
   const clampedLimit = clampLimit(limit, 5);
   const overFetchLimit = Math.min(clampedLimit * 3, RESULT_HARD_CAP);
@@ -137,14 +138,47 @@ async function handleSearchQuotes(input, { openai, recordHelperLlmUsage }) {
   }, { openai, recordHelperLlmUsage });
   filterFluffResults(data);
 
+  // Enrich each paragraph result with its episode-level `guests` array. The
+  // service returns paragraph metadata (no guests field); we pull guests from
+  // the episode-type metadata docs in one batch lookup. Reranker + downstream
+  // attribution rules need this signal — without it, every clip looks the
+  // same regardless of which person actually sat on the episode.
+  if (data.results && data.results.length > 0) {
+    try {
+      const epGuids = [...new Set(data.results.map(r => {
+        const sl = r.shareLink || r.shareUrl || '';
+        return sl.replace(/_p\d+$/, '');
+      }).filter(Boolean))];
+      if (epGuids.length > 0) {
+        const epDocs = await JamieVectorMetadata.find({
+          guid: { $in: epGuids },
+          type: 'episode',
+        }).select('guid metadataRaw.guests').lean();
+        const guestsByGuid = new Map();
+        for (const doc of epDocs) {
+          const g = doc.metadataRaw?.guests;
+          guestsByGuid.set(doc.guid, Array.isArray(g) ? g : []);
+        }
+        for (const r of data.results) {
+          const sl = r.shareLink || r.shareUrl || '';
+          const epGuid = sl.replace(/_p\d+$/, '');
+          r.guests = guestsByGuid.get(epGuid) || [];
+        }
+      }
+    } catch (enrichErr) {
+      printLog(`[TOOL] search_quotes guest enrichment failed (non-fatal): ${enrichErr.message}`);
+    }
+  }
+
   if (data.results && data.results.length > 2 && openai) {
     const clips = data.results.map(r => ({
       quote: r.quote,
       creator: r.creator || r.episode,
       episode: r.episode,
+      guests: Array.isArray(r.guests) ? r.guests : [],
     }));
     try {
-      const reranked = await rerankClips({ query: q, clips, openai });
+      const reranked = await rerankClips({ query: q, clips, openai, userMessage });
       if (typeof recordHelperLlmUsage === 'function' && reranked.usage) {
         recordHelperLlmUsage(
           reranked.usage.model,
@@ -460,14 +494,14 @@ const TOOL_DISPATCH = {
  *        invoked by helpers (reranker, embedding, query expansion) so the
  *        caller can attribute their real spend to the request's cost tracker.
  */
-async function executeAgentTool(toolName, toolInput, { openai, sessionId, req, clipCache, recordHelperLlmUsage }) {
+async function executeAgentTool(toolName, toolInput, { openai, sessionId, req, clipCache, recordHelperLlmUsage, userMessage }) {
   const handler = TOOL_DISPATCH[toolName];
   if (!handler) {
     return { error: `Unknown tool: ${toolName}` };
   }
 
   try {
-    return await handler(toolInput, { openai, req, clipCache, recordHelperLlmUsage });
+    return await handler(toolInput, { openai, req, clipCache, recordHelperLlmUsage, userMessage });
   } catch (err) {
     const msg = err && (err.message || String(err));
     printLog(`[TOOL] ${toolName} threw (recovered): ${msg}`);

--- a/utils/clipReranker.js
+++ b/utils/clipReranker.js
@@ -8,13 +8,14 @@ const MIN_RELEVANCE_SCORE = 4;
  * relevance to the query, filters out low-scorers, and re-orders by score.
  *
  * @param {object} options
- * @param {string} options.query - The user's original search query
- * @param {Array}  options.clips - Array of clip objects (must have .quote or .text)
+ * @param {string} options.query - The (possibly rewritten) embedding query
+ * @param {Array}  options.clips - Array of clip objects (must have .quote or .text). May include .guests (episode-level tagged guests).
  * @param {object} options.openai - OpenAI client instance
  * @param {number} [options.minScore=4] - Minimum score to keep (0-10)
+ * @param {string} [options.userMessage] - The original user question (NOT the rewritten search query). When provided, the scorer applies a person-mismatch penalty: clips from episodes whose tagged guests don't include a person the user named score 0-3.
  * @returns {{ clips: Array, usage: { model: string, input_tokens: number, output_tokens: number } }}
  */
-async function rerankClips({ query, clips, openai, minScore = MIN_RELEVANCE_SCORE }) {
+async function rerankClips({ query, clips, openai, minScore = MIN_RELEVANCE_SCORE, userMessage }) {
   const debugPrefix = '[RERANKER]';
 
   if (!clips || clips.length === 0) {
@@ -30,7 +31,11 @@ async function rerankClips({ query, clips, openai, minScore = MIN_RELEVANCE_SCOR
     const text = (c.quote || c.text || '').substring(0, 250);
     const speaker = c.creator || 'Unknown';
     const episode = c.episode || '';
-    return `[${i}] (${speaker} — ${episode}) "${text}"`;
+    const guests = Array.isArray(c.guests) ? c.guests : [];
+    const guestStr = guests.length > 0
+      ? ` [guests: ${guests.slice(0, 4).join(', ')}]`
+      : ' [guests: none-tagged]';
+    return `[${i}] (${speaker} — ${episode})${guestStr} "${text}"`;
   });
 
   const systemPrompt = `You are a relevance scorer for podcast transcript clips. Given the user's question and a numbered list of clips, score each clip 0-10 on how directly relevant and substantive it is to answering the question.
@@ -49,9 +54,18 @@ Additional penalties:
 - If the question specifically names a podcast, host, or creator (e.g. "whatifalthist", "Lex Fridman", "All-In"), clips NOT from that source should score 0-2 regardless of topical relevance
 - Closing/farewell exchanges ("where can people find you", "where can I follow you", "thanks for coming on", "that's all for today") should score 0-1 regardless of keyword overlap
 
+Person-mismatch penalty (HARD RULE — apply before any topical score):
+- Each clip carries a [guests: ...] tag listing the episode's tagged guests, OR [guests: none-tagged] when the show/episode has no guest metadata.
+- If the user's question names a specific person (a guest, "what did X say", "X's appearance on Y", "summary of X on Z"), and the clip's [guests: ...] list is non-empty AND does NOT include that person (case-insensitive substring match against any listed guest), score the clip **0-3** regardless of topical fit. Topical relevance is NOT proof the user's named person is the speaker.
+- If the clip is [guests: none-tagged], do NOT apply this penalty — score normally on topical/substantive relevance. Empty guest metadata is ambiguous, not exonerating.
+- This penalty does NOT apply when the user's question is a pure topic query with no named person ("Bitcoin custody", "AI agents").
+
 Return ONLY a JSON array: [{"i":0,"s":7},{"i":1,"s":3},...]`;
 
-  const userMessage = `Question: "${query}"
+  const questionForScorer = (typeof userMessage === 'string' && userMessage.trim().length > 0)
+    ? userMessage.trim()
+    : query;
+  const userPrompt = `Question: "${questionForScorer}"
 
 Clips:
 ${clipSummaries.join('\n')}`;
@@ -61,7 +75,7 @@ ${clipSummaries.join('\n')}`;
       model: RERANKER_MODEL,
       messages: [
         { role: 'system', content: systemPrompt },
-        { role: 'user', content: userMessage },
+        { role: 'user', content: userPrompt },
       ],
       response_format: { type: 'json_object' },
       temperature: 0.0,


### PR DESCRIPTION
## Summary

Fixes a confident hallucination in `/api/pull` where the agent attributed quotes to a person on a show where they were never a guest. Original failure: *"Create a summary of sourcenode's latest appearance on the Robin Seyr podcast in the last month"* came back attributing Bitcoin paragraphs from the April 26 *AI Is About to Kill Your Pension* episode to Sourcenode (he was never on it). Robin Seyr's metadata leaves the per-episode `guests` array empty, so nothing in the pipeline could verify the speaker.

Three layered defenses, ordered by what they catch:

1. **Synthesis prompt anti-attribution rule** ([setup-agent.js synthesisGuard + strictSynthesisGuard](setup-agent.js)). New rule explicitly forbids attributing a quote to a named person unless either (a) the clip's manifest entry lists them under `[guests:]`, or (b) the search was scoped to that person's GUIDs from `find_person`/`get_person_episodes`. For SPEAKER UNVERIFIED clips the model must use neutral framing (*"the discussion covers…"*) and is told NOT to write *"X said / X explains / X discusses"*.

2. **Manifest SPEAKER UNVERIFIED tag** ([setup-agent.js buildClipManifest](setup-agent.js)). Clips from empty-guest episodes now render with `[SPEAKER UNVERIFIED — episode has no tagged guests; do NOT attribute this quote to any specific person by name]` inline, and the manifest header counts how many of the listed clips are unverified — anchoring rule (1) in concrete data the synthesis model reads.

3. **Reranker person-mismatch penalty** ([utils/clipReranker.js](utils/clipReranker.js), [utils/agentToolHandler.js](utils/agentToolHandler.js), [routes/agentChatRoutes.js](routes/agentChatRoutes.js)). Every `search_quotes` result is now enriched with episode-level guests via one batched `JamieVectorMetadata` lookup; the original user message threads through `executeAgentTool` to the reranker; the reranker prompt scores **0–3** any clip whose `[guests: ...]` is non-empty AND does NOT include the person the user named — so topical matches from non-guest episodes can't reach the synthesizer's manifest when guest data exists.

## Test results

Driven by the new [`scripts/trial-attribution.js`](scripts/trial-attribution.js) probe (authenticates with `JWT_TEST_TOKEN` from `.env`).

| Sourcenode/Robin Seyr (4 trials) | Before | After |
|---|---|---|
| Lead with correct May 1 episode | 0/N | **4/4** |
| Pure May 1 cites only | 0/N | 2/4 |
| Leaked April 26 citation | every trial | 2/4 (residual) |

The 2 residual April-26 leaks are the empty-guest case defense (3) cannot fire on (Robin Seyr never tags guests), so the reranker has no negative signal to score against. Closing that last gap needs `find_person`-resolved GUIDs plumbed into the manifest as a positive `[verified guest]` tag — out of scope for this PR.

**Regression checks:**
- Jim Carucci probe: still a clean win (find_person → GUID-scoped search_quotes → 4/4 cites from the correct GUID).
- Keith Gardner probe: still a clean win (Branta-related episodes, accurate framing of intro segments).

## Test plan

- [ ] `node scripts/trial-attribution.js "Create a summary of sourcenode's latest appearance on the Robin Seyr podcast in the last month" 4` — expect ≥3/4 trials to lead with May 1 and ≥2/4 to cite only May 1 GUIDs
- [ ] `node scripts/trial-attribution.js "Create a summary of Jim Carucci's latest podcast appearance" 2` — expect 2/2 to cite only `12c062f7-fe6a-4497-be70-f3500a55cdd5`
- [ ] Server log shows `RERANKER` lines with token counts; manifest text contains `**N of M clips below are marked SPEAKER UNVERIFIED**` when applicable
- [ ] Existing search_quotes integration tests still pass (no schema change to public response — `guests` is added inline, not breaking)
- [ ] Spot-check a query with NO named person (e.g. "Bitcoin custody best practices") to confirm reranker doesn't spuriously down-score (the rule only fires on named-person queries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)