### PR TITLE
fix(l402): switch invoice generation to NWC (legacy Alby API deprecated)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@anthropic-ai/sdk": "^0.91.1",
         "@aws-sdk/client-s3": "^3.717.0",
         "@aws-sdk/s3-request-presigner": "^3.758.0",
+        "@getalby/sdk": "^7.0.0",
         "@langchain/community": "^1.1.15",
         "@langchain/openai": "^1.4.4",
         "@pinecone-database/pinecone": "^4.1.0",
@@ -1129,6 +1130,36 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@getalby/lightning-tools": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@getalby/lightning-tools/-/lightning-tools-6.1.0.tgz",
+      "integrity": "sha512-rGurar9X4Gm+9xwoNYS8s9YLK7ZYqvbqv4KbHLYV0LEeB0HxZHRgmxblGqg+fYfp6iiYHx+edIgUpt9rS3VwFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "lightning",
+        "url": "lightning:hello@getalby.com"
+      }
+    },
+    "node_modules/@getalby/sdk": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@getalby/sdk/-/sdk-7.0.0.tgz",
+      "integrity": "sha512-0c8gyvFbRDHZIgHmOD/dfyPukxZLeidx/hx7SXlMIS/hsx4mXpKpo9Gx1zW90buElnd3k9TVB/S/bnFSEZPE7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@getalby/lightning-tools": "^6.0.0",
+        "nostr-tools": "^2.17.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "lightning",
+        "url": "lightning:hello@getalby.com"
       }
     },
     "node_modules/@ibm-cloud/watsonx-ai": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@anthropic-ai/sdk": "^0.91.1",
     "@aws-sdk/client-s3": "^3.717.0",
     "@aws-sdk/s3-request-presigner": "^3.758.0",
+    "@getalby/sdk": "^7.0.0",
     "@langchain/community": "^1.1.15",
     "@langchain/openai": "^1.4.4",
     "@pinecone-database/pinecone": "^4.1.0",

--- a/scripts/probe-nwc-invoice.js
+++ b/scripts/probe-nwc-invoice.js
@@ -1,0 +1,21 @@
+require('dotenv').config();
+const { generateInvoiceForSats } = require('../utils/lightning-utils');
+
+(async () => {
+  const start = Date.now();
+  try {
+    console.log('NWC_CONNECTION_URI present:', !!process.env.NWC_CONNECTION_URI);
+    const inv = await generateInvoiceForSats(10);
+    console.log('SUCCESS in', Date.now() - start, 'ms');
+    console.log('paymentHash:', inv.paymentHash);
+    console.log('expiresAt:', inv.expiresAt.toISOString());
+    console.log('pr length:', inv.pr.length);
+    console.log('pr prefix:', inv.pr.substring(0, 40) + '...');
+  } catch (e) {
+    console.log('FAILED in', Date.now() - start, 'ms');
+    console.log('error:', e.message);
+    console.log('stack:', e.stack);
+  } finally {
+    process.exit(0);
+  }
+})();

--- a/utils/lightning-utils.js
+++ b/utils/lightning-utils.js
@@ -1,10 +1,26 @@
 const axios = require("axios");
 const bolt11 = require("bolt11");
-const crypto = require('crypto'); 
+const crypto = require('crypto');
+// Node 20 lacks a global WebSocket; @getalby/sdk needs one for nostr relays.
+if (typeof globalThis.WebSocket === 'undefined') {
+  globalThis.WebSocket = require('ws');
+}
+const { NWCClient } = require('@getalby/sdk');
 // DEPRECATED: SQLite invoice tracking is disabled due to security vulnerabilities
 // The imported functions are now no-op stubs - see invoice-db.js for MongoDB migration path
 const { isPaymentHashValid, recordPayment, storeInvoice } = require('./invoice-db');
 const { DEBUG_MODE } = require("../constants");
+
+let _nwcClient;
+function getNwcClient() {
+  if (!_nwcClient) {
+    if (!process.env.NWC_CONNECTION_URI) {
+      throw new Error('NWC_CONNECTION_URI not set');
+    }
+    _nwcClient = new NWCClient({ nostrWalletConnectUrl: process.env.NWC_CONNECTION_URI });
+  }
+  return _nwcClient;
+}
 
 
 function getLNURL() {
@@ -233,29 +249,25 @@ async function generateInvoiceForSats(amountSats, description = 'PTUJ Agent API 
   const timestamp = new Date().toISOString().replace('T', ' ').substring(0, 19);
   const fullDescription = `${description} (${amountSats} sats) at ${timestamp}`;
 
-  const response = await axios.post('https://api.getalby.com/invoices', {
-    description: fullDescription,
-    amount: amountSats
-  }, {
-    headers: {
-      'Authorization': `Bearer ${process.env.ALBY_WALLET_API_KEY}`,
-      'Content-Type': 'application/json'
-    }
+  const result = await getNwcClient().makeInvoice({
+    amount: amountSats * 1000, // NIP-47 makeInvoice takes msats
+    description: fullDescription
   });
 
-  const invoiceData = response.data;
+  const paymentRequest = result.invoice;
+  const paymentHash = result.payment_hash;
 
-  if (!invoiceData.payment_request) {
-    throw new Error(`No payment request in Alby response: ${JSON.stringify(invoiceData)}`);
+  if (!paymentRequest) {
+    throw new Error(`No invoice returned from NWC: ${JSON.stringify(result)}`);
   }
 
-  const decodedInvoice = bolt11.decode(invoiceData.payment_request);
+  const decodedInvoice = bolt11.decode(paymentRequest);
   const expirySeconds = decodedInvoice.tags.find(tag => tag.tagName === 'expire_time')?.data || 3600;
   const expiresAt = new Date((decodedInvoice.timestamp + expirySeconds) * 1000);
 
   return {
-    pr: invoiceData.payment_request,
-    paymentHash: invoiceData.payment_hash,
+    pr: paymentRequest,
+    paymentHash,
     expiresAt
   };
 }


### PR DESCRIPTION
## Summary
- Prod /api/pull was returning 500 `CHALLENGE_ERROR` because the `api.getalby.com/invoices` call was failing with `code: 9 - "wallet is online and unlocked"` / 401 invalid token. The hosted Alby wallet behind `ALBY_WALLET_API_KEY` is being sunset.
- Rewires `generateInvoiceForSats` to use `@getalby/sdk`'s `NWCClient` against an Alby Hub NWC app connection (`NWC_CONNECTION_URI`).
- Adds a `ws` polyfill for Node 20 (no global `WebSocket`) so the SDK can reach nostr relays.
- Other invoice helpers (`generateInvoice`, `generateInvoiceAlbyAPI`) are untouched — they're separate code paths and not part of the failing flow.

## Required env change
Set `NWC_CONNECTION_URI=nostr+walletconnect://...` in all environments (local + prod). The connection should grant `make_invoice` (and `lookup_invoice` if/when we migrate paid-check) with a budget cap. `ALBY_WALLET_API_KEY` can be removed once we're confident no other code path depends on it.

## Test plan
- [x] Direct test: `node scripts/probe-nwc-invoice.js` → invoice generated in ~1.1s (paymentHash + valid bolt11)
- [x] Request test: `curl -X POST http://localhost:4132/api/pull -H 'Content-Type: application/json' -d '{"message":"ping","stream":false}'` → `402 Payment Required` with fresh `lnbc...` invoice (vs. `500 CHALLENGE_ERROR` before)
- [ ] Deploy to prod with `NWC_CONNECTION_URI` set; re-curl prod `/api/pull` and confirm 402

## Notes
- Lazy NWC client init keeps server start fast and avoids touching nostr unless an L402 challenge is actually requested.
- The probe script under `scripts/probe-nwc-invoice.js` is kept as a diagnostic for future Alby/NWC issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)