### PR TITLE
fix(agent): keep SSE streams alive through proxy idle timeouts

### DIFF
--- a/routes/agentChatRoutes.js
+++ b/routes/agentChatRoutes.js
@@ -944,10 +944,11 @@ function createAgentChatRoutes({ openai } = {}) {
 
     printLog(`[${requestId}] POST ${req.path} — provider=${modelConfig.provider}, model=${modelConfig.label} (${modelKey}), profile=${profileKey}, history=${history.length}, compact=${compactResults}/${compactHistoryEnabled}, stream=${streaming}, "${message.substring(0, 100)}"`);
 
+    let _heartbeat = null;
     if (streaming) {
       res.writeHead(200, {
         'Content-Type': 'text/event-stream',
-        'Cache-Control': 'no-cache',
+        'Cache-Control': 'no-cache, no-transform',
         'Connection': 'keep-alive',
         'X-Accel-Buffering': 'no',
       });
@@ -956,6 +957,18 @@ function createAgentChatRoutes({ openai } = {}) {
       // Without this, synthesis tokens (which arrive via async for-await) still
       // get bundled into one burst before being sent to the client.
       res.socket?.setNoDelay(true);
+      // Tell the browser's EventSource to reconnect after 3s (default is ~3s
+      // already, but stating it makes behavior explicit across browsers).
+      try { res.write('retry: 3000\n\n'); } catch (_) {}
+      // Heartbeat: SSE comment line (ignored by EventSource parser) every 15s.
+      // Prevents intermediate proxies (Cloudflare/ALB/nginx) from idle-closing
+      // the socket during long quiet gaps (LLM thinking, slow tool calls),
+      // which is the usual cause of "network error" mid-stream in prod.
+      _heartbeat = setInterval(() => {
+        try { res.write(': keepalive\n\n'); }
+        catch (_) { clearInterval(_heartbeat); _heartbeat = null; }
+      }, 15000);
+      if (typeof _heartbeat.unref === 'function') _heartbeat.unref();
     }
 
     // Non-streaming accumulator. Populated by emit() when !streaming.
@@ -1089,7 +1102,10 @@ function createAgentChatRoutes({ openai } = {}) {
     };
 
     let _aborted = false;
-    res.on('close', () => { _aborted = true; });
+    res.on('close', () => {
+      _aborted = true;
+      if (_heartbeat) { clearInterval(_heartbeat); _heartbeat = null; }
+    });
     const aborted = () => _aborted;
 
     let agentLog = null;
@@ -2226,6 +2242,7 @@ function createAgentChatRoutes({ openai } = {}) {
       });
 
       if (streaming) {
+        if (_heartbeat) { clearInterval(_heartbeat); _heartbeat = null; }
         res.end();
       } else {
         const responseBody = {
@@ -2272,10 +2289,12 @@ function createAgentChatRoutes({ openai } = {}) {
       }
       if (streaming) {
         emit('error', { error: error.message });
+        if (_heartbeat) { clearInterval(_heartbeat); _heartbeat = null; }
         res.end();
       } else if (!res.headersSent) {
         res.status(500).json({ sessionId, error: error.message });
       } else {
+        if (_heartbeat) { clearInterval(_heartbeat); _heartbeat = null; }
         res.end();
       }
     }

--- a/server.js
+++ b/server.js
@@ -2035,7 +2035,7 @@ if (DEBUG_MODE) {
 
 
 
-app.listen(PORT, async () => {
+const _server = app.listen(PORT, async () => {
   console.log(`Server running on port ${PORT}`);
   console.log(`DEBUG_MODE:`, process.env.DEBUG_MODE === 'true')
   console.log(`SCHEDULER_ENABLED:`, SCHEDULER_ENABLED)
@@ -2304,6 +2304,14 @@ app.listen(PORT, async () => {
     console.warn('Continuing without backup system...');
   }
 });
+
+// Long-running SSE streams need timeouts looser than Node's defaults so the
+// server doesn't close the socket out from under the heartbeat. Defaults are
+// keepAlive=5s / headers=60s. Set keepAlive > typical proxy idle (60s on
+// Cloudflare/ALB) and headers > keepAlive per Node's required ordering.
+_server.requestTimeout = 0;          // no per-request hard limit
+_server.keepAliveTimeout = 75_000;
+_server.headersTimeout   = 80_000;
 
 // Update the shutdown handlers
 process.on('SIGTERM', async () => {


### PR DESCRIPTION
## Summary
- Adds a **15s heartbeat** (`: keepalive` SSE comment) on the agent chat stream so intermediate proxies (Cloudflare / ALB / nginx) don't idle-close the socket during long quiet gaps (LLM thinking, slow tool calls). This is the usual cause of the generic "network error" we see mid-stream in prod.
- Adds an explicit `retry: 3000` directive at stream open so EventSource's reconnect interval is deterministic across browsers.
- Adds `no-transform` to `Cache-Control` to block proxy-side compression buffering.
- Loosens Node's HTTP timeouts (`keepAliveTimeout=75s`, `headersTimeout=80s`, `requestTimeout=0`) so the server doesn't close the socket out from under the heartbeat. Node's defaults (5s/60s) are shorter than typical reverse-proxy idle timeouts.
- Heartbeat timer is cleared on `res.on('close')`, natural completion, and the error path — no leaked intervals.

## Test plan
- [ ] Hit `/api/pull` with a streaming request; confirm `:keepalive` comments appear in the wire log roughly every 15s
- [ ] Confirm normal `text_delta` / `tool_call` / `done` events still render in the React client
- [ ] Confirm `retry: 3000` shows up as the first chunk of the stream
- [ ] Force a long synthesis (>30s of quiet) behind the prod proxy and verify the connection survives end-to-end
- [ ] Abort a stream from the client and confirm no "interval still firing" log noise (heartbeat cleanly cleared)

## Frontend note
If the React client uses native `EventSource`, it auto-reconnects and now honors the explicit 3s retry. If it uses `fetch` + `ReadableStream` (common when the request is POST or needs auth headers), it does **not** auto-reconnect — a follow-up wrapper on the client side is still needed to re-issue the request on read errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)