### PR TITLE
feat(agent): persist per-request agent logs to MongoDB

### DIFF
--- a/models/AgentRunLog.js
+++ b/models/AgentRunLog.js
@@ -26,7 +26,8 @@ const AgentRunLogSchema = new mongoose.Schema({
   compactHistory:   { type: Boolean },
   bypassTriage:     { type: Boolean },
 
-  // Caller identity (best-effort; varies by entry point)
+  // Caller identity (best-effort; varies by entry point). `ip` is a salted
+  // SHA-256 truncated to 16 hex chars — never the raw address.
   ip:               { type: String },
   entitlementType:  { type: String, index: true }, // 'pull' | 'free-tier' | etc
   entitlementSource:{ type: String },               // 'nostr-bot' | 'web' | etc

--- a/models/AgentRunLog.js
+++ b/models/AgentRunLog.js
@@ -1,0 +1,68 @@
+const mongoose = require('mongoose');
+
+// Persisted copy of the per-request `agentLog` object that
+// routes/agentChatRoutes.js already builds and writes to logs/agent/*.json.
+// Schema is intentionally permissive (Mixed for round/tool details) so it
+// stays in sync with agentLog without requiring a schema migration every
+// time a new field is added inline. Keep file writes as the source of
+// truth; this collection exists to make the same data queryable.
+const AgentRunLogSchema = new mongoose.Schema({
+  requestId:        { type: String, required: true, index: true },
+  sessionId:        { type: String, index: true },
+  startedAt:        { type: Date,   required: true },
+  completedAt:      { type: Date },
+  latencyMs:        { type: Number, index: true },
+
+  // Routing / config snapshot
+  intent:           { type: String, index: true },
+  model:            { type: String, index: true },
+  modelKey:         { type: String, index: true },
+  provider:         { type: String },
+  synthesisModel:   { type: String, default: null },
+  synthesisModelKey:{ type: String, default: null },
+  executionProfile: { type: String, index: true }, // 'fast' | 'deep' | etc
+  streaming:        { type: Boolean },
+  compactResults:   { type: Boolean },
+  compactHistory:   { type: Boolean },
+  bypassTriage:     { type: Boolean },
+
+  // Caller identity (best-effort; varies by entry point)
+  ip:               { type: String },
+  entitlementType:  { type: String, index: true }, // 'pull' | 'free-tier' | etc
+  entitlementSource:{ type: String },               // 'nostr-bot' | 'web' | etc
+
+  // The user input + final answer
+  query:            { type: String },
+  finalText:        { type: String },
+
+  // Round-by-round trace + per-call tool details
+  rounds:           { type: [mongoose.Schema.Types.Mixed], default: [] },
+
+  // Final summary (cost, tokens, tool call list, completion reason)
+  summary:          { type: mongoose.Schema.Types.Mixed, default: null },
+
+  // Synthesis recovery details when Tier 1 was unsatisfactory
+  synthesisRecovery:{ type: mongoose.Schema.Types.Mixed, default: null },
+
+  // Triage classifier token usage (when triage ran)
+  classifierTokens: { type: mongoose.Schema.Types.Mixed, default: null },
+
+  // Populated when the request errored before completing
+  error:            { type: String, default: null, index: true },
+}, {
+  timestamps: true,
+  // Permissive container — agentLog gains fields organically; we don't
+  // want strict mode silently dropping them.
+  strict: false,
+});
+
+// 90-day TTL — these docs are large (full round trace, tool inputs,
+// final text). Adjust here if you ever want longer retention.
+AgentRunLogSchema.index({ startedAt: 1 }, { expireAfterSeconds: 90 * 24 * 60 * 60 });
+
+// Compound indexes for common dashboard slices
+AgentRunLogSchema.index({ intent: 1, startedAt: -1 });
+AgentRunLogSchema.index({ modelKey: 1, startedAt: -1 });
+AgentRunLogSchema.index({ error: 1, startedAt: -1 });
+
+module.exports = mongoose.model('AgentRunLog', AgentRunLogSchema);

--- a/routes/agentChatRoutes.js
+++ b/routes/agentChatRoutes.js
@@ -23,6 +23,23 @@ const { rerankClips, RERANKER_MODEL } = require('../utils/clipReranker');
 const AGENT_LOG_DIR = path.join(__dirname, '..', 'logs', 'agent');
 try { fs.mkdirSync(AGENT_LOG_DIR, { recursive: true }); } catch {}
 
+// Lazy-loaded so unit tests / scripts that exercise the router without a
+// Mongo connection don't fail on import. require()ing inside the function
+// is cheap (Node caches the module) and keeps the dual-write opt-out
+// simple — set AGENT_RUN_LOG_MONGO=false to disable.
+function persistAgentLogToMongo(logData) {
+  if (process.env.AGENT_RUN_LOG_MONGO === 'false') return;
+  try {
+    const AgentRunLog = require('../models/AgentRunLog');
+    // Fire-and-forget. Mongo hiccups must not affect the user request.
+    AgentRunLog.create(logData).catch(err => {
+      printLog(`[AGENT-LOG] Mongo write failed: ${err.message}`);
+    });
+  } catch (err) {
+    printLog(`[AGENT-LOG] Mongo persist init failed: ${err.message}`);
+  }
+}
+
 function writeAgentLog(requestId, sessionId, logData) {
   try {
     const ts = new Date().toISOString().replace(/[:.]/g, '-');
@@ -34,6 +51,7 @@ function writeAgentLog(requestId, sessionId, logData) {
   } catch (err) {
     printLog(`[AGENT-LOG] Failed to write log: ${err.message}`);
   }
+  persistAgentLogToMongo(logData);
 }
 
 const MAX_HISTORY_MESSAGES = 4; // 2 prior turns (user + assistant each)
@@ -1217,8 +1235,18 @@ function createAgentChatRoutes({ openai } = {}) {
       };
       agentLog = {
         requestId, sessionId, model: modelConfig.label, intent,
+        modelKey,
+        provider: modelConfig.provider,
         synthesisModel: synthesisIsDistinct ? synthesisModelConfig.label : null,
         synthesisModelKey: synthesisIsDistinct ? synthesisModelKey : null,
+        executionProfile: profileKey,
+        streaming,
+        compactResults,
+        compactHistory: compactHistoryEnabled,
+        bypassTriage,
+        ip: req.ip || null,
+        entitlementType: req.entitlement?.type || null,
+        entitlementSource: req.entitlement?.source || null,
         query: message, startedAt: new Date().toISOString(),
         classifierTokens,
         rounds: [],

--- a/routes/agentChatRoutes.js
+++ b/routes/agentChatRoutes.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const Anthropic = require('@anthropic-ai/sdk');
+const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const { printLog } = require('../constants.js');
@@ -22,6 +23,26 @@ const { rerankClips, RERANKER_MODEL } = require('../utils/clipReranker');
 
 const AGENT_LOG_DIR = path.join(__dirname, '..', 'logs', 'agent');
 try { fs.mkdirSync(AGENT_LOG_DIR, { recursive: true }); } catch {}
+
+// Hash request IPs before they land in any persisted log. SHA-256 with a
+// server-side salt; truncated to 16 hex chars (64 bits — plenty of entropy
+// for correlation, no useful inversion). If IP_HASH_SALT is unset we drop
+// the IP entirely rather than store an unsalted hash, since IPv4 space is
+// small enough to rainbow-table without a salt. The warning fires once per
+// process so we notice in dev but don't spam prod logs.
+let _ipSaltWarned = false;
+function hashIp(ip) {
+  if (!ip) return null;
+  const salt = process.env.IP_HASH_SALT;
+  if (!salt) {
+    if (!_ipSaltWarned) {
+      printLog('[AGENT-LOG] IP_HASH_SALT unset — IP field will be omitted from agent run logs. Set IP_HASH_SALT to a long random string to enable hashed-IP correlation.');
+      _ipSaltWarned = true;
+    }
+    return null;
+  }
+  return crypto.createHash('sha256').update(salt).update(String(ip)).digest('hex').slice(0, 16);
+}
 
 // Lazy-loaded so unit tests / scripts that exercise the router without a
 // Mongo connection don't fail on import. require()ing inside the function
@@ -1244,7 +1265,7 @@ function createAgentChatRoutes({ openai } = {}) {
         compactResults,
         compactHistory: compactHistoryEnabled,
         bypassTriage,
-        ip: req.ip || null,
+        ip: hashIp(req.ip),
         entitlementType: req.entitlement?.type || null,
         entitlementSource: req.entitlement?.source || null,
         query: message, startedAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary
Adds an `AgentRunLog` Mongoose model that mirrors the per-request `agentLog` object the agent route already builds and writes to `logs/agent/*.json`. The dual write is fire-and-forget — Mongo errors are logged but never bleed into the user request, and file writes remain the source of truth.

Schema captures everything that was already in `agentLog` plus a few request-level fields that weren't being persisted yet:
- `executionProfile` (fast/deep), `streaming`, `compactResults`, `compactHistory`, `bypassTriage`
- `ip`, `entitlementType`, `entitlementSource`
- `modelKey`, `provider` (alongside the existing label fields)

Round-by-round trace (`rounds[]`) and end-of-run `summary` (cost, tokens, tool calls, latency, completion reason) are stored as Mixed so they stay in lockstep with whatever the route pushes — no schema migration needed when a new field gets added inline.

## What gets logged per request
- Routing/config: model, modelKey, provider, executionProfile, intent, streaming, compact flags, bypassTriage
- Caller identity (best-effort): ip, entitlementType, entitlementSource
- Q&A: query (raw input), finalText (synthesized answer), classifierTokens
- Round trace: per round type/tokens, per tool call name + full input + resultCount + latencyMs
- Summary: rounds, full toolCalls list, tokens, cost (orchestrator + helpers + per-helper breakdown), latencyMs, naturalCompletion, synthesisExitReason
- Errors: `error` string + `synthesisRecovery` (Tier 1/2/3 details)

## What is NOT logged (intentional gaps)
- userId — `req.identity` isn't populated for typical web/SSE callers; would need middleware plumbing
- Full message history — only the current turn's user message is in `query`
- Tool result bodies — only `resultCount`/`latencyMs`, not the actual clip lists / search hits
- Suggested actions emitted to the client
- Synthesis system/user prompts (reconstructable from `query` + `intent` + `executionProfile`)
- Per-token `text_delta` timing — only the final `text_done` is logged

## Storage
- Collection: `agentrunlogs`
- DB: `MONGO_URI` (or `MONGO_DEBUG_URI` when `DEBUG_MODE=true`) — same connection the app already uses
- TTL: 90 days on `startedAt`
- Indexes: requestId, sessionId, intent, model, modelKey, executionProfile, entitlementType, error, latencyMs + compound (intent, modelKey, error) × startedAt
- Opt-out: set `AGENT_RUN_LOG_MONGO=false`

## How to interact
```js
const AgentRunLog = require('./models/AgentRunLog');
// Recent failures
await AgentRunLog.find({ error: { $ne: null } }).sort({ startedAt: -1 }).limit(50);
// Cost outliers in fast mode last 24h
await AgentRunLog.find({
  executionProfile: 'fast',
  startedAt: { $gte: new Date(Date.now() - 86400_000) },
}).sort({ 'summary.cost.total': -1 }).limit(20);
```

Natural follow-up (not in this PR): a read-only `/api/agent-runs` admin route exposing filtered queries for an LLM dashboard. Better to wait until a few days of real data are flowing before designing that surface.

## Test plan
- [ ] Restart the server (mongoose connection picks up the new model)
- [ ] Fire a streaming agent request; confirm the new `logs/agent/*.json` contains `executionProfile`, `streaming`, `modelKey`, `provider`, `ip`, `entitlementType`
- [ ] Confirm the same record appears in Mongo: `db.agentrunlogs.find().sort({startedAt:-1}).limit(1).pretty()`
- [ ] Force a Mongo error (e.g. set `MONGO_URI` to garbage, restart) — confirm `[AGENT-LOG] Mongo write failed:` lands in stderr but the user's request still completes normally
- [ ] Set `AGENT_RUN_LOG_MONGO=false`, restart — confirm file logs still write but Mongo collection gets no new docs
- [ ] Verify TTL index exists: `db.agentrunlogs.getIndexes()` shows `expireAfterSeconds: 7776000` on `startedAt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)