### PR TITLE
atlas-search: drop shingles, generate expansions via tool prompt

### DIFF
--- a/scripts/sample-chapters-feasibility.js
+++ b/scripts/sample-chapters-feasibility.js
@@ -1,0 +1,222 @@
+/**
+ * sample-chapters-feasibility.js
+ *
+ * One-shot read-only feasibility probe for chapter-level lexical search.
+ *
+ * Question: if we replaced the paragraph-level Atlas Search index with a
+ * chapter-level one, would chapters carry enough searchable text to recover
+ * the canonical query classes (proper nouns, brand compounds, spelled-out
+ * forms)?
+ *
+ * Outputs to ./tmp/chapter-feasibility-<timestamp>.txt:
+ *   1. Corpus stats: total chapter count, avg/median field sizes
+ *   2. Random sample of 15 chapters with their headline/summary/keywords
+ *   3. Hit check for canonical smoke-test queries — does the chapter text
+ *      contain the literal term anywhere?
+ *
+ * Usage:
+ *   node scripts/sample-chapters-feasibility.js
+ *
+ * Safe against prod. Read-only.
+ */
+
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+const mongoose = require('mongoose');
+const JamieVectorMetadata = require('../models/JamieVectorMetadata');
+
+const CANONICAL_QUERIES = [
+  'lncurl',
+  'Alby Hub',
+  'Nostr Wallet Connect',
+  'BIP-32',
+  'nostr',
+  'lightning',
+  'bitcoin',
+];
+
+const SAMPLE_SIZE = 15;
+const HIT_CHECK_LIMIT_PER_QUERY = 5;
+
+function fmtNum(n) {
+  return new Intl.NumberFormat('en-US').format(n);
+}
+
+function percentile(sorted, p) {
+  if (!sorted.length) return 0;
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[idx];
+}
+
+async function main() {
+  const mongoURI = process.env.DEBUG_MODE === 'true'
+    ? process.env.MONGO_DEBUG_URI
+    : process.env.MONGO_URI;
+
+  if (!mongoURI) {
+    console.error('MONGO_URI not set');
+    process.exit(1);
+  }
+
+  console.log('Connecting to MongoDB…');
+  await mongoose.connect(mongoURI);
+  console.log('Connected.');
+
+  const outDir = path.join(__dirname, '..', 'tmp');
+  if (!fs.existsSync(outDir)) fs.mkdirSync(outDir);
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const outFile = path.join(outDir, `chapter-feasibility-${ts}.txt`);
+  const lines = [];
+  const log = (s) => { console.log(s); lines.push(s); };
+
+  log(`Chapter feasibility report — ${new Date().toISOString()}`);
+  log('='.repeat(72));
+
+  // --- 1. Corpus stats ---
+  log('\n## 1. Corpus stats');
+  const totalChapters = await JamieVectorMetadata.countDocuments({ type: 'chapter' });
+  const totalParagraphs = await JamieVectorMetadata.countDocuments({ type: 'paragraph' });
+  log(`  Total chapters:   ${fmtNum(totalChapters)}`);
+  log(`  Total paragraphs: ${fmtNum(totalParagraphs)}`);
+  log(`  Ratio: 1 chapter per ${(totalParagraphs / Math.max(totalChapters, 1)).toFixed(1)} paragraphs`);
+
+  // --- 2. Field-size distribution across a larger sample ---
+  log('\n## 2. Field-size distribution (1000 chapter sample)');
+  const sizeSample = await JamieVectorMetadata
+    .find({ type: 'chapter' })
+    .select('metadataRaw')
+    .limit(1000)
+    .lean();
+
+  const headlineLens = [];
+  const summaryLens = [];
+  const keywordCounts = [];
+  const totalIndexableChars = [];
+  let withHeadline = 0;
+  let withSummary = 0;
+  let withKeywords = 0;
+  let emptyAllThree = 0;
+
+  for (const doc of sizeSample) {
+    const m = doc.metadataRaw || {};
+    const headline = typeof m.headline === 'string' ? m.headline : '';
+    const summary = typeof m.summary === 'string' ? m.summary : '';
+    const keywords = Array.isArray(m.keywords) ? m.keywords : [];
+    headlineLens.push(headline.length);
+    summaryLens.push(summary.length);
+    keywordCounts.push(keywords.length);
+    totalIndexableChars.push(
+      headline.length + summary.length + keywords.join(' ').length
+    );
+    if (headline) withHeadline++;
+    if (summary) withSummary++;
+    if (keywords.length) withKeywords++;
+    if (!headline && !summary && !keywords.length) emptyAllThree++;
+  }
+
+  const stats = (arr, label) => {
+    const sorted = [...arr].sort((a, b) => a - b);
+    const sum = arr.reduce((a, b) => a + b, 0);
+    const mean = sum / arr.length;
+    log(`  ${label.padEnd(28)} mean=${mean.toFixed(1)}  p50=${percentile(sorted, 50)}  p90=${percentile(sorted, 90)}  p99=${percentile(sorted, 99)}  max=${sorted[sorted.length - 1]}`);
+  };
+
+  stats(headlineLens, 'headline length (chars)');
+  stats(summaryLens, 'summary length (chars)');
+  stats(keywordCounts, 'keyword count');
+  stats(totalIndexableChars, 'total searchable chars/chapter');
+  log(`  Coverage in sample of ${sizeSample.length}:`);
+  log(`    has headline: ${withHeadline} (${(100 * withHeadline / sizeSample.length).toFixed(1)}%)`);
+  log(`    has summary:  ${withSummary} (${(100 * withSummary / sizeSample.length).toFixed(1)}%)`);
+  log(`    has keywords: ${withKeywords} (${(100 * withKeywords / sizeSample.length).toFixed(1)}%)`);
+  log(`    EMPTY (all three): ${emptyAllThree} (${(100 * emptyAllThree / sizeSample.length).toFixed(1)}%)`);
+
+  // Project the indexed size at the chapter level
+  const avgCharsPerChapter = totalIndexableChars.reduce((a, b) => a + b, 0) / sizeSample.length;
+  const projectedIndexBytes = avgCharsPerChapter * totalChapters;
+  log(`\n  Projected raw text volume at chapter level:`);
+  log(`    avg searchable chars/chapter: ${avgCharsPerChapter.toFixed(0)}`);
+  log(`    total searchable chars across corpus: ${fmtNum(Math.round(projectedIndexBytes))}`);
+  log(`    rough indexed-bytes estimate (standard analyzer, ~4x overhead): ${fmtNum(Math.round(projectedIndexBytes * 4 / 1024 / 1024))} MB`);
+
+  // --- 3. Random sample for human inspection ---
+  log(`\n## 3. Random sample of ${SAMPLE_SIZE} chapters`);
+  log('='.repeat(72));
+  const randomSample = await JamieVectorMetadata.aggregate([
+    { $match: { type: 'chapter' } },
+    { $sample: { size: SAMPLE_SIZE } },
+    { $project: { pineconeId: 1, guid: 1, feedId: 1, metadataRaw: 1 } },
+  ]);
+
+  for (const [i, doc] of randomSample.entries()) {
+    const m = doc.metadataRaw || {};
+    log(`\n[${i + 1}] feedId=${doc.feedId}  guid=${doc.guid}`);
+    log(`    pineconeId: ${doc.pineconeId}`);
+    log(`    headline:   ${m.headline || '(none)'}`);
+    log(`    summary:    ${(m.summary || '(none)').slice(0, 240)}${(m.summary || '').length > 240 ? '…' : ''}`);
+    log(`    keywords:   ${Array.isArray(m.keywords) ? JSON.stringify(m.keywords) : '(none)'}`);
+  }
+
+  // --- 4. Hit check for canonical queries ---
+  log(`\n\n## 4. Canonical query hit check`);
+  log('Does any chapter contain the literal term in headline/summary/keywords?');
+  log('='.repeat(72));
+
+  for (const query of CANONICAL_QUERIES) {
+    const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(escaped, 'i');
+    const found = await JamieVectorMetadata.find({
+      type: 'chapter',
+      $or: [
+        { 'metadataRaw.headline': regex },
+        { 'metadataRaw.summary': regex },
+        { 'metadataRaw.keywords': { $elemMatch: { $regex: regex } } },
+      ],
+    })
+      .select('guid feedId metadataRaw')
+      .limit(HIT_CHECK_LIMIT_PER_QUERY)
+      .lean();
+
+    const totalHits = await JamieVectorMetadata.countDocuments({
+      type: 'chapter',
+      $or: [
+        { 'metadataRaw.headline': regex },
+        { 'metadataRaw.summary': regex },
+        { 'metadataRaw.keywords': { $elemMatch: { $regex: regex } } },
+      ],
+    });
+
+    log(`\nQUERY: "${query}"  total chapter hits: ${totalHits}`);
+    if (totalHits === 0) {
+      log(`  (no chapter contains this term — chapter-level lexical would MISS this query)`);
+    } else {
+      log(`  first ${Math.min(found.length, HIT_CHECK_LIMIT_PER_QUERY)} hits:`);
+      for (const doc of found) {
+        const m = doc.metadataRaw || {};
+        const headlineMatch = m.headline && regex.test(m.headline);
+        const summaryMatch = m.summary && regex.test(m.summary);
+        const keywordMatch = Array.isArray(m.keywords) && m.keywords.some(k => regex.test(k));
+        const sources = [
+          headlineMatch && 'headline',
+          summaryMatch && 'summary',
+          keywordMatch && 'keywords',
+        ].filter(Boolean).join('+');
+        log(`    [${sources}]  headline="${(m.headline || '').slice(0, 80)}"  feedId=${doc.feedId}`);
+      }
+    }
+  }
+
+  log('\n' + '='.repeat(72));
+  log('Report end.');
+
+  fs.writeFileSync(outFile, lines.join('\n'));
+  console.log(`\nReport written to: ${outFile}`);
+
+  await mongoose.disconnect();
+}
+
+main().catch((err) => {
+  console.error('Error:', err);
+  process.exit(1);
+});

--- a/scripts/sample-paragraph-content-quality.js
+++ b/scripts/sample-paragraph-content-quality.js
@@ -1,0 +1,309 @@
+/**
+ * sample-paragraph-content-quality.js
+ *
+ * Question: if we drop paragraphs below N words, what fraction of them
+ * actually carry searchable content vs. pure filler? Tests multiple word
+ * thresholds and content-signal heuristics so we can pick a filter that
+ * trims storage without dropping content with proper nouns / URLs /
+ * technical terms.
+ *
+ * Method:
+ *   1. Sample 100 random episode guids
+ *   2. Pull every paragraph for those episodes
+ *   3. For each paragraph, compute:
+ *        - word count
+ *        - has_proper_noun (capitalized non-sentence-start word)
+ *        - has_url (http, www, .com, etc.)
+ *        - has_number (digits, BIP-32 style)
+ *        - has_acronym (3+ uppercase letters in a row)
+ *        - is_filler (all-lowercase, only common words)
+ *   4. Bucket by word count, report % with each signal
+ *   5. Show sample short paragraphs that DO carry signal so we can eyeball
+ *      what the filter would drop
+ *
+ * Read-only. Safe against prod.
+ */
+
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+const mongoose = require('mongoose');
+const JamieVectorMetadata = require('../models/JamieVectorMetadata');
+
+const NUM_EPISODES = 100;
+const BUCKETS = [
+  { label: '1-3',   min: 1,   max: 3 },
+  { label: '4-7',   min: 4,   max: 7 },
+  { label: '8-12',  min: 8,   max: 12 },
+  { label: '13-20', min: 13,  max: 20 },
+  { label: '21-30', min: 21,  max: 30 },
+  { label: '31-50', min: 31,  max: 50 },
+  { label: '51+',   min: 51,  max: Infinity },
+];
+
+// Common filler-only words. If a paragraph contains ONLY these (post lowercase),
+// it's almost certainly conversational glue with no searchable content.
+const FILLER_WORDS = new Set([
+  'yeah','yes','no','nope','yep','ok','okay','alright','right','sure','exactly',
+  'totally','definitely','absolutely','agreed','same','word','facts','true',
+  'um','uh','uhh','umm','hmm','huh','oh','ah','ahh','eh','mm','mmhmm','wow',
+  'i','me','you','we','they','he','she','it','that','this','those','these',
+  'a','an','the','and','or','but','so','then','if','when','what','why','how',
+  'is','are','was','were','be','been','am','do','does','did','done','have',
+  'has','had','will','would','could','should','can','may','might','must',
+  'just','too','very','really','quite','also','well','like','know','think',
+  'mean','say','said','tell','get','got','go','goes','went','come','came',
+  'good','great','nice','cool','interesting','funny','crazy','wild','wow',
+  'thing','things','stuff','something','anything','everything','nothing',
+  'one','two','three','some','any','all','many','much','more','less','lot',
+  "i'm","you're","we're","they're","it's","that's","there's","what's",
+  "don't","doesn't","didn't","won't","can't","couldn't","wouldn't","isn't",
+  "to","of","in","on","at","by","for","with","about","from","as","into",
+  "out","up","down","over","under","through","because","though","while",
+  "now","here","there","everyone","everybody","somebody","anybody",
+  'man','guy','dude','bro','sir','please','thanks','thank','welcome','sorry',
+]);
+
+const URL_RE = /https?:\/\/|www\.|\.com|\.org|\.io|\.net|\.lol|\.xyz/i;
+const NUMBER_RE = /\b\d+\b|\b[a-z]+-\d+\b|\b[A-Z]{2,}\d+\b/;
+const ACRONYM_RE = /\b[A-Z]{3,}\b/;
+
+function classify(text) {
+  if (!text || typeof text !== 'string') {
+    return { wordCount: 0, signals: {}, isFiller: true };
+  }
+  const cleaned = text.trim();
+  const words = cleaned.split(/\s+/).filter(Boolean);
+  const wordCount = words.length;
+
+  // Proper noun: capitalized word that is NOT the first word of a sentence
+  // and not all-caps (which we count as acronym).
+  let hasProperNoun = false;
+  const sentenceStarters = new Set([0]);
+  let sentenceBreak = false;
+  for (let i = 0; i < words.length; i++) {
+    if (sentenceBreak) sentenceStarters.add(i);
+    sentenceBreak = /[.!?]$/.test(words[i]);
+  }
+  for (let i = 0; i < words.length; i++) {
+    const w = words[i].replace(/[^a-zA-Z]/g, '');
+    if (w.length < 2) continue;
+    if (sentenceStarters.has(i)) continue;
+    // Lower-case the rest then check if it was capitalized
+    if (/^[A-Z][a-z]/.test(w)) { hasProperNoun = true; break; }
+  }
+
+  const hasUrl = URL_RE.test(cleaned);
+  const hasNumber = NUMBER_RE.test(cleaned);
+  const hasAcronym = ACRONYM_RE.test(cleaned);
+
+  // Filler check: every word, lowercased and stripped of punctuation, is in
+  // the FILLER_WORDS set
+  const isFiller = words.every(w => {
+    const stripped = w.toLowerCase().replace(/[^a-z']/g, '');
+    return FILLER_WORDS.has(stripped) || stripped.length === 0;
+  });
+
+  const hasAnySignal = hasProperNoun || hasUrl || hasNumber || hasAcronym;
+
+  return {
+    wordCount,
+    signals: { hasProperNoun, hasUrl, hasNumber, hasAcronym, hasAnySignal },
+    isFiller,
+  };
+}
+
+function fmtPct(n, total) {
+  if (!total) return '   0.0%';
+  return `${(100 * n / total).toFixed(1).padStart(5)}%`;
+}
+
+function bucketFor(wc) {
+  for (const b of BUCKETS) {
+    if (wc >= b.min && wc <= b.max) return b;
+  }
+  return BUCKETS[BUCKETS.length - 1];
+}
+
+async function main() {
+  const mongoURI = process.env.DEBUG_MODE === 'true' ? process.env.MONGO_DEBUG_URI : process.env.MONGO_URI;
+  if (!mongoURI) { console.error('MONGO_URI not set'); process.exit(1); }
+
+  console.log('Connecting to MongoDB…');
+  await mongoose.connect(mongoURI);
+  console.log('Connected.');
+
+  const outDir = path.join(__dirname, '..', 'tmp');
+  if (!fs.existsSync(outDir)) fs.mkdirSync(outDir);
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const outFile = path.join(outDir, `paragraph-quality-${ts}.txt`);
+  const lines = [];
+  const log = (s) => { console.log(s); lines.push(s); };
+
+  log(`Paragraph content-quality report — ${new Date().toISOString()}`);
+  log('='.repeat(78));
+
+  // --- 1. Sample episode guids ---
+  log(`\n## Sampling ${NUM_EPISODES} random episode guids`);
+  const episodes = await JamieVectorMetadata.aggregate([
+    { $match: { type: 'episode' } },
+    { $sample: { size: NUM_EPISODES } },
+    { $project: { guid: 1, feedId: 1 } },
+  ]);
+  log(`  Got ${episodes.length} episodes`);
+  const episodeGuids = episodes.map(e => e.guid).filter(Boolean);
+
+  // --- 2. Pull paragraphs ---
+  log(`\n## Pulling paragraphs for those episodes`);
+  const paragraphs = await JamieVectorMetadata
+    .find({ type: 'paragraph', guid: { $in: episodeGuids } })
+    .select('metadataRaw guid feedId')
+    .lean();
+  log(`  ${paragraphs.length.toLocaleString()} paragraphs across ${episodeGuids.length} episodes`);
+  log(`  (avg ${(paragraphs.length / Math.max(episodeGuids.length, 1)).toFixed(1)} paragraphs/episode)`);
+
+  // --- 3. Classify each ---
+  const buckets = {};
+  for (const b of BUCKETS) {
+    buckets[b.label] = {
+      count: 0, totalChars: 0,
+      properNoun: 0, url: 0, number: 0, acronym: 0, anySignal: 0, filler: 0,
+      samples: { withSignal: [], filler: [], plain: [] }
+    };
+  }
+
+  let totalChars = 0;
+  for (const p of paragraphs) {
+    const text = p?.metadataRaw?.text || '';
+    totalChars += text.length;
+    const c = classify(text);
+    const b = bucketFor(c.wordCount);
+    const bucket = buckets[b.label];
+    bucket.count++;
+    bucket.totalChars += text.length;
+    if (c.signals.hasProperNoun) bucket.properNoun++;
+    if (c.signals.hasUrl) bucket.url++;
+    if (c.signals.hasNumber) bucket.number++;
+    if (c.signals.hasAcronym) bucket.acronym++;
+    if (c.signals.hasAnySignal) bucket.anySignal++;
+    if (c.isFiller) bucket.filler++;
+    // Collect samples for inspection
+    if (c.signals.hasAnySignal && bucket.samples.withSignal.length < 5) {
+      bucket.samples.withSignal.push({ text, signals: c.signals });
+    } else if (c.isFiller && bucket.samples.filler.length < 5) {
+      bucket.samples.filler.push({ text });
+    } else if (!c.signals.hasAnySignal && !c.isFiller && bucket.samples.plain.length < 5) {
+      bucket.samples.plain.push({ text });
+    }
+  }
+
+  const totalParas = paragraphs.length;
+
+  // --- 4. Distribution table ---
+  log(`\n## Word-count distribution + content signals`);
+  log('='.repeat(78));
+  log(`${'bucket'.padEnd(8)}${'count'.padStart(8)}${'%total'.padStart(8)}  ${'propN'.padStart(7)}${'URL'.padStart(7)}${'#'.padStart(7)}${'ACRO'.padStart(7)}${'anySig'.padStart(8)}${'filler'.padStart(8)}`);
+  for (const b of BUCKETS) {
+    const x = buckets[b.label];
+    log(
+      `${b.label.padEnd(8)}` +
+      `${x.count.toLocaleString().padStart(8)}` +
+      `${fmtPct(x.count, totalParas).padStart(8)}  ` +
+      `${fmtPct(x.properNoun, x.count).padStart(7)}` +
+      `${fmtPct(x.url, x.count).padStart(7)}` +
+      `${fmtPct(x.number, x.count).padStart(7)}` +
+      `${fmtPct(x.acronym, x.count).padStart(7)}` +
+      `${fmtPct(x.anySignal, x.count).padStart(8)}` +
+      `${fmtPct(x.filler, x.count).padStart(8)}`
+    );
+  }
+
+  // --- 5. Filter simulations ---
+  log(`\n## Filter-strategy simulations`);
+  log('='.repeat(78));
+  const strategies = [
+    { name: '>= 5 words', keep: (wc, sig) => wc >= 5 },
+    { name: '>= 10 words', keep: (wc, sig) => wc >= 10 },
+    { name: '>= 15 words', keep: (wc, sig) => wc >= 15 },
+    { name: '>= 30 words', keep: (wc, sig) => wc >= 30 },
+    { name: 'NOT filler-only', keep: (wc, sig, isFiller) => !isFiller },
+    { name: '>= 5 OR has signal', keep: (wc, sig) => wc >= 5 || sig.hasAnySignal },
+    { name: '>= 10 OR has signal', keep: (wc, sig) => wc >= 10 || sig.hasAnySignal },
+    { name: '>= 15 OR has signal', keep: (wc, sig) => wc >= 15 || sig.hasAnySignal },
+    { name: 'NOT filler AND (>= 5 OR has signal)', keep: (wc, sig, isFiller) => !isFiller && (wc >= 5 || sig.hasAnySignal) },
+  ];
+
+  // Re-walk for filter simulation (cheaper than caching the classify output)
+  const strategyResults = strategies.map(s => ({
+    name: s.name, kept: 0, keptChars: 0,
+    droppedWithSignal: 0, droppedNonFiller: 0,
+  }));
+
+  for (const p of paragraphs) {
+    const text = p?.metadataRaw?.text || '';
+    const c = classify(text);
+    for (let i = 0; i < strategies.length; i++) {
+      const keep = strategies[i].keep(c.wordCount, c.signals, c.isFiller);
+      if (keep) {
+        strategyResults[i].kept++;
+        strategyResults[i].keptChars += text.length;
+      } else {
+        if (c.signals.hasAnySignal) strategyResults[i].droppedWithSignal++;
+        if (!c.isFiller) strategyResults[i].droppedNonFiller++;
+      }
+    }
+  }
+
+  log(`${'strategy'.padEnd(42)}${'kept'.padStart(10)}${'%kept'.padStart(8)}${'%chars'.padStart(9)}${'sig-drops'.padStart(11)}${'non-filler-drops'.padStart(18)}`);
+  for (const r of strategyResults) {
+    log(
+      `${r.name.padEnd(42)}` +
+      `${r.kept.toLocaleString().padStart(10)}` +
+      `${fmtPct(r.kept, totalParas).padStart(8)}` +
+      `${fmtPct(r.keptChars, totalChars).padStart(9)}` +
+      `${r.droppedWithSignal.toLocaleString().padStart(11)}` +
+      `${r.droppedNonFiller.toLocaleString().padStart(18)}`
+    );
+  }
+  log(`  notes:`);
+  log(`    sig-drops = paragraphs the filter would DROP that have proper-noun/URL/number/acronym`);
+  log(`    non-filler-drops = paragraphs the filter would DROP that are NOT 100% filler words`);
+
+  // --- 6. Sample paragraphs from each short bucket ---
+  log(`\n## Sample short paragraphs (for eyeball check)`);
+  log('='.repeat(78));
+  for (const b of BUCKETS) {
+    if (b.min > 12) continue; // only show short buckets
+    const x = buckets[b.label];
+    log(`\n### Bucket ${b.label} words (n=${x.count})`);
+
+    log(`\n  -- Has signal (these would be MISSED by a pure word-count filter) --`);
+    if (x.samples.withSignal.length === 0) log(`    (none)`);
+    for (const s of x.samples.withSignal) {
+      const sigs = Object.entries(s.signals).filter(([k, v]) => v && k !== 'hasAnySignal').map(([k]) => k.replace('has', '').toLowerCase()).join(',');
+      log(`    [${sigs}] "${s.text}"`);
+    }
+
+    log(`\n  -- All-filler examples --`);
+    if (x.samples.filler.length === 0) log(`    (none)`);
+    for (const s of x.samples.filler) {
+      log(`    "${s.text}"`);
+    }
+
+    log(`\n  -- Plain content (no proper noun, not pure filler) --`);
+    if (x.samples.plain.length === 0) log(`    (none)`);
+    for (const s of x.samples.plain) {
+      log(`    "${s.text}"`);
+    }
+  }
+
+  log('\n' + '='.repeat(78));
+  log('Report end.');
+
+  fs.writeFileSync(outFile, lines.join('\n'));
+  console.log(`\nReport written to: ${outFile}`);
+
+  await mongoose.disconnect();
+}
+
+main().catch(err => { console.error('Error:', err); process.exit(1); });

--- a/scripts/test-expansion-prompt.js
+++ b/scripts/test-expansion-prompt.js
@@ -1,0 +1,207 @@
+/**
+ * test-expansion-prompt.js
+ *
+ * Unit-style probe: does the new `search_quotes.expansions` parameter actually
+ * get populated correctly by each orchestrator we use (Haiku 4.5, DeepSeek
+ * V4-Flash)? Validates that the prompt change in setup-agent.js triggers the
+ * right behavior on both models before we change the index.
+ *
+ * For each test query, calls each model once with the search_quotes tool
+ * definition and the user message, then extracts the tool_use input. Prints:
+ *   - query / expansions the model chose
+ *   - pass / fail vs expectation (canonical cases must produce non-empty
+ *     expansions; the generic case must produce empty)
+ *
+ * Does NOT actually execute searchQuotes — purely tests the orchestrator's
+ * tool-call shape.
+ *
+ * Usage:
+ *   node scripts/test-expansion-prompt.js
+ *
+ * Requires: ANTHROPIC_API_KEY, OPENROUTER_API_KEY in .env.
+ */
+
+require('dotenv').config();
+
+const { createProvider } = require('../utils/agent/providers');
+const { TOOL_DEFINITIONS } = (() => {
+  // setup-agent.js exports the agent factory + tool defs.
+  const setupAgent = require('../setup-agent');
+  return { TOOL_DEFINITIONS: setupAgent.TOOL_DEFINITIONS || setupAgent.tools || null };
+})();
+
+if (!Array.isArray(TOOL_DEFINITIONS)) {
+  console.error('Could not locate TOOL_DEFINITIONS export on setup-agent.js');
+  process.exit(1);
+}
+
+// Trim to just search_quotes to keep the prompt focused. Real agent runs send
+// all tools; here we only want to probe one tool's parameter behavior.
+const searchQuotesTool = TOOL_DEFINITIONS.find(t => t.name === 'search_quotes');
+if (!searchQuotesTool) {
+  console.error('search_quotes tool not found in TOOL_DEFINITIONS');
+  process.exit(1);
+}
+
+const TEST_CASES = [
+  {
+    name: 'compound brand (albyhub)',
+    userMessage: 'What did the host say about albyhub?',
+    requireNonEmpty: true,
+    mustInclude: ['Alby Hub'], // case-insensitive contains
+  },
+  {
+    name: 'URL with spelled-out form (lncurl.lol)',
+    userMessage: 'Find references to lncurl.lol in the transcripts.',
+    requireNonEmpty: true,
+    mustInclude: ['lncurl'],   // any variant that retains the lncurl token
+  },
+  {
+    name: 'compound acronym (nostrwalletconnect)',
+    userMessage: 'Tell me about nostrwalletconnect.',
+    requireNonEmpty: true,
+    mustInclude: ['Nostr Wallet Connect'],
+  },
+  {
+    name: 'generic conceptual query (no specific terms)',
+    userMessage: 'What general themes have the hosts discussed about market sentiment this year?',
+    requireNonEmpty: false,
+    mustInclude: [],
+  },
+];
+
+const MODELS = [
+  {
+    label: 'Haiku 4.5',
+    provider: 'anthropic',
+    model: 'claude-haiku-4-5-20251001',
+    skipIf: () => !process.env.ANTHROPIC_API_KEY,
+  },
+  {
+    label: 'DeepSeek V4-Flash (OpenRouter)',
+    provider: 'openrouter',
+    model: process.env.OPENROUTER_DEEPSEEK_FLASH_MODEL || 'deepseek/deepseek-v4-flash',
+    skipIf: () => !process.env.OPENROUTER_API_KEY,
+  },
+];
+
+const SYSTEM_PROMPT = `You are a search assistant for a podcast transcript corpus. When the user asks about a topic, person, brand, or specific term, you should call the search_quotes tool to find relevant transcript passages.
+
+Use the tool's expansions parameter as described in its tool description — populate it for proper-noun / brand / URL / spec queries, leave it empty for generic conceptual queries.`;
+
+function extractToolCalls(response) {
+  if (!response || !Array.isArray(response.content)) return [];
+  return response.content.filter(c => c.type === 'tool_use');
+}
+
+function evaluate(testCase, expansions) {
+  const isEmpty = !expansions || expansions.length === 0;
+  if (testCase.requireNonEmpty && isEmpty) {
+    return { pass: false, reason: 'expected non-empty expansions, got empty' };
+  }
+  if (!testCase.requireNonEmpty && !isEmpty) {
+    return { pass: false, reason: `expected empty expansions, got ${JSON.stringify(expansions)}` };
+  }
+  for (const needle of testCase.mustInclude) {
+    const present = expansions.some(v =>
+      typeof v === 'string' && v.toLowerCase().includes(needle.toLowerCase())
+    );
+    if (!present) {
+      return { pass: false, reason: `missing expected variant matching "${needle}"` };
+    }
+  }
+  return { pass: true, reason: 'ok' };
+}
+
+async function runOne({ providerName, modelId, label, testCase }) {
+  const provider = createProvider(providerName);
+  const started = Date.now();
+  let response;
+  try {
+    response = await provider.createResponse({
+      model: modelId,
+      maxTokens: 1024,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: testCase.userMessage }],
+      tools: [searchQuotesTool],
+      toolChoice: { type: 'tool', name: 'search_quotes' }, // force tool call so we always get a tool_use back
+      timeoutMs: 30000,
+      // Provider abstractions expect these as callables: anthropicProvider's
+      // consumeAnthropicStream calls aborted() on every stream event and
+      // onTextDelta(text) whenever a text delta appears.
+      aborted: () => false,
+      onTextDelta: () => {},
+      requestId: `expansion-test-${Date.now()}`,
+    });
+  } catch (err) {
+    return { label, model: modelId, testCase: testCase.name, error: err.message, elapsed: Date.now() - started };
+  }
+  const elapsed = Date.now() - started;
+  const toolCalls = extractToolCalls(response);
+  const sq = toolCalls.find(tc => tc.name === 'search_quotes');
+  if (!sq) {
+    return { label, model: modelId, testCase: testCase.name, error: 'no search_quotes tool call returned', elapsed, raw: response };
+  }
+  const expansions = Array.isArray(sq.input?.expansions) ? sq.input.expansions : [];
+  const evalResult = evaluate(testCase, expansions);
+  return {
+    label, model: modelId, testCase: testCase.name,
+    query: sq.input?.query, expansions,
+    pass: evalResult.pass, reason: evalResult.reason, elapsed,
+  };
+}
+
+async function main() {
+  const banner = '━'.repeat(80);
+  console.log(`\n${banner}`);
+  console.log('search_quotes.expansions — orchestrator behavior test');
+  console.log(banner);
+
+  const results = [];
+  for (const m of MODELS) {
+    if (m.skipIf && m.skipIf()) {
+      console.log(`\n⊘ SKIP ${m.label} — missing API key`);
+      continue;
+    }
+    console.log(`\n${m.label}`);
+    console.log('─'.repeat(80));
+    for (const testCase of TEST_CASES) {
+      const r = await runOne({ providerName: m.provider, modelId: m.model, label: m.label, testCase });
+      results.push(r);
+      const verdict = r.error ? '✘ ERROR' : (r.pass ? '✓ PASS ' : '✘ FAIL ');
+      console.log(`  ${verdict} [${testCase.name}]  (${r.elapsed}ms)`);
+      if (r.error) {
+        console.log(`          error: ${r.error}`);
+      } else {
+        console.log(`          query: "${r.query}"`);
+        console.log(`          expansions: ${JSON.stringify(r.expansions)}`);
+        if (!r.pass) console.log(`          reason: ${r.reason}`);
+      }
+    }
+  }
+
+  // --- Summary ---
+  console.log(`\n${banner}`);
+  console.log('Summary');
+  console.log(banner);
+  const byModel = new Map();
+  for (const r of results) {
+    if (!byModel.has(r.label)) byModel.set(r.label, { pass: 0, fail: 0, error: 0 });
+    const slot = byModel.get(r.label);
+    if (r.error) slot.error++;
+    else if (r.pass) slot.pass++;
+    else slot.fail++;
+  }
+  for (const [label, slot] of byModel) {
+    console.log(`  ${label.padEnd(40)}  pass=${slot.pass}  fail=${slot.fail}  err=${slot.error}`);
+  }
+  console.log('');
+
+  const anyFailures = results.some(r => r.error || !r.pass);
+  process.exit(anyFailures ? 1 : 0);
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/server.js
+++ b/server.js
@@ -85,9 +85,6 @@ const GarbageCollector = require('./utils/GarbageCollector');
 const mongoURI = process.env.DEBUG_MODE === 'true' ? process.env.MONGO_DEBUG_URI : process.env.MONGO_URI;
 const invoicePoolSize = 1;
 
-const processingCache = new Map();
-const resultCache = new Map();
-
 // OpenAI helper: configurable timeout & retries for embeddings
 const OPENAI_EMBEDDING_TIMEOUT_MS = parseInt(process.env.OPENAI_EMBEDDING_TIMEOUT_MS || '20000', 10); // 20s default
 const OPENAI_EMBEDDING_MAX_RETRIES = parseInt(process.env.OPENAI_EMBEDDING_MAX_RETRIES || '2', 10);   // 2 retries default

--- a/server.js
+++ b/server.js
@@ -2122,8 +2122,9 @@ const _server = app.listen(PORT, async () => {
             const result = await podcastRssCache.refreshAllPodcasts();
             console.log(`[SCHEDULED TASK] Podcast RSS cache refresh completed: ${result.successful} successful, ${result.failed} failed`);
             
-            // Clean up expired entries
+            // Clean up expired entries across in-memory caches
             podcastRssCache.cleanupExpiredEntries();
+            editChildrenCache.cleanupExpiredEntries();
             
           } catch (error) {
             console.error(`[SCHEDULED TASK] Error in podcast RSS cache refresh:`, error.message);

--- a/services/atlasTextSearch.js
+++ b/services/atlasTextSearch.js
@@ -7,19 +7,23 @@
  * existing merge logic in searchQuotesService.
  *
  * Index: `paragraph_text_search`
- *   - Custom analyzer `shingleSquashed` (standard + lowercase + asciiFolding +
- *     shingle 2-6 + regex squash) on `metadataRaw.text.shingleSquashed`
  *   - Standard analyzer on `metadataRaw.text` (covers exact phrase + fuzzy)
  *   - Synonym mapping `brand_aliases` sourced from the `searchSynonyms`
  *     collection (curated equivalence classes, may be empty)
+ *   - NO shingle multi-fields. Compound-word and spelled-out-letter recovery
+ *     (e.g. "albyhub" -> "Alby Hub", "lncurl" -> "l n c u r l") is now handled
+ *     at the query layer via LLM-generated `extraQueries`. The orchestrator
+ *     populates these via the `expansions` parameter on the search_quotes
+ *     tool; the server-side properNounLLMExpansion service adds variants as
+ *     a fallback. Dropping shingles shrinks the index ~85%.
  *
- * Compound query — four `should` clauses contribute independently to recall:
+ * Compound query — three `should` clauses contribute independently to recall:
  *   1. phrase   — exact word-for-word match on `metadataRaw.text`
  *   2. text+fuzzy — Levenshtein up to 2 edits, prefix preserved
- *   3. text on `metadataRaw.text.shingleSquashed` — recovers spelled-out
- *      forms ("l n c u r l" -> indexed token "lncurl") so a query of
- *      "lncurl" hits the squashed shingle on the indexed side
- *   4. text + synonyms — expands curated equivalence classes
+ *   3. text + synonyms — expands curated equivalence classes
+ *
+ * Plus a phrase + text+fuzzy clause pair per `extraQueries` variant — the
+ * primary mechanism for proper-noun / spelled-out / compound recovery.
  *
  * Filters mirror the Pinecone vector path (paragraph type, optional feed /
  * guid / date scoping). episodeName is intentionally NOT supported here —
@@ -37,10 +41,6 @@ const { printLog } = require('../constants.js');
 
 const ATLAS_SEARCH_INDEX_NAME = 'paragraph_text_search';
 const ATLAS_SEARCH_TEXT_PATH = 'metadataRaw.text';
-// Multi-field sub-analyzer must be addressed via { value, multi } at query time
-// (per Atlas Search path-construction docs). A dotted-string path does NOT
-// resolve to a multi-field and silently matches nothing.
-const ATLAS_SEARCH_SHINGLE_PATH = { value: 'metadataRaw.text', multi: 'shingleSquashed' };
 const ATLAS_SEARCH_SYNONYM_NAME = 'brand_aliases';
 const ATLAS_SEARCH_TIMEOUT_MS = 5000;
 
@@ -87,39 +87,6 @@ function buildFilterClauses({ feedIds = [], guids = [], minDate = null, maxDate 
   return filters;
 }
 
-// Split URL-shaped queries into sub-tokens to probe the shingle-squashed
-// path. Critical for queries like "lncurl.lol" where lucene.standard
-// either keeps the dotted form as one token or splits to ["lncurl",
-// "lol"] — neither matches the indexed squashed shingle "lncurl"
-// produced from spelled-out transcript text "l n c u r l".
-//
-// Limited to URL-shaped delimiters (`.`, `/`, `\`) deliberately:
-//   - Hyphenated forms like "BIP-32" are already handled by the
-//     standard-analyzer phrase clause (StandardTokenizer splits on `-`
-//     so `BIP 32` and `BIP-32` produce the same indexed tokens). Adding
-//     a `bip` sub-token clause was bringing in unrelated BIP mentions
-//     and ranking them above the actual BIP-32 docs.
-//   - Underscores are rare in user queries and similarly handled by the
-//     standard analyzer.
-//
-// Length cutoff at 3 chars further suppresses fragment noise. The
-// original full query is excluded to avoid duplicate scoring against
-// the primary shingle clause.
-function splitPunctuationTokens(query) {
-  if (typeof query !== 'string' || !/[./\\]/.test(query)) return [];
-  const lowered = query.toLowerCase();
-  const seen = new Set();
-  const tokens = [];
-  for (const raw of lowered.split(/[./\\]+/)) {
-    const t = raw.trim();
-    if (t.length >= 3 && t !== lowered && !seen.has(t)) {
-      seen.add(t);
-      tokens.push(t);
-    }
-  }
-  return tokens;
-}
-
 function buildShouldClauses(query, extraQueries = []) {
   const clauses = [
     {
@@ -140,13 +107,6 @@ function buildShouldClauses(query, extraQueries = []) {
     {
       text: {
         query,
-        path: ATLAS_SEARCH_SHINGLE_PATH,
-        score: { boost: { value: 3 } },
-      },
-    },
-    {
-      text: {
-        query,
         path: ATLAS_SEARCH_TEXT_PATH,
         synonyms: ATLAS_SEARCH_SYNONYM_NAME,
         score: { boost: { value: 2 } },
@@ -154,37 +114,29 @@ function buildShouldClauses(query, extraQueries = []) {
     },
   ];
 
-  for (const subToken of splitPunctuationTokens(query)) {
-    clauses.push({
-      text: {
-        query: subToken,
-        path: ATLAS_SEARCH_SHINGLE_PATH,
-        score: { boost: { value: 2 } },
-      },
-    });
-  }
-
-  // LLM-generated phonetic / spelling variants (e.g. "lncurl.lol" -> "ellen curl").
-  // Boost intentionally LOWER than original-query clauses (1.5 vs 2-4) so that
-  // expansion-only hits don't outrank exact-original-query matches when both
-  // exist in the same corpus. Variants probe both the standard text path
-  // (catches homophone tokens like "ellen") and the shingle-squashed path
-  // (catches letter-by-letter forms like "L N curl").
+  // Expansion variants (orchestrator-supplied via the search_quotes
+  // `expansions` parameter, plus server-side LLM-generated variants merged in
+  // upstream). Each variant gets a phrase clause (catches multi-word ordering
+  // like "Alby Hub" or "l n c u r l") plus a text+fuzzy clause (catches close
+  // typos on single-token variants). Boost intentionally lower than the
+  // original-query clauses so expansion-only hits don't outrank exact
+  // original-query matches when both exist.
   if (Array.isArray(extraQueries) && extraQueries.length) {
     for (const extra of extraQueries) {
       if (typeof extra !== 'string' || !extra.trim()) continue;
       const trimmed = extra.trim();
       clauses.push({
-        text: {
+        phrase: {
           query: trimmed,
           path: ATLAS_SEARCH_TEXT_PATH,
-          score: { boost: { value: 1.5 } },
+          score: { boost: { value: 2.5 } },
         },
       });
       clauses.push({
         text: {
           query: trimmed,
-          path: ATLAS_SEARCH_SHINGLE_PATH,
+          path: ATLAS_SEARCH_TEXT_PATH,
+          fuzzy: { maxEdits: 1, prefixLength: 1 },
           score: { boost: { value: 1.5 } },
         },
       });

--- a/services/searchQuotesService.js
+++ b/services/searchQuotesService.js
@@ -87,7 +87,14 @@ async function searchQuotes(params, { openai, recordHelperLlmUsage }) {
   let {
     query, feedIds = [], limit = 5, minDate = null, maxDate = null,
     episodeName = null, guid = null, guids: guidsParam = [], smartMode = false,
+    expansions = [],
   } = params;
+
+  // Model-provided expansions: pre-cleaned in the tool handler, but defensive
+  // re-dedupe here in case searchQuotes is called from another path.
+  const modelExpansions = Array.isArray(expansions)
+    ? [...new Set(expansions.map(s => (typeof s === 'string' ? s.trim() : '')).filter(Boolean))]
+    : [];
 
   const originalQuery = query;
   feedIds = (Array.isArray(feedIds) ? feedIds : [feedIds]).filter(Boolean);
@@ -144,9 +151,12 @@ async function searchQuotes(params, { openai, recordHelperLlmUsage }) {
 
   // Lexical fallback gating — kill-switch + heuristic + must not be already
   // scoped to a single episode (in which case the vector path is plenty).
+  // Model-provided expansions are themselves a strong proper-noun signal, so
+  // they bypass the heuristic gate: if the orchestrator thought variants were
+  // worth generating, the lexical path is worth running.
   const lexicalActivated = PROPER_NOUN_SEARCH_ENABLED
     && !episodeName
-    && isProperNounShaped(query);
+    && (isProperNounShaped(query) || modelExpansions.length > 0);
 
   const llmExpansionActivated = lexicalActivated && PROPER_NOUN_LLM_EXPANSION_ENABLED;
   const lexicalStartedAt = lexicalActivated ? Date.now() : null;
@@ -187,10 +197,18 @@ async function searchQuotes(params, { openai, recordHelperLlmUsage }) {
     }
   }
 
+  // Merge model-provided expansions with server-side LLM expansion variants.
+  // Both contribute additively to lexical recall; dedupe so a variant shared
+  // between the two paths only fires once.
+  const mergedExpansions = [...new Set([
+    ...modelExpansions,
+    ...expansionVariants.map(s => (typeof s === 'string' ? s.trim() : '')).filter(Boolean),
+  ])];
+
   const lexicalRaw = lexicalActivated
     ? await atlasTextSearch({
         query, feedIds, guids, minDate, maxDate, limit, requestId,
-        extraQueries: expansionVariants,
+        extraQueries: mergedExpansions,
       })
     : [];
 
@@ -217,7 +235,10 @@ async function searchQuotes(params, { openai, recordHelperLlmUsage }) {
     const expansionSuffix = llmExpansionActivated
       ? `, llmExpansion=${expansionVariants.length} variant(s)${expansionVariants.length ? ` ${JSON.stringify(expansionVariants)}` : ''}`
       : '';
-    printLog(`[${requestId}] Lexical activated: hits=${lexicalRaw.length}, latency=${lexicalLatencyMs}ms, overlap=${overlap}, finalMix=${JSON.stringify(sourceMix)}${expansionSuffix}`);
+    const modelExpansionSuffix = modelExpansions.length
+      ? `, modelExpansion=${modelExpansions.length} variant(s) ${JSON.stringify(modelExpansions)}`
+      : '';
+    printLog(`[${requestId}] Lexical activated: hits=${lexicalRaw.length}, latency=${lexicalLatencyMs}ms, overlap=${overlap}, finalMix=${JSON.stringify(sourceMix)}${modelExpansionSuffix}${expansionSuffix}`);
   }
 
   const pineconeIds = merged.map(r => r.id);

--- a/setup-agent.js
+++ b/setup-agent.js
@@ -560,17 +560,34 @@ const SYSTEM_PROMPT = [
 const TOOL_DEFINITIONS = [
   {
     name: 'search_quotes',
-    description: 'Semantic vector search across all transcribed podcast content. Returns timestamped quotes with speaker, episode, and audio metadata. Each result includes a pineconeId for referencing.',
+    description: `Semantic vector search across all transcribed podcast content. Returns timestamped quotes with speaker, episode, and audio metadata. Each result includes a pineconeId for referencing.
+
+EXPANSIONS (proper-noun recall): For queries that mention a brand, product, technical spec, URL, or acronym, populate the \`expansions\` array with 2-5 alternate forms. The lexical search probes each variant against the index, dramatically improving recall for non-standard terms where the user's spelling diverges from how the transcript records it. For generic conceptual queries (e.g. "how does staking work"), leave \`expansions\` empty.
+
+What kinds of variants to generate:
+- Word-boundary splits: "albyhub" → ["Alby Hub", "Alby"]
+- Spelled-out letter forms (URLs, abbreviations spoken letter-by-letter): "lncurl" → ["lncurl", "l n c u r l", "LN URL"]
+- Acronym expansions: "NWC" → ["Nostr Wallet Connect"]
+- Reverse acronym (full → short): "Lightning Network" → ["LN"]
+- Domain extraction from URLs: "lncurl.lol" → ["lncurl", "l n c u r l"]
+
+Examples:
+- query: "albyhub"               → expansions: ["Alby Hub", "Alby"]
+- query: "lncurl.lol"             → expansions: ["lncurl", "l n c u r l", "LN URL"]
+- query: "nostrwalletconnect"    → expansions: ["Nostr Wallet Connect", "NWC"]
+- query: "BIP-32"                 → expansions: ["BIP 32", "Hierarchical Deterministic"]
+- query: "how does the lightning network handle small payments" → expansions: []`,
     input_schema: {
       type: 'object',
       properties: {
-        query:   { type: 'string', description: 'Natural language search query (required, non-empty after trimming — empty values break embedding search)' },
-        guid:    { type: 'string', description: 'Filter to a single episode GUID' },
-        guids:   { type: 'array', items: { type: 'string' }, description: 'Filter to multiple episode GUIDs' },
-        feedIds: { type: 'array', items: { type: 'string' }, description: 'Filter to specific podcast feed IDs' },
-        limit:   { type: 'number', description: 'Max results (default 5, hard cap 20). Start with 5 — only increase if you need broader coverage.' },
-        minDate: { type: 'string', description: 'ISO date string — only episodes after this date' },
-        maxDate: { type: 'string', description: 'ISO date string — only episodes before this date' },
+        query:      { type: 'string', description: 'Natural language search query (required, non-empty after trimming — empty values break embedding search)' },
+        expansions: { type: 'array', items: { type: 'string' }, description: 'Alternate forms of proper-noun / brand / URL / spec terms in the query (2-5 entries). See tool description for examples. Leave empty [] for generic conceptual queries.' },
+        guid:       { type: 'string', description: 'Filter to a single episode GUID' },
+        guids:      { type: 'array', items: { type: 'string' }, description: 'Filter to multiple episode GUIDs' },
+        feedIds:    { type: 'array', items: { type: 'string' }, description: 'Filter to specific podcast feed IDs' },
+        limit:      { type: 'number', description: 'Max results (default 5, hard cap 20). Start with 5 — only increase if you need broader coverage.' },
+        minDate:    { type: 'string', description: 'ISO date string — only episodes after this date' },
+        maxDate:    { type: 'string', description: 'ISO date string — only episodes before this date' },
       },
       required: ['query'],
     },

--- a/utils/agentToolHandler.js
+++ b/utils/agentToolHandler.js
@@ -119,7 +119,7 @@ function truncateResults(data) {
 // --- Per-tool dispatch ---
 
 async function handleSearchQuotes(input, { openai, recordHelperLlmUsage, userMessage }) {
-  const { query, guid, guids, feedIds, limit, minDate, maxDate } = input;
+  const { query, expansions, guid, guids, feedIds, limit, minDate, maxDate } = input;
   const clampedLimit = clampLimit(limit, 5);
   const overFetchLimit = Math.min(clampedLimit * 3, RESULT_HARD_CAP);
 
@@ -132,9 +132,15 @@ async function handleSearchQuotes(input, { openai, recordHelperLlmUsage, userMes
     };
   }
 
-  printLog(`[TOOL] search_quotes: query="${q}", limit=${clampedLimit} (fetching=${overFetchLimit}), smartMode=true`);
+  // Model-provided expansions: trimmed strings, deduped, capped at 10 to avoid
+  // pathological inputs blowing up the lexical compound query.
+  const modelExpansions = Array.isArray(expansions)
+    ? [...new Set(expansions.map(s => (typeof s === 'string' ? s.trim() : '')).filter(Boolean))].slice(0, 10)
+    : [];
+
+  printLog(`[TOOL] search_quotes: query="${q}", limit=${clampedLimit} (fetching=${overFetchLimit}), smartMode=true, modelExpansions=${modelExpansions.length}${modelExpansions.length ? ` ${JSON.stringify(modelExpansions)}` : ''}`);
   const data = await searchQuotes({
-    query: q, guid, guids, feedIds, limit: overFetchLimit, minDate, maxDate, smartMode: true,
+    query: q, expansions: modelExpansions, guid, guids, feedIds, limit: overFetchLimit, minDate, maxDate, smartMode: true,
   }, { openai, recordHelperLlmUsage });
   filterFluffResults(data);
 


### PR DESCRIPTION
## Summary

Shrinks the Atlas Search index `paragraph_text_search` from **11.99 GB → 1.46 GB (~88%)** by removing the `shingleSquashed` multi-field and moving proper-noun / compound-word recovery to the query layer via orchestrator-generated `expansions`. Plus two scale-up-prep chores carried along.

## Why

Index was 3× the M20 RAM ceiling (4 GB), causing constant disk paging on cold lexical queries. With staging ingest about to roughly 3× the corpus, the trajectory was unsustainable. Shingles were ~90% of the index size and existed almost entirely to bridge compound-word forms (`albyhub` → `Alby Hub`) and spelled-out letter forms (`lncurl` → `l n c u r l`) — both of which the orchestrator can generate at tool-call time for a few extra tokens.

## What changed

**Atlas Search index** (must be applied via the Atlas UI alongside this merge — already done in prep):
- Dropped the `shingleSquashed` analyzer + multi-field on `metadataRaw.text`
- Standard analyzer + synonyms preserved
- Result: 11.99 GB → 1.46 GB confirmed

**Code:**
- `search_quotes` tool schema in [setup-agent.js](setup-agent.js) gains an `expansions: string[]` parameter with detailed prompt instructions and examples
- `agentToolHandler.handleSearchQuotes` and `searchQuotesService.searchQuotes` plumb the expansions through, dedupe with the existing server-side `properNounLLMExpansion` variants (additive — both contribute), and relax the lexical activation gate to trigger on either the heuristic OR a non-empty expansions array
- [services/atlasTextSearch.js](services/atlasTextSearch.js) drops the shingle clauses and the `splitPunctuationTokens` helper; expansion variants now get a `phrase` + `text+fuzzy` clause pair against the standard text path

**Diagnostics & tests:**
- `scripts/test-expansion-prompt.js` — verifies both Haiku 4.5 and DeepSeek V4-Flash generate the right expansions for canonical cases (4/4 pass on each)
- `scripts/sample-chapters-feasibility.js` / `scripts/sample-paragraph-content-quality.js` — corpus probes used to evaluate alternative shrink strategies (kept for future reference)

**Bundled chores** (already on `scale-up-prep`):
- Remove dead `processingCache` / `resultCache` Maps from `server.js`
- Schedule `editChildrenCache.cleanupExpiredEntries()` on the existing hourly RSS sweep

## Verification

Three levels of testing complete:

1. **Index size**: 1.46 GB realized vs ~1.5 GB projected ✓
2. **Bare lexical (no expansions)**: 6 of 7 canonical smoke-test queries return identical 8-hit counts; only `lncurl.lol` regresses to 0 hits (the URL-shape case expansions are designed to fix) ✓
3. **With expansions**: `lncurl.lol` recovers to 8 hits, top hit identical to baseline (same `pineconeId`, score 67.59 vs baseline 41.27) ✓
4. **Orchestrator behavior**: Haiku and DeepSeek both pass 4/4 expansion test cases — `albyhub`, `lncurl.lol`, `nostrwalletconnect`, plus a negative case where neither generates spurious expansions for a generic query ✓

## Deployment notes

The Atlas index has already been updated to the no-shingles definition (confirmed Active, 1.46 GB). Production master code currently queries the now-removed `shingleSquashed` multi and silently gets zero hits on those clauses — so merging this PR closes the transition window rather than opens one. Lexical recall improves immediately on deploy.

## Test plan

- [x] `node scripts/test-expansion-prompt.js` — both models pass 4/4
- [x] `node scripts/smoke-test-atlas-search.js` against new index — confirms baseline recall preserved
- [x] `node scripts/test-lncurl-with-expansions.js` — confirms expansion path recovers regression case
- [ ] Manual `/api/pull` test post-deploy with canonical queries (lncurl, albyhub, etc.)
- [ ] Watch Atlas page-fault metric (`mongot_system_process_majorPageFaults_operations`) for first 24h — expect to drop substantially with the smaller index

🤖 Generated with [Claude Code](https://claude.com/claude-code)