### PR TITLE
hotfix: repair leaked [[CLIP:N]] tokens before they reach the client

### DIFF
--- a/routes/agentChatRoutes.js
+++ b/routes/agentChatRoutes.js
@@ -16,7 +16,7 @@ const { executeAgentTool } = require('../utils/agentToolHandler');
 const JamieVectorMetadata = require('../models/JamieVectorMetadata');
 const { filterUpsellCandidates } = require('../utils/upsellRelevance');
 const { createProvider } = require('../utils/agent/providers');
-const { sanitizeAgentText, hasToolCallMarkup, createStreamSanitizer, scrubClipIds } = require('../utils/agent/sanitizeOutput');
+const { sanitizeAgentText, hasToolCallMarkup, createStreamSanitizer, createClipTokenStreamSanitizer, scrubClipIds, repairIndexedClipTokens } = require('../utils/agent/sanitizeOutput');
 const { evaluateSynthesisOutput } = require('../utils/agent/synthesisQuality');
 const { rerankClips, RERANKER_MODEL } = require('../utils/clipReranker');
 
@@ -1001,16 +1001,35 @@ function createAgentChatRoutes({ openai } = {}) {
     // carry there.
     const streamSanitizer = createStreamSanitizer();
     let streamSanitizerLeakLogged = false;
+    // Indexed-clip-token sanitizer is initialized lazily once clipCache is
+    // created (see further down in handleAgentChat). The holder lets the
+    // emit closure capture a reference now and read the live sanitizer
+    // when text_delta events fire. `clipCache` is also stored on the
+    // holder so text_done can run document-level repair too.
+    const clipTokenSanitizerRef = { current: null, clipCache: null };
+    let clipLeakLogged = false;
 
     const emit = (eventType, data) => {
       if (eventType === 'text_delta'
           && data && typeof data.text === 'string') {
-        const safe = streamSanitizer.feed(data.text);
+        let safe = streamSanitizer.feed(data.text);
         if (!streamSanitizerLeakLogged && safe.length !== data.text.length) {
           console.warn(`[${requestId}] Stream sanitizer trimmed text_delta: ${data.text.length} → ${safe.length} chars (further drops will be silent for this request)`);
           streamSanitizerLeakLogged = true;
         }
-        if (!safe.length) return; // entire delta is in-flight markup carry
+        // Repair / hold-back indexed clip tokens (`[[CLIP:N]]` etc.) before
+        // emitting. Without this, the model's raw indexed refs ship to the
+        // browser as literal text — what users were seeing as "[[CLIP:0]]"
+        // tokens with quote bodies underneath instead of clip pills.
+        if (clipTokenSanitizerRef.current && safe.length) {
+          const repaired = clipTokenSanitizerRef.current.feed(safe);
+          if (!clipLeakLogged && repaired !== safe) {
+            console.warn(`[${requestId}] Clip-token sanitizer altered text_delta: ${safe.length} → ${repaired.length} chars (further changes silent for this request)`);
+            clipLeakLogged = true;
+          }
+          safe = repaired;
+        }
+        if (!safe.length) return; // entire delta is in-flight markup/clip carry
         data = { ...data, text: safe };
       } else if (eventType === 'text_done'
           && data && typeof data.text === 'string') {
@@ -1018,15 +1037,22 @@ function createAgentChatRoutes({ openai } = {}) {
         // carry (its content is included in `data.text`) and run the
         // regular sanitizer for any markup the streaming pass missed.
         streamSanitizer.flush();
-        if (hasToolCallMarkup(data.text)) {
-          const cleaned = sanitizeAgentText(data.text);
-          console.warn(`[${requestId}] Stripped tool-call markup from text_done: ${data.text.length} → ${cleaned.length} chars`);
+        if (clipTokenSanitizerRef.current) clipTokenSanitizerRef.current.flush();
+        // Always run the document sanitizer on text_done — repairs indexed
+        // clip refs that survived streaming and strips any tool-call markup
+        // the per-delta pass missed.
+        const cleaned = sanitizeAgentText(data.text, clipTokenSanitizerRef.clipCache);
+        if (cleaned !== data.text) {
+          console.warn(`[${requestId}] text_done sanitized: ${data.text.length} → ${cleaned.length} chars`);
           data = { ...data, text: cleaned };
         }
       } else if (eventType === 'error') {
         // Surface any held-back content before the error so the user sees
         // partial work product rather than dropping it on the floor.
-        const tail = streamSanitizer.flush();
+        let tail = streamSanitizer.flush();
+        if (clipTokenSanitizerRef.current) {
+          tail = clipTokenSanitizerRef.current.feed(tail) + clipTokenSanitizerRef.current.flush();
+        }
         if (tail && streaming) {
           try {
             res.write(`event: text_delta\ndata: ${JSON.stringify({ text: tail })}\n\n`);
@@ -1108,6 +1134,12 @@ function createAgentChatRoutes({ openai } = {}) {
       const effectiveHistory = compactHistoryEnabled ? compactHistory(history) : history;
       const messages = [...effectiveHistory, { role: 'user', content: message }];
       const clipCache = new Map(); // shareLink → raw clip metadata, populated by search_quotes results
+      // Now that clipCache exists, wire up the streaming clip-token
+      // sanitizer the emit wrapper has been holding a reference for.
+      // Ordering matters: text_delta events fired BEFORE this point
+      // (none today, but defensively) would have skipped repair.
+      clipTokenSanitizerRef.clipCache = clipCache;
+      clipTokenSanitizerRef.current = createClipTokenStreamSanitizer(clipCache);
       let toolCalls = [];
       const costs = createCostTracker(modelConfig, executionProfile);
       // Classifier (Haiku) ran before the cost tracker existed, so backfill its
@@ -1295,18 +1327,28 @@ function createAgentChatRoutes({ openai } = {}) {
             break;
           }
 
-          // Trickle-emit the buffered chunks so the client sees progressive
-          // output rather than a single mag-dump. setImmediate yields the event
-          // loop between chunks so TCP can flush each write individually.
+          // Sanitize BEFORE emitting. Without this, the model's raw text
+          // (which can contain indexed clip refs like `[[CLIP:0]]`,
+          // tool-call DSML, etc.) is shipped to the client. Repair indexed
+          // refs against clipCache so they become real {{clip:shareLink}}
+          // tokens; scrubClipIds validates {{clip:...}} IDs against the
+          // cache. Both passes are idempotent on already-clean text.
+          //
+          // We deliberately drop the per-chunk trickle here: chunks can
+          // split a token like `[[CLIP:0]]` across boundaries, and
+          // per-chunk sanitization can't repair across the split. Emitting
+          // the sanitized whole as a single text_delta + text_done is the
+          // only correctness-preserving option until we add a stateful
+          // streaming repair (planned, not yet shipped).
           naturalCompletion = true;
-          console.log(`[${requestId}] Final text trickle-emit: ${roundText.length} chars, ${roundTextDeltaBuffer.length} chunks, effectiveFinal=${effectiveFinal} (round ${round})`);
+          const sanitizedFinal = scrubClipIds(sanitizeAgentText(roundText, clipCache), clipCache);
+          console.log(`[${requestId}] Final text sanitize: ${roundText.length} → ${sanitizedFinal.length} chars (chunks=${roundTextDeltaBuffer.length}, effectiveFinal=${effectiveFinal}, round ${round})`);
           agentLog.rounds.push({ round, type: effectiveFinal && !isFinalResponse ? 'final_suggest_shortcircuit' : 'final', tokens: response.usage });
-          agentLog.finalText = roundText;
-          for (const chunk of roundTextDeltaBuffer) {
-            emit('text_delta', { text: chunk });
-            await new Promise(resolve => setImmediate(resolve));
+          agentLog.finalText = sanitizedFinal;
+          if (sanitizedFinal.length > 0) {
+            emit('text_delta', { text: sanitizedFinal });
           }
-          emit('text_done', { text: roundText });
+          emit('text_done', { text: sanitizedFinal });
           break;
         }
 

--- a/utils/agent/sanitizeOutput.js
+++ b/utils/agent/sanitizeOutput.js
@@ -52,9 +52,44 @@ const STRIP_BLOCK_PATTERNS = [
 ];
 
 // Indexed clip references that synthesis models sometimes emit instead of the
-// correct {{clip:shareLink}} format. Strip them so they don't render as literal
-// text in the UI. Examples: [[CLIP:0]], [CLIP:1], (clip 2), [[clip:3]]
-const INDEXED_CLIP_RE = /\[\[clip:\d+\]\]|\[clip:\d+\]|\(clip\s*\d+\)/gi;
+// correct {{clip:shareLink}} format. Examples: [[CLIP:0]], [CLIP:1], (clip 2),
+// [[clip:3]], {{clip:0}}.
+//
+// We REPAIR these against clipCache (mapping the integer index to the Nth
+// shareLink in clipCache key-iteration order — same order buildClipManifest
+// uses) and strip whatever can't be repaired. The /i flag matches CLIP/clip;
+// /g lets `replace` walk every occurrence.
+const INDEXED_CLIP_RE = /\[\[\s*clip\s*:\s*(\d+)\s*\]\]|\[\s*clip\s*:\s*(\d+)\s*\]|\(\s*clip\s+(\d+)\s*\)|\{\{\s*clip\s*:\s*(\d+)\s*\}\}/gi;
+
+/**
+ * Repair indexed clip references against the orchestrator's clipCache.
+ *
+ * The synthesis manifest renders clips as `{{clip:<shareLink>}}` ordered by
+ * `clipCache.entries().slice(0,25)`. When models leak `[[CLIP:N]]` instead,
+ * N is an index into that same ordering. We map index → shareLink and emit
+ * the canonical token. Out-of-range indices and bare patterns get stripped
+ * so the user never sees `[[CLIP:0]]` as literal text.
+ *
+ * @param {string} text
+ * @param {Map<string, *>} clipCache  shareLink → metadata, populated by search_quotes
+ * @returns {string}
+ */
+function repairIndexedClipTokens(text, clipCache) {
+  if (typeof text !== 'string' || text.length === 0) return text;
+  const ordered = clipCache && clipCache.size > 0
+    ? [...clipCache.keys()].slice(0, 25)
+    : [];
+  return text.replace(INDEXED_CLIP_RE, (match, ...groups) => {
+    // exec capture groups: 4 alternatives × 1 capture each = 4 indices in groups
+    const idxStr = groups.slice(0, 4).find(g => g !== undefined);
+    if (idxStr === undefined) return ''; // shouldn't happen, but be safe
+    const idx = parseInt(idxStr, 10);
+    if (!Number.isFinite(idx) || idx < 0 || idx >= ordered.length) {
+      return ''; // out-of-range: strip rather than emit broken ref
+    }
+    return `{{clip:${ordered[idx]}}}`;
+  });
+}
 
 // Stray-tag patterns: clean up orphan opens/closes left behind after an
 // incomplete or mid-stream truncation.
@@ -87,14 +122,21 @@ function stripMarkupOnly(text) {
   return out;
 }
 
-function sanitizeAgentText(text) {
+function sanitizeAgentText(text, clipCache) {
   if (typeof text !== 'string' || text.length === 0) return text;
-  // Document-level cleanup: strip markup and indexed clip refs, then collapse
-  // empty paragraphs and trim. Do NOT use this on streaming fragments.
-  return stripMarkupOnly(text)
-    .replace(INDEXED_CLIP_RE, '')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
+  // Document-level cleanup: strip markup, repair (or strip) indexed clip refs,
+  // then collapse empty paragraphs and trim. Do NOT use this on streaming
+  // fragments. When `clipCache` is provided, indexed refs like `[[CLIP:0]]`
+  // are mapped to the canonical `{{clip:<shareLink>}}` token so the user
+  // sees a working clip pill instead of an empty hole. Without `clipCache`
+  // we still strip broken refs.
+  let out = stripMarkupOnly(text);
+  if (clipCache && clipCache.size > 0) {
+    out = repairIndexedClipTokens(out, clipCache);
+  } else {
+    out = out.replace(INDEXED_CLIP_RE, '');
+  }
+  return out.replace(/\n{3,}/g, '\n\n').trim();
 }
 
 function hasToolCallMarkup(text) {
@@ -221,6 +263,60 @@ function sanitizeStreamDelta(pending, delta) {
  *   for (const delta of deltas) socket.write(stream.feed(delta));
  *   socket.write(stream.flush());
  */
+/**
+ * Stateful streaming sanitizer for indexed clip tokens (`[[CLIP:N]]`,
+ * `[CLIP:N]`, `(clip N)`, `{{clip:N}}`).
+ *
+ * Pattern: same one-shot architecture as `createStreamSanitizer` — buffer
+ * across deltas so a token split at the chunk boundary (e.g. `[[CL` in chunk
+ * N, `IP:0]]` in chunk N+1) is recognized as one unit and repaired against
+ * `clipCache`. Without this, raw `[[CLIP:0]]` ships in `text_delta` events
+ * and the frontend renders it literally.
+ *
+ * Returns `{ feed, flush }`. `feed(delta)` returns the safe prefix to emit;
+ * `flush()` drains the carry at end-of-stream.
+ *
+ * Implementation strategy:
+ *   1. Append delta to internal buffer.
+ *   2. Run `repairIndexedClipTokens` on the buffer — every COMPLETE indexed
+ *      ref becomes `{{clip:<shareLink>}}`. Out-of-range ones get stripped.
+ *   3. Detect a trailing PARTIAL-token tail (`[`, `[[`, `[[C`, `(c`, `{{`,
+ *      etc.) that could grow into a complete ref once the next delta
+ *      arrives. Hold that tail back; emit everything before it.
+ *
+ * The partial-tail regex is anchored to the buffer end and matches the
+ * longest progress along any of the four indexed-ref shapes.
+ */
+const PARTIAL_INDEXED_CLIP_TAIL_RE = /(\[\[?\s*[cC]?[lL]?[iI]?[pP]?\s*:?\s*\d*\s*\]?|\(\s*[cC]?[lL]?[iI]?[pP]?\s*\d*\s*|\{\{?\s*[cC]?[lL]?[iI]?[pP]?\s*:?\s*\d*\s*\}?)$/;
+
+function createClipTokenStreamSanitizer(clipCache) {
+  let pending = '';
+  const repair = (text) => repairIndexedClipTokens(text, clipCache);
+  return {
+    feed(delta) {
+      pending += delta || '';
+      if (!pending.length) return '';
+      // Hold back any trailing fragment that could grow into a complete
+      // indexed ref. Cap the holdback at 32 chars so a stray `[` in prose
+      // can't pin the buffer indefinitely.
+      const m = pending.match(PARTIAL_INDEXED_CLIP_TAIL_RE);
+      const holdLen = m && m[0].length <= 32 ? m[0].length : 0;
+      const safe = pending.slice(0, pending.length - holdLen);
+      const carry = pending.slice(pending.length - holdLen);
+      pending = carry;
+      return repair(safe);
+    },
+    flush() {
+      const out = repair(pending);
+      pending = '';
+      return out;
+    },
+    peekPending() {
+      return pending;
+    },
+  };
+}
+
 function createStreamSanitizer() {
   let pending = '';
   return {
@@ -364,6 +460,8 @@ module.exports = {
   hasToolCallMarkup,
   sanitizeStreamDelta,
   createStreamSanitizer,
+  createClipTokenStreamSanitizer,
   createNarrationFilter,
   scrubClipIds,
+  repairIndexedClipTokens,
 };


### PR DESCRIPTION
## PROD INCIDENT

Users were seeing literal `[[CLIP:0]]` / `[[CLIP:1]]` text in agent responses where playable clip pills should have been. Two unsanitized paths were shipping the model's raw output:

1. **Natural-completion path** ([routes/agentChatRoutes.js around line 1304](routes/agentChatRoutes.js#L1304)) emitted `roundText` and the per-chunk `roundTextDeltaBuffer` directly via `text_delta` + `text_done`. No `sanitizeAgentText`, no `scrubClipIds`. When DeepSeek (or any orchestrator) wrote `[[CLIP:N]]` instead of `{{clip:<shareLink>}}` it went straight to the browser.
2. **Synthesis streaming path** ([emit wrapper at line 1005](routes/agentChatRoutes.js#L1005)) sanitized tool-call markup but not indexed clip refs. The final `text_done` was strip-only — broken token became an empty hole instead of a working pill, so even frontends that re-rendered on `text_done` were degraded.

This PR is independent of PR #112 (attribution work) so it can ship on its own.

## Fix

- **New `repairIndexedClipTokens(text, clipCache)`** in [utils/agent/sanitizeOutput.js](utils/agent/sanitizeOutput.js) maps `[[CLIP:N]]`, `[CLIP:N]`, `(clip N)`, `{{clip:N}}` to the canonical `{{clip:<shareLink>}}` token using `clipCache` key-iteration order — the same ordering `buildClipManifest` uses to render the synthesis manifest. Out-of-range indices are stripped.
- **`sanitizeAgentText(text, clipCache?)`** now repairs when `clipCache` is provided and falls back to the original strip behavior when it isn't (backward compatible).
- **New `createClipTokenStreamSanitizer(clipCache)`** is the streaming analog of `createStreamSanitizer`. It buffers a partial-token tail across deltas (so a token split as `[[CL` / `IP:0]]` across chunks is recognized as one unit), repairs complete refs, emits the safe prefix.
- **The route's emit wrapper** now chains every `text_delta` through both stream sanitizers (markup + clip tokens) and runs `sanitizeAgentText(..., clipCache)` on every `text_done` for belt-and-suspenders repair of anything streaming missed.
- **Natural-completion path** no longer trickles raw chunks. It sanitizes `roundText` once and emits a single `text_delta` + `text_done`. Trickle UX is suspended on this path until a stateful streaming repair is added on top of the new sanitizer; correctness over UX while prod is bleeding.

## Verification

Same query that triggered the screenshots — *"summarize the last 3 sourcenode podcast appearances"* — run 4 times against the patched server: **zero `[[CLIP:N]]` / `[CLIP:N]` / `(clip N)` literals** in any output. Telemetry confirms the new sanitizer is firing on every request:

```
[AGENT-1-snr9rt] Clip-token sanitizer altered text_delta: 2 → 1 chars (further changes silent for this request)
[AGENT-9-i3djrq] Clip-token sanitizer altered text_delta: 2 → 1 chars (further changes silent for this request)
[AGENT-5-gy3dub] Clip-token sanitizer altered text_delta: 2 → 1 chars (further changes silent for this request)
[AGENT-1-bbmsvs] Clip-token sanitizer altered text_delta: 2 → 1 chars (further changes silent for this request)
```

Unit-level smoke test (split-token streaming case) also passes:

```
feed("[[CL")           -> ""                       (held back)
feed("IP:0]] world ")  -> "{{clip:<shareLink>}} world "
feed("[[CLIP:1")       -> ""                       (held back)
feed("]] and tail.")   -> "{{clip:<shareLink>}} and tail."
```

## Test plan

- [ ] Hit `/api/pull` (deep mode) with any query that returns search_quotes results and confirm no `[[CLIP:N]]` / `[CLIP:N]` / `(clip N)` literals in the streamed response or final `text_done`
- [ ] Sanity-check a non-clip query ("hello world" type) — text passes through unchanged with no spurious holdback
- [ ] Verify server logs show `Clip-token sanitizer altered text_delta` lines when a leak would have happened (and absent when input is already clean)
- [ ] Check that the natural-completion path still terminates cleanly (one `text_delta` + `text_done`) — no missing final-text regressions

## Caveats

- Trickle UX on the natural-completion path is suspended (single delta + done). Synthesis streaming is preserved. If the trickle-back-on UX matters, it's a follow-up using the new stream sanitizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)