### PR TITLE
benchmark: scale-up harness + HMAC-gated metrics

### DIFF
--- a/routes/agentChatRoutes.js
+++ b/routes/agentChatRoutes.js
@@ -20,6 +20,7 @@ const { createProvider } = require('../utils/agent/providers');
 const { sanitizeAgentText, hasToolCallMarkup, createStreamSanitizer, createClipTokenStreamSanitizer, scrubClipIds, repairIndexedClipTokens } = require('../utils/agent/sanitizeOutput');
 const { evaluateSynthesisOutput } = require('../utils/agent/synthesisQuality');
 const { rerankClips, RERANKER_MODEL } = require('../utils/clipReranker');
+const { isBenchmarkRequest } = require('../utils/benchmarkAuth');
 
 const AGENT_LOG_DIR = path.join(__dirname, '..', 'logs', 'agent');
 try { fs.mkdirSync(AGENT_LOG_DIR, { recursive: true }); } catch {}
@@ -899,7 +900,14 @@ function createAgentChatRoutes({ openai } = {}) {
     // SSE emits are stripped of model, cost, tokens, intent, tool inputs,
     // round numbers, etc. Set AGENT_INCLUDE_METRICS=true in .env on internal
     // environments (local dev, benchmarks) to receive the full payload.
-    const includeMetrics = process.env.AGENT_INCLUDE_METRICS === 'true' || req.body?.includeMetrics === true;
+    //
+    // Benchmark mode: when the request carries a valid HMAC signature signed
+    // with BENCHMARK_HMAC_SECRET (single dedicated env var; see
+    // utils/benchmarkAuth.js), metrics are attached regardless of env/body
+    // flags. Fail-quiet — invalid/missing signatures are indistinguishable
+    // from a normal user request. Used by scripts/benchmarks/.
+    const benchmarkRequested = isBenchmarkRequest(req);
+    const includeMetrics = process.env.AGENT_INCLUDE_METRICS === 'true' || req.body?.includeMetrics === true || benchmarkRequested;
 
     if (!message || typeof message !== 'string') {
       return res.status(400).json({ error: 'message (or task) is required' });

--- a/scripts/benchmarks/benchmark-queries.json
+++ b/scripts/benchmarks/benchmark-queries.json
@@ -1,0 +1,144 @@
+{
+  "version": 1,
+  "description": "Canonical benchmark query set. Each query exercises a different path through the agent + search pipeline. Expectations are deliberately permissive (keywords + heuristics) to allow paraphrased responses; the judge LLM grades the harder semantic checks.",
+  "queries": [
+    {
+      "id": "compound-brand-albyhub",
+      "category": "proper-noun-compound",
+      "prompt": "What have the hosts said about albyhub?",
+      "expected": {
+        "minResultsInToolCalls": 1,
+        "responseShouldMention": ["alby"],
+        "responseMinChars": 100
+      },
+      "judgeCriteria": "The response should reference Alby Hub or Alby (the Bitcoin Lightning wallet) and cite at least one transcript clip."
+    },
+    {
+      "id": "url-spelled-lncurl",
+      "category": "proper-noun-url",
+      "prompt": "Find references to lncurl.lol in the transcripts.",
+      "expected": {
+        "minResultsInToolCalls": 1,
+        "responseShouldMention": ["lncurl", "ln", "lightning"],
+        "responseShouldMentionAny": true,
+        "responseMinChars": 100
+      },
+      "judgeCriteria": "The response should mention lncurl, ln curl, or LNURL in the context of Lightning Network. A cited clip is expected."
+    },
+    {
+      "id": "acronym-nostr-wallet-connect",
+      "category": "proper-noun-acronym",
+      "prompt": "What is Nostr Wallet Connect and what have the hosts said about it?",
+      "expected": {
+        "minResultsInToolCalls": 1,
+        "responseShouldMention": ["nostr", "wallet"],
+        "responseMinChars": 200
+      },
+      "judgeCriteria": "The response should explain or describe Nostr Wallet Connect (NWC) in some form and reference podcast content."
+    },
+    {
+      "id": "technical-spec-bip32",
+      "category": "technical-spec",
+      "prompt": "What have the hosts discussed about BIP-32 and hierarchical deterministic wallets?",
+      "expected": {
+        "minResultsInToolCalls": 1,
+        "responseShouldMention": ["bip", "wallet", "key"],
+        "responseShouldMentionAny": true,
+        "responseMinChars": 150
+      },
+      "judgeCriteria": "The response should reference BIP-32 or hierarchical deterministic wallets in some technical context."
+    },
+    {
+      "id": "general-topic-lightning",
+      "category": "general-topic",
+      "prompt": "What are the main themes hosts have discussed about the Lightning Network this year?",
+      "expected": {
+        "minResultsInToolCalls": 3,
+        "responseShouldMention": ["lightning"],
+        "responseMinChars": 300
+      },
+      "judgeCriteria": "The response should describe multiple themes or aspects of Lightning Network discussions. Pure vector-search territory; many hits expected."
+    },
+    {
+      "id": "general-topic-bitcoin-mining",
+      "category": "general-topic",
+      "prompt": "Summarize recent discussion about bitcoin mining and energy.",
+      "expected": {
+        "minResultsInToolCalls": 3,
+        "responseShouldMention": ["mining", "energy"],
+        "responseShouldMentionAny": true,
+        "responseMinChars": 300
+      },
+      "judgeCriteria": "The response should cover mining + energy / power / electricity in some combination and cite multiple sources."
+    },
+    {
+      "id": "person-luke-gromen",
+      "category": "person-query",
+      "prompt": "What has Luke Gromen said about the bond market recently?",
+      "expected": {
+        "minResultsInToolCalls": 1,
+        "responseShouldMention": ["bond", "gromen", "treasury", "rate"],
+        "responseShouldMentionAny": true,
+        "responseMinChars": 200
+      },
+      "judgeCriteria": "The response should reference Luke Gromen's views on bonds, treasuries, or interest rates. find_person + search_quotes path expected."
+    },
+    {
+      "id": "broad-theme-ai-agents",
+      "category": "general-topic",
+      "prompt": "Have any hosts talked about AI agents in 2026?",
+      "expected": {
+        "minResultsInToolCalls": 2,
+        "responseShouldMention": ["ai", "agent"],
+        "responseMinChars": 200
+      },
+      "judgeCriteria": "The response should discuss AI agents in some form, ideally citing 2026 content if available."
+    },
+    {
+      "id": "obscure-no-result-likely",
+      "category": "edge-case-empty",
+      "prompt": "What did the hosts say about quasicrystalline metallurgy in space habitats?",
+      "expected": {
+        "responseMinChars": 50,
+        "graceful": true
+      },
+      "judgeCriteria": "The query is intentionally obscure. The agent should respond gracefully — either with a 'no information found' message or by surfacing tangentially related material with an honest framing. A confident fabricated answer is a FAIL."
+    },
+    {
+      "id": "feed-scoped-bitcoin-audible",
+      "category": "feed-scoped",
+      "prompt": "On the Bitcoin Audible podcast, what books have been featured this year?",
+      "expected": {
+        "minResultsInToolCalls": 1,
+        "responseShouldMention": ["bitcoin audible", "book"],
+        "responseShouldMentionAny": true,
+        "responseMinChars": 150
+      },
+      "judgeCriteria": "The response should reference Bitcoin Audible content, ideally book titles or themes covered on that show."
+    },
+    {
+      "id": "compound-brand-openai",
+      "category": "proper-noun-compound",
+      "prompt": "Find clips about openai's latest models.",
+      "expected": {
+        "minResultsInToolCalls": 1,
+        "responseShouldMention": ["openai", "model"],
+        "responseShouldMentionAny": true,
+        "responseMinChars": 150
+      },
+      "judgeCriteria": "The response should reference OpenAI / GPT / similar in some context. Compound-word expansion case."
+    },
+    {
+      "id": "general-recent-market",
+      "category": "general-topic",
+      "prompt": "What's the general sentiment about market conditions on recent episodes?",
+      "expected": {
+        "minResultsInToolCalls": 3,
+        "responseShouldMention": ["market", "sentiment", "price"],
+        "responseShouldMentionAny": true,
+        "responseMinChars": 250
+      },
+      "judgeCriteria": "The response should synthesize market sentiment from multiple episodes — bullish/bearish/cautious framing. No proper-noun expansion expected."
+    }
+  ]
+}

--- a/scripts/benchmarks/judge.js
+++ b/scripts/benchmarks/judge.js
@@ -1,0 +1,101 @@
+/**
+ * gpt-4o-mini grader for benchmark responses.
+ *
+ * Heuristic checks (keyword presence, length) catch the easy cases but miss
+ * paraphrased-but-correct answers. The judge picks up that slack: given the
+ * original question, the agent's response, and a one-line criteria string,
+ * it returns { pass, reason }.
+ *
+ * Cost is small (~$0.005 per call for a few hundred response tokens), so
+ * grading the whole 12-query suite is ~$0.06 per run.
+ */
+
+const OpenAI = require('openai');
+
+const JUDGE_MODEL = process.env.BENCHMARK_JUDGE_MODEL || 'gpt-4o-mini';
+const JUDGE_TIMEOUT_MS = 20000;
+
+const SYSTEM_PROMPT = `You are a strict but fair grader of search-agent responses. The agent searches a corpus of podcast transcripts and synthesizes answers from cited clips.
+
+You will receive:
+  - The original USER QUESTION
+  - The agent's RESPONSE
+  - Specific CRITERIA describing what a passing response looks like
+
+Reply with a single JSON object on one line, no markdown fences:
+  {"pass": true|false, "reason": "one short sentence"}
+
+Grading rules:
+  - PASS if the response substantively addresses the question per the criteria.
+  - PASS if the criteria mentions a graceful "no info found" response is acceptable AND the agent declined honestly.
+  - FAIL if the agent fabricated content (made-up facts, fake citations).
+  - FAIL if the agent refused for non-content reasons (safety filter, unclear question).
+  - FAIL if the response is empty, garbled, or under ~50 characters of substance.
+  - Paraphrase is fine; exact keyword matches are not required.
+  - Be honest. "Pass" doesn't require perfection, just substantive accuracy on the question asked.`;
+
+async function judgeResponse({ question, response, criteria }) {
+  if (!process.env.OPENAI_API_KEY) {
+    return { pass: null, reason: 'OPENAI_API_KEY not set; judge skipped', skipped: true };
+  }
+
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+  const userPrompt = [
+    `USER QUESTION:`,
+    question,
+    ``,
+    `AGENT RESPONSE:`,
+    response,
+    ``,
+    `CRITERIA:`,
+    criteria,
+    ``,
+    `Reply with a single line: {"pass": ..., "reason": "..."}`,
+  ].join('\n');
+
+  const started = Date.now();
+  let raw = '';
+  try {
+    const resp = await Promise.race([
+      openai.chat.completions.create({
+        model: JUDGE_MODEL,
+        messages: [
+          { role: 'system', content: SYSTEM_PROMPT },
+          { role: 'user', content: userPrompt },
+        ],
+        temperature: 0,
+        max_tokens: 150,
+      }),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('judge timeout')), JUDGE_TIMEOUT_MS)),
+    ]);
+    raw = resp?.choices?.[0]?.message?.content?.trim() || '';
+  } catch (err) {
+    return { pass: null, reason: `judge error: ${err.message}`, skipped: true, latencyMs: Date.now() - started };
+  }
+
+  const latencyMs = Date.now() - started;
+
+  // Lenient JSON parse — strip code fences if the judge slipped them in.
+  const cleaned = raw.replace(/^```(?:json)?\s*/i, '').replace(/```\s*$/i, '').trim();
+  try {
+    const parsed = JSON.parse(cleaned);
+    if (typeof parsed.pass !== 'boolean') throw new Error('missing pass field');
+    return {
+      pass: parsed.pass,
+      reason: String(parsed.reason || '').slice(0, 200),
+      latencyMs,
+      model: JUDGE_MODEL,
+    };
+  } catch (err) {
+    return {
+      pass: null,
+      reason: `judge JSON parse failed: ${err.message}; raw="${raw.slice(0, 120)}"`,
+      latencyMs,
+      model: JUDGE_MODEL,
+      skipped: true,
+    };
+  }
+}
+
+module.exports = { judgeResponse };

--- a/scripts/benchmarks/scale-up-benchmark.js
+++ b/scripts/benchmarks/scale-up-benchmark.js
@@ -1,0 +1,338 @@
+/**
+ * scale-up-benchmark.js
+ *
+ * Runs a fixed query suite against /api/pull in production. For each query:
+ *   1. Sends a signed (HMAC + JWT) POST so the server includes its `metrics`
+ *      payload in the JSON response.
+ *   2. Runs heuristic gates (response length, expected keywords).
+ *   3. Calls a gpt-4o-mini judge to grade semantic quality.
+ *   4. Records per-query timing breakdown + tool-call latencies.
+ *
+ * Writes a Markdown report to tmp/benchmark-<timestamp>.md so you can run
+ * this at each episode-count milestone during staging ramp and diff results.
+ *
+ * Required env:
+ *   - BENCHMARK_BASE_URL      (e.g. https://api.pullthatupjamie.ai)
+ *   - JWT_TEST_TOKEN          (auth — exists in your .env)
+ *   - BENCHMARK_HMAC_SECRET   (the openssl rand -hex 32 value; same in server .env)
+ *   - OPENAI_API_KEY          (for the judge — already in your env)
+ *
+ * Usage:
+ *   node scripts/benchmarks/scale-up-benchmark.js
+ *   node scripts/benchmarks/scale-up-benchmark.js --no-judge     # skip grading
+ *   node scripts/benchmarks/scale-up-benchmark.js --repeats 3    # run each query N times
+ *   node scripts/benchmarks/scale-up-benchmark.js --filter compound  # only matching IDs
+ */
+
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+
+const { signRequest } = require('./signRequest');
+const { judgeResponse } = require('./judge');
+const queriesFile = require('./benchmark-queries.json');
+
+// ─── Config ───────────────────────────────────────────────────────────────
+
+const BASE_URL = process.env.BENCHMARK_BASE_URL;
+const JWT = process.env.JWT_TEST_TOKEN;
+const HMAC_SECRET = process.env.BENCHMARK_HMAC_SECRET;
+
+const REQUEST_TIMEOUT_MS = 90000; // /api/pull can be slow under load
+const PER_QUERY_PAUSE_MS = 200;   // tiny inter-query breather, optional
+
+// ─── Arg parsing ──────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const noJudge = args.includes('--no-judge');
+const repeatArgIdx = args.indexOf('--repeats');
+const repeats = repeatArgIdx > -1 ? Math.max(1, parseInt(args[repeatArgIdx + 1], 10) || 1) : 2;
+const filterArgIdx = args.indexOf('--filter');
+const filter = filterArgIdx > -1 ? args[filterArgIdx + 1] : null;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function fmtMs(ms) {
+  if (ms == null) return '   —';
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function pct(num, total) {
+  if (!total) return '0%';
+  return `${Math.round((100 * num) / total)}%`;
+}
+
+function percentile(sorted, p) {
+  if (!sorted.length) return null;
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[idx];
+}
+
+function checkResponseShouldMention(text, expected) {
+  if (!expected || !Array.isArray(expected.responseShouldMention) || expected.responseShouldMention.length === 0) {
+    return { skipped: true };
+  }
+  const lower = (text || '').toLowerCase();
+  const matched = expected.responseShouldMention.filter(needle => lower.includes(needle.toLowerCase()));
+  const requiresAny = expected.responseShouldMentionAny === true;
+  const pass = requiresAny ? matched.length > 0 : matched.length === expected.responseShouldMention.length;
+  return {
+    pass,
+    matched,
+    expected: expected.responseShouldMention,
+    mode: requiresAny ? 'any' : 'all',
+  };
+}
+
+async function callPull({ query }) {
+  const url = `${BASE_URL}/api/pull`;
+  const body = {
+    message: query.prompt,
+    stream: false,
+    includeMetrics: false, // we want the SCOPED-via-HMAC metrics, not the env one
+  };
+  const rawBody = JSON.stringify(body);
+
+  const hmacHeaders = signRequest({
+    method: 'POST',
+    path: '/api/pull',
+    rawBody,
+    secret: HMAC_SECRET,
+  });
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  const startedAt = Date.now();
+  let response, parsed, networkErr;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${JWT}`,
+        ...hmacHeaders,
+      },
+      body: rawBody,
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    try { parsed = JSON.parse(text); }
+    catch { parsed = { _rawText: text }; }
+  } catch (err) {
+    networkErr = err.message;
+  } finally {
+    clearTimeout(timeout);
+  }
+  const wallClockMs = Date.now() - startedAt;
+
+  return {
+    httpStatus: response?.status ?? null,
+    wallClockMs,
+    body: parsed,
+    networkErr,
+  };
+}
+
+function evaluateQueryResult(query, result) {
+  const gates = [];
+  if (result.networkErr) gates.push({ name: 'network', pass: false, detail: result.networkErr });
+  if (result.httpStatus && result.httpStatus !== 200) gates.push({ name: 'http', pass: false, detail: `status ${result.httpStatus}` });
+
+  const text = result.body?.text || '';
+  const minChars = query.expected?.responseMinChars || 0;
+  if (minChars > 0) {
+    gates.push({
+      name: 'minChars',
+      pass: text.length >= minChars,
+      detail: `${text.length}/${minChars} chars`,
+    });
+  }
+
+  const minResults = query.expected?.minResultsInToolCalls || 0;
+  if (minResults > 0) {
+    const totalResultCount = (result.body?.metrics?.toolCalls || [])
+      .reduce((acc, tc) => acc + (tc.resultCount || 0), 0);
+    gates.push({
+      name: 'minResults',
+      pass: totalResultCount >= minResults,
+      detail: `${totalResultCount}/${minResults} results across tool calls`,
+    });
+  }
+
+  const mentionCheck = checkResponseShouldMention(text, query.expected);
+  if (!mentionCheck.skipped) {
+    gates.push({
+      name: 'mention',
+      pass: mentionCheck.pass,
+      detail: `${mentionCheck.mode}: matched [${mentionCheck.matched.join(', ')}] of [${mentionCheck.expected.join(', ')}]`,
+    });
+  }
+
+  const passedAllGates = gates.length > 0 && gates.every(g => g.pass);
+  return { gates, passedAllGates };
+}
+
+function aggregateTimings(allRuns) {
+  const wallTimes = allRuns.map(r => r.result.wallClockMs).sort((a, b) => a - b);
+  const llmTotals = allRuns.map(r => r.result.body?.metrics?.latencyMs).filter(x => Number.isFinite(x)).sort((a, b) => a - b);
+  const totalToolMs = allRuns.map(r => {
+    const tc = r.result.body?.metrics?.toolCalls || [];
+    return tc.reduce((acc, t) => acc + (t.latencyMs || 0), 0);
+  }).sort((a, b) => a - b);
+
+  return {
+    wallClock: { p50: percentile(wallTimes, 50), p95: percentile(wallTimes, 95), p99: percentile(wallTimes, 99) },
+    serverLatency: { p50: percentile(llmTotals, 50), p95: percentile(llmTotals, 95), p99: percentile(llmTotals, 99) },
+    toolTime: { p50: percentile(totalToolMs, 50), p95: percentile(totalToolMs, 95), p99: percentile(totalToolMs, 99) },
+  };
+}
+
+function toolNameBreakdown(allRuns) {
+  const acc = new Map();
+  for (const { result } of allRuns) {
+    const tcs = result.body?.metrics?.toolCalls || [];
+    for (const tc of tcs) {
+      const name = tc.name || 'unknown';
+      if (!acc.has(name)) acc.set(name, { count: 0, totalMs: 0 });
+      const e = acc.get(name);
+      e.count++;
+      e.totalMs += tc.latencyMs || 0;
+    }
+  }
+  return Array.from(acc.entries()).map(([name, { count, totalMs }]) => ({
+    name, count, totalMs, avgMs: count ? Math.round(totalMs / count) : 0,
+  })).sort((a, b) => b.totalMs - a.totalMs);
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────
+
+async function main() {
+  if (!BASE_URL) { console.error('BENCHMARK_BASE_URL not set'); process.exit(1); }
+  if (!JWT) { console.error('JWT_TEST_TOKEN not set'); process.exit(1); }
+  if (!HMAC_SECRET) { console.error('BENCHMARK_HMAC_SECRET not set'); process.exit(1); }
+
+  const allQueries = queriesFile.queries.filter(q => !filter || q.id.includes(filter));
+  if (allQueries.length === 0) {
+    console.error(`No queries matched filter "${filter}"`);
+    process.exit(1);
+  }
+
+  console.log(`\nScale-up benchmark`);
+  console.log(`  target:   ${BASE_URL}`);
+  console.log(`  queries:  ${allQueries.length} × ${repeats} repeats = ${allQueries.length * repeats} requests`);
+  console.log(`  judge:    ${noJudge ? 'disabled' : 'gpt-4o-mini'}\n`);
+
+  const runs = [];
+  const startedAt = Date.now();
+
+  for (let r = 0; r < repeats; r++) {
+    for (const query of allQueries) {
+      const tag = `[${query.id}#${r + 1}]`;
+      process.stdout.write(`${tag} `.padEnd(48));
+      const result = await callPull({ query });
+      const gateResult = evaluateQueryResult(query, result);
+
+      let judgeResult = null;
+      if (!noJudge && !result.networkErr && result.httpStatus === 200 && query.judgeCriteria) {
+        judgeResult = await judgeResponse({
+          question: query.prompt,
+          response: result.body?.text || '',
+          criteria: query.judgeCriteria,
+        });
+      }
+
+      const overallPass = gateResult.passedAllGates && (judgeResult?.pass !== false);
+      const statusMark = overallPass ? '✓' : '✘';
+      const judgeMark = judgeResult == null ? '—' : (judgeResult.pass === true ? '✓' : (judgeResult.pass === false ? '✘' : '?'));
+      console.log(`${statusMark} ${fmtMs(result.wallClockMs).padStart(7)}  gates:${gateResult.passedAllGates ? '✓' : '✘'}  judge:${judgeMark}`);
+
+      runs.push({ query, result, gateResult, judgeResult });
+
+      if (PER_QUERY_PAUSE_MS) await new Promise(r => setTimeout(r, PER_QUERY_PAUSE_MS));
+    }
+  }
+
+  const wallMs = Date.now() - startedAt;
+  const passCount = runs.filter(r => r.gateResult.passedAllGates && (r.judgeResult?.pass !== false)).length;
+  const failCount = runs.length - passCount;
+  const timings = aggregateTimings(runs);
+  const toolBreakdown = toolNameBreakdown(runs);
+
+  // ─── Markdown report ───
+  const reportLines = [];
+  const r = (s) => reportLines.push(s);
+
+  r(`# Scale-up Benchmark — ${new Date().toISOString()}`);
+  r('');
+  r(`- Target: \`${BASE_URL}\``);
+  r(`- Queries: ${allQueries.length} × ${repeats} repeats = ${runs.length} requests`);
+  r(`- Total wall time: ${fmtMs(wallMs)}`);
+  r(`- Judge: ${noJudge ? 'disabled' : 'gpt-4o-mini'}`);
+  r('');
+  r(`## Summary`);
+  r(`- **Pass:** ${passCount}/${runs.length} (${pct(passCount, runs.length)})`);
+  r(`- **Fail:** ${failCount}/${runs.length}`);
+  r('');
+  r(`### Latency (wall-clock, client-side)`);
+  r(`- p50: ${fmtMs(timings.wallClock.p50)}`);
+  r(`- p95: ${fmtMs(timings.wallClock.p95)}`);
+  r(`- p99: ${fmtMs(timings.wallClock.p99)}`);
+  r('');
+  r(`### Server-reported latency (\`metrics.latencyMs\`)`);
+  r(`- p50: ${fmtMs(timings.serverLatency.p50)}`);
+  r(`- p95: ${fmtMs(timings.serverLatency.p95)}`);
+  r(`- p99: ${fmtMs(timings.serverLatency.p99)}`);
+  r('');
+  r(`### Tool-call time (sum across rounds, server-reported)`);
+  r(`- p50: ${fmtMs(timings.toolTime.p50)}`);
+  r(`- p95: ${fmtMs(timings.toolTime.p95)}`);
+  r(`- p99: ${fmtMs(timings.toolTime.p99)}`);
+  r('');
+  r(`### Tool breakdown (aggregate across all runs)`);
+  r('');
+  r(`| Tool | Calls | Total ms | Avg ms/call |`);
+  r(`|---|---|---|---|`);
+  for (const t of toolBreakdown) {
+    r(`| \`${t.name}\` | ${t.count} | ${t.totalMs} | ${t.avgMs} |`);
+  }
+  r('');
+  r(`## Per-query results`);
+  r('');
+  r(`| Query | Status | Wall | Server | Gates | Judge | Notes |`);
+  r(`|---|---|---|---|---|---|---|`);
+  for (const run of runs) {
+    const q = run.query;
+    const result = run.result;
+    const overallPass = run.gateResult.passedAllGates && (run.judgeResult?.pass !== false);
+    const gateBlurb = run.gateResult.gates.map(g => `${g.name}:${g.pass ? '✓' : '✘'}`).join(' ');
+    const judgeBlurb = run.judgeResult == null
+      ? '—'
+      : (run.judgeResult.pass === true ? '✓' : (run.judgeResult.pass === false ? '✘' : '?'));
+    const notes = (run.judgeResult?.reason || '').slice(0, 100).replace(/\|/g, '\\|');
+    r(`| ${q.id} | ${overallPass ? '✓' : '✘'} | ${fmtMs(result.wallClockMs)} | ${fmtMs(result.body?.metrics?.latencyMs)} | ${gateBlurb} | ${judgeBlurb} | ${notes} |`);
+  }
+  r('');
+  r(`## Notes`);
+  r('');
+  r(`Run with \`--repeats N\` to tighten p95/p99 numbers. Run with \`--no-judge\` to skip semantic grading (saves ~$0.05 in OpenAI tokens). Run with \`--filter <id-substring>\` to narrow to a subset.`);
+
+  const outDir = path.join(__dirname, '..', '..', 'tmp');
+  if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const outFile = path.join(outDir, `benchmark-${ts}.md`);
+  fs.writeFileSync(outFile, reportLines.join('\n'));
+
+  console.log(`\n${'─'.repeat(60)}`);
+  console.log(`Summary: ${passCount}/${runs.length} pass, ${failCount} fail`);
+  console.log(`Wall: p50=${fmtMs(timings.wallClock.p50)} p95=${fmtMs(timings.wallClock.p95)} p99=${fmtMs(timings.wallClock.p99)}`);
+  console.log(`Report written to: ${outFile}`);
+
+  process.exit(failCount > 0 ? 1 : 0);
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/scripts/benchmarks/signRequest.js
+++ b/scripts/benchmarks/signRequest.js
@@ -1,0 +1,71 @@
+/**
+ * Sign a request with the HMAC scheme that utils/benchmarkAuth.js expects.
+ *
+ * Mirrors the canonical-string format used server-side:
+ *   METHOD\nPATH\nSORTED_QUERY\nBODY_SHA256_HEX\nTIMESTAMP\nKEY_ID
+ *
+ * The keyId is fixed to "benchmark" — the server-side verifier hardcodes
+ * the same string so we don't need a per-key map. The harness only knows
+ * the secret (from BENCHMARK_HMAC_SECRET) and the fixed keyId.
+ */
+
+const crypto = require('crypto');
+
+const KEY_ID = 'benchmark';
+
+function sha256Hex(input) {
+  return crypto.createHash('sha256').update(input || '').digest('hex');
+}
+
+function buildSortedQueryString(query) {
+  if (!query || typeof query !== 'object') return '';
+  const params = [];
+  for (const key of Object.keys(query).sort()) {
+    const value = query[key];
+    if (Array.isArray(value)) {
+      for (const v of [...value].map(v => `${v}`).sort()) {
+        params.push(`${encodeURIComponent(key)}=${encodeURIComponent(v)}`);
+      }
+    } else if (value === undefined || value === null) {
+      params.push(`${encodeURIComponent(key)}=`);
+    } else {
+      params.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+    }
+  }
+  return params.join('&');
+}
+
+/**
+ * @param {Object} args
+ * @param {string} args.method      HTTP method (e.g. 'POST')
+ * @param {string} args.path        URL path (e.g. '/api/pull')
+ * @param {Object} [args.query]     Query params (object form)
+ * @param {string} [args.rawBody]   The exact body string that will be sent
+ * @param {string} args.secret      HMAC secret (hex string from BENCHMARK_HMAC_SECRET)
+ * @returns {Object} headers to attach to the outgoing request
+ */
+function signRequest({ method, path, query, rawBody, secret }) {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const bodyHashHex = rawBody ? sha256Hex(rawBody) : '';
+  const queryString = buildSortedQueryString(query);
+
+  const canonical = [
+    String(method).toUpperCase(),
+    path,
+    queryString || '',
+    bodyHashHex || '',
+    String(timestamp),
+    KEY_ID,
+  ].join('\n');
+
+  const signature = crypto.createHmac('sha256', secret).update(canonical).digest('base64');
+
+  return {
+    'X-Svc-KeyId': KEY_ID,
+    'X-Svc-Timestamp': String(timestamp),
+    'X-Svc-Body-Hash': bodyHashHex,
+    'X-Svc-Signature': signature,
+  };
+}
+
+module.exports = { signRequest, sha256Hex, buildSortedQueryString, KEY_ID };

--- a/scripts/benchmarks/test-sign-verify.js
+++ b/scripts/benchmarks/test-sign-verify.js
@@ -1,0 +1,131 @@
+/**
+ * test-sign-verify.js
+ *
+ * Local roundtrip test for the benchmark HMAC scheme. Signs a mock request
+ * with the harness's signRequest(), then verifies it through the same
+ * isBenchmarkRequest() that the server uses. Also probes negative cases
+ * (bad signature, expired timestamp, body tampering) to confirm fail-quiet
+ * semantics.
+ *
+ * Does not touch network or DB. Pure local crypto.
+ *
+ * Usage:
+ *   BENCHMARK_HMAC_SECRET=$(openssl rand -hex 32) node scripts/benchmarks/test-sign-verify.js
+ */
+
+// Set a deterministic test secret before loading the verifier so we don't
+// depend on the user's local .env.
+if (!process.env.BENCHMARK_HMAC_SECRET) {
+  process.env.BENCHMARK_HMAC_SECRET = 'a'.repeat(64); // 32 hex bytes worth of 'a'
+}
+
+const { signRequest, sha256Hex } = require('./signRequest');
+const { isBenchmarkRequest } = require('../../utils/benchmarkAuth');
+
+const SECRET = process.env.BENCHMARK_HMAC_SECRET;
+
+function makeMockReq({ method = 'POST', path = '/api/pull', rawBody = '{"message":"hello"}', headers = {} } = {}) {
+  return {
+    method,
+    baseUrl: '',
+    path,
+    query: {},
+    rawBody,
+    headers: {
+      'content-length': String(Buffer.byteLength(rawBody, 'utf8')),
+      ...Object.fromEntries(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v])),
+    },
+  };
+}
+
+let passes = 0;
+let fails = 0;
+function check(label, condition, detail = '') {
+  if (condition) { console.log(`  ✓ ${label}`); passes++; }
+  else { console.log(`  ✘ ${label}${detail ? ` — ${detail}` : ''}`); fails++; }
+}
+
+console.log('\nBenchmark HMAC roundtrip test');
+console.log('─'.repeat(60));
+
+const rawBody = JSON.stringify({ message: 'What did they say about albyhub?' });
+const headers = signRequest({
+  method: 'POST',
+  path: '/api/pull',
+  rawBody,
+  secret: SECRET,
+});
+
+// Test 1: valid signature roundtrip
+{
+  const req = makeMockReq({ rawBody, headers });
+  check('valid signature accepted', isBenchmarkRequest(req) === true);
+}
+
+// Test 2: missing all HMAC headers
+{
+  const req = makeMockReq({ rawBody, headers: {} });
+  check('missing headers rejected silently', isBenchmarkRequest(req) === false);
+}
+
+// Test 3: bad signature
+{
+  const bad = { ...headers, 'X-Svc-Signature': 'AAAA' + headers['X-Svc-Signature'].slice(4) };
+  const req = makeMockReq({ rawBody, headers: bad });
+  check('bad signature rejected silently', isBenchmarkRequest(req) === false);
+}
+
+// Test 4: expired timestamp
+{
+  const oldTs = String(Math.floor(Date.now() / 1000) - 600); // 10 min ago, well past 60s window
+  const expired = { ...headers, 'X-Svc-Timestamp': oldTs };
+  const req = makeMockReq({ rawBody, headers: expired });
+  check('expired timestamp rejected silently', isBenchmarkRequest(req) === false);
+}
+
+// Test 5: body tampered (different rawBody than what was signed)
+{
+  const tamperedRawBody = JSON.stringify({ message: 'malicious change' });
+  const req = makeMockReq({
+    rawBody: tamperedRawBody,
+    headers: { ...headers, 'content-length': String(Buffer.byteLength(tamperedRawBody, 'utf8')) },
+  });
+  check('body tamper rejected silently', isBenchmarkRequest(req) === false);
+}
+
+// Test 6: wrong keyId
+{
+  const wrongKey = { ...headers, 'X-Svc-KeyId': 'not-benchmark' };
+  const req = makeMockReq({ rawBody, headers: wrongKey });
+  check('wrong keyId rejected silently', isBenchmarkRequest(req) === false);
+}
+
+// Test 7: env secret unset (mechanism off)
+{
+  const saved = process.env.BENCHMARK_HMAC_SECRET;
+  delete process.env.BENCHMARK_HMAC_SECRET;
+  const req = makeMockReq({ rawBody, headers });
+  const result = isBenchmarkRequest(req);
+  process.env.BENCHMARK_HMAC_SECRET = saved;
+  check('mechanism disabled when env unset', result === false);
+}
+
+// Test 8: signature is a function of body — body change without re-signing is rejected
+// (overlaps with #5 but tests via length mismatch instead of hash)
+{
+  const shortBody = '{}';
+  // Compute a fresh hash for the shorter body, but DO NOT re-sign — use old sig
+  const tamperedHeaders = {
+    ...headers,
+    'X-Svc-Body-Hash': sha256Hex(shortBody), // hash matches new body
+    'content-length': String(Buffer.byteLength(shortBody, 'utf8')),
+  };
+  const req = makeMockReq({ rawBody: shortBody, headers: tamperedHeaders });
+  // The hash now matches the body, BUT the signature was computed over the
+  // ORIGINAL hash, so signature verification should fail.
+  check('body+hash swapped without resign rejected', isBenchmarkRequest(req) === false);
+}
+
+console.log('─'.repeat(60));
+console.log(`\nSummary: ${passes} passed, ${fails} failed`);
+process.exit(fails > 0 ? 1 : 0);

--- a/utils/benchmarkAuth.js
+++ b/utils/benchmarkAuth.js
@@ -1,0 +1,125 @@
+/**
+ * Dedicated HMAC verification for benchmark-mode requests.
+ *
+ * Single-purpose by design. Reads ONE env var (BENCHMARK_HMAC_SECRET) and
+ * verifies an incoming request signature against it. If the env var is
+ * unset, benchmark mode is fully off — the function always returns false,
+ * and no caller can see internal `_timings`/`metrics` regardless of headers.
+ *
+ * Fail-quiet: bad/missing/expired headers all return false silently. Never
+ * 401s, so the existence of the mechanism isn't observable to probing.
+ *
+ * Same crypto as middleware/hmac.js (HMAC-SHA256 over the canonical request
+ * string, 60-second clock-skew window, timing-safe comparison, body-hash
+ * check when raw body is available).
+ *
+ * Why not reuse serviceHmac? That middleware uses a multi-key/scope system
+ * driven by SVC_HMAC_KEYS_JSON + ALLOWED_SCOPES_JSON. Benchmark needs only
+ * one secret; threading it through the scope system would require two env
+ * vars instead of one. This file keeps the single-secret promise.
+ */
+
+const crypto = require('crypto');
+
+const KEY_ID = 'benchmark';
+const DEFAULT_MAX_SKEW_SECONDS = Number(process.env.BENCHMARK_HMAC_MAX_SKEW_SECS || 60);
+
+function sha256Hex(input) {
+  return crypto.createHash('sha256').update(input || '').digest('hex');
+}
+
+function buildSortedQueryString(query) {
+  if (!query || typeof query !== 'object') return '';
+  const params = [];
+  for (const key of Object.keys(query).sort()) {
+    const value = query[key];
+    if (Array.isArray(value)) {
+      for (const v of [...value].map(v => `${v}`).sort()) {
+        params.push(`${encodeURIComponent(key)}=${encodeURIComponent(v)}`);
+      }
+    } else if (value === undefined || value === null) {
+      params.push(`${encodeURIComponent(key)}=`);
+    } else {
+      params.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+    }
+  }
+  return params.join('&');
+}
+
+function timingSafeEqualStr(a, b) {
+  const aBuf = Buffer.from(a || '', 'utf8');
+  const bBuf = Buffer.from(b || '', 'utf8');
+  if (aBuf.length !== bBuf.length) return false;
+  return crypto.timingSafeEqual(aBuf, bBuf);
+}
+
+function computeExpectedSignature({ method, path, queryString, bodyHashHex, timestamp, secret }) {
+  const canonical = [
+    String(method).toUpperCase(),
+    path,
+    queryString || '',
+    bodyHashHex || '',
+    String(timestamp),
+    KEY_ID,
+  ].join('\n');
+  return crypto.createHmac('sha256', secret).update(canonical).digest('base64');
+}
+
+/**
+ * Returns true iff the request carries a valid HMAC signature for the
+ * benchmark mode. Silently returns false for any failure condition.
+ */
+function isBenchmarkRequest(req, { maxSkewSeconds = DEFAULT_MAX_SKEW_SECONDS } = {}) {
+  const secret = process.env.BENCHMARK_HMAC_SECRET;
+  if (!secret) return false; // benchmark mode disabled entirely
+
+  try {
+    const keyId = String(req.headers['x-svc-keyid'] || '');
+    const tsStr = String(req.headers['x-svc-timestamp'] || '');
+    const providedSig = String(req.headers['x-svc-signature'] || '');
+    const providedBodyHash = String(req.headers['x-svc-body-hash'] || '');
+
+    if (!keyId || !tsStr || !providedSig) return false;
+    if (keyId !== KEY_ID) return false;
+
+    const now = Math.floor(Date.now() / 1000);
+    const ts = Number(tsStr);
+    if (!Number.isFinite(ts)) return false;
+    if (Math.abs(now - ts) > maxSkewSeconds) return false;
+
+    const contentLength = Number(req.headers['content-length'] || 0);
+    let bodyHashHex = providedBodyHash;
+    if (contentLength > 0) {
+      if (!providedBodyHash) return false;
+      if (req.rawBody !== undefined) {
+        const actualBodyHash = sha256Hex(req.rawBody);
+        if (!timingSafeEqualStr(providedBodyHash, actualBodyHash)) return false;
+      }
+      // If rawBody isn't captured, we accept the provided hash on faith for
+      // signature input. TLS still protects body integrity in transit, but
+      // worth wiring captureRawBody before express.json() in a hardening pass.
+    }
+
+    const method = (req.method || 'GET').toUpperCase();
+    const path = ((req.baseUrl || '') + (req.path || '/')) || '/';
+    const queryString = buildSortedQueryString(req.query);
+    const expectedSig = computeExpectedSignature({
+      method, path, queryString, bodyHashHex, timestamp: ts, secret,
+    });
+    if (!timingSafeEqualStr(providedSig, expectedSig)) return false;
+
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+module.exports = {
+  isBenchmarkRequest,
+  // Exported so the benchmark harness (scripts/benchmarks/signRequest.js)
+  // can import and reuse the exact same canonical-string logic.
+  KEY_ID,
+  sha256Hex,
+  buildSortedQueryString,
+  computeExpectedSignature,
+};


### PR DESCRIPTION
## Summary

Adds a production benchmark that runs a 12-query suite against `/api/pull`, captures per-call timing + tool breakdown from the server's existing `metrics` payload, grades responses with a gpt-4o-mini judge, and writes a Markdown report. Intended to run at each episode-count milestone during staging ingest ramp so we catch regressions preemptively.

## Why

You're about to roughly 3× the corpus from staging. The Atlas-Search index shrink (PR #118) and scheduler-lock work (PR #119) gave us scaling headroom on paper. This PR gives us the way to *verify* the headroom is real at each step — and catch the first signal of degradation before users do.

## Single env var to set

```
# .env (operator-only — never commit, never log)
BENCHMARK_HMAC_SECRET=<run: openssl rand -hex 32>
```

Same value on server and in the harness env. When unset, benchmark mode is **fully off** — no metrics exposed, no behavior change for anyone.

## Security model

- HMAC-SHA256 signature over canonical request (method, path, sorted query, body hash, timestamp, fixed keyId)
- 60-second clock skew window → replay protection
- Body hash bound in the signature → tamper protection
- Timing-safe comparison
- **Fail-quiet:** missing/expired/invalid signatures are indistinguishable from a normal user's response. No 401, no error field, no leak that the mechanism exists.

The raw secret never crosses the wire. Each request carries a signature that's only valid for that request, for 60 seconds.

## What's in the response when benchmarking

When `isBenchmarkRequest(req)` returns true, the JSON response includes the existing `metrics` payload that's gated today by `AGENT_INCLUDE_METRICS=true`:

```json
{
  "sessionId": "...",
  "text": "the agent's answer ...",
  "suggestedActions": [...],
  "metrics": {
    "provider": "openrouter",
    "model": "DeepSeek V4-Flash (OpenRouter)",
    "intent": "...",
    "rounds": 3,
    "toolCalls": [{ "name": "search_quotes", "resultCount": 5, "latencyMs": 1240 }, ...],
    "tokens": { "input": ..., "output": ... },
    "cost": { "claude": ..., "tools": ..., "total": ... },
    "latencyMs": 4380
  }
}
```

The benchmark aggregates `metrics.toolCalls[].latencyMs` (per-tool time), `metrics.latencyMs` (total server-side), and the harness's own wall-clock measurement (client-side, includes network).

## Files

**Server-side (additive only):**
- `utils/benchmarkAuth.js` — dedicated HMAC verifier reading just `BENCHMARK_HMAC_SECRET`
- `routes/agentChatRoutes.js` — adds `isBenchmarkRequest(req)` check alongside the existing `AGENT_INCLUDE_METRICS` flag

**Harness (`scripts/benchmarks/`):**
- `scale-up-benchmark.js` — main runner
- `signRequest.js` — HMAC signing helper
- `judge.js` — gpt-4o-mini grader
- `benchmark-queries.json` — 12 canonical queries covering proper-noun compounds, URL spellings, acronyms, technical specs, general topics, person queries, feed-scoped, and an obscure edge case (no-result expected)
- `test-sign-verify.js` — local roundtrip test, no network needed

## Verification

Local sign+verify roundtrip: **8/8 pass**

```
✓ valid signature accepted
✓ missing headers rejected silently
✓ bad signature rejected silently
✓ expired timestamp rejected silently
✓ body tamper rejected silently
✓ wrong keyId rejected silently
✓ mechanism disabled when env unset
✓ body+hash swapped without resign rejected
```

## Usage

```bash
# One-time setup
echo "BENCHMARK_HMAC_SECRET=$(openssl rand -hex 32)" >> .env
echo "BENCHMARK_BASE_URL=https://api.pullthatupjamie.ai" >> .env   # or your prod URL

# Run a benchmark
node scripts/benchmarks/scale-up-benchmark.js

# Flags
node scripts/benchmarks/scale-up-benchmark.js --repeats 3        # tighter p95/p99
node scripts/benchmarks/scale-up-benchmark.js --no-judge         # skip $0.05 in OpenAI grading
node scripts/benchmarks/scale-up-benchmark.js --filter compound  # subset by id substring
```

Report lands at `tmp/benchmark-<timestamp>.md` — gitignored. Archive locally as your scaling logbook.

## When to run

Recommended cadence during staging ramp (per the scale-up plan):

- 15k episodes (current baseline)
- 20k
- 25k (M20 yellow zone — first watch)
- 30k (M20 red zone — schedule M30 upgrade by now)
- After M30 upgrade
- 40k
- 50k

Diff successive reports to spot the first component to degrade.

## Cost per run

- ~$0.50–1.00 LLM tokens (depends on response length × 24 queries with 2 repeats)
- ~$0.06 gpt-4o-mini judge grading
- Real entitlement quota burns under your JWT_TEST_TOKEN — that token should be configured with effectively-unlimited quota for testing

## Risk profile

Low. Three reasons:

1. **Server change is conditional.** No code path runs differently for normal users — `isBenchmarkRequest` returns false instantly when env is unset OR headers are missing.
2. **No collection/migration changes.** Pure code addition.
3. **Existing `metrics` payload is reused.** Already accessible via `AGENT_INCLUDE_METRICS=true` in internal envs; this just adds an HMAC-gated path to it.

## Test plan

- [x] `node scripts/benchmarks/test-sign-verify.js` — 8/8 pass
- [ ] After merge + env set: `node scripts/benchmarks/scale-up-benchmark.js` against prod, confirm `metrics` field populated in response and report writes successfully
- [ ] Archive the first report as the 14.5k-episode baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
