### PR TITLE
benchmark: fix HMAC signature path (use req.originalUrl)

### DIFF
--- a/scripts/benchmarks/test-sign-verify.js
+++ b/scripts/benchmarks/test-sign-verify.js
@@ -29,6 +29,10 @@ function makeMockReq({ method = 'POST', path = '/api/pull', rawBody = '{"message
     method,
     baseUrl: '',
     path,
+    // Mirror what production sees: originalUrl is the incoming URL, which
+    // /api/pull's route handler does NOT rewrite (only req.url gets changed).
+    // Production verification reads originalUrl, so the test must set it too.
+    originalUrl: path,
     query: {},
     rawBody,
     headers: {

--- a/utils/benchmarkAuth.js
+++ b/utils/benchmarkAuth.js
@@ -107,7 +107,15 @@ function isBenchmarkRequest(req, { maxSkewSeconds = DEFAULT_MAX_SKEW_SECONDS } =
     }
 
     const method = (req.method || 'GET').toUpperCase();
-    const path = ((req.baseUrl || '') + (req.path || '/')) || '/';
+    // Use req.originalUrl (preserved across Express sub-router dispatch)
+    // rather than req.path / req.url. The /api/pull route internally
+    // rewrites req.url to '/agent' before dispatching to the agent router,
+    // so by the time this check runs, req.path is '/agent'. The harness
+    // signs over the original incoming path ('/api/pull'), so we must
+    // recover that here too. Strip any query string — it's signed via the
+    // separate queryString component.
+    const originalUrl = req.originalUrl || ((req.baseUrl || '') + (req.path || '/')) || '/';
+    const path = originalUrl.split('?')[0] || '/';
     const queryString = buildSortedQueryString(req.query);
     const expectedSig = computeExpectedSignature({
       method, path, queryString, bodyHashHex, timestamp: ts, secret,


### PR DESCRIPTION
## Summary

One-line bug fix for a routing-edge-case that was silently breaking the benchmark.

## The bug

`/api/pull` internally rewrites `req.url = '/agent'` before dispatching to the agent router ([server.js:1844](server.js#L1844)). By the time `isBenchmarkRequest(req)` runs inside `handleAgentChat`, `req.path` is `/agent` — but the harness signs the canonical string using `/api/pull`.

Result: signatures never matched, server silently returned false, no `metrics` field ever appeared in responses. The harness's "⚠️ NO responses contained the metrics field" warning was the only signal that anything was wrong — the request itself succeeded normally.

## Fix

Use `req.originalUrl` (preserved across Express sub-router dispatch) for the canonical path, stripping any query string. Matches what the client signed.

## Verification

- Sign+verify roundtrip: **8/8 pass** (with mock req updated to set `originalUrl` so the test mirrors production routing semantics)

## Deploy + verify

After merge + redeploy:
```bash
node scripts/benchmarks/scale-up-benchmark.js --no-judge --filter compound-brand-albyhub --repeats 1
```
Expected: 1/1 pass, **no "NO responses contained the metrics field" warning**, server-reported latency and tool breakdown populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)