### PR TITLE
fix(reranker): structured JSON output + patch dependency CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5828,9 +5828,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -6062,13 +6062,12 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.19.tgz",
-      "integrity": "sha512-5tFoETuFMvGkbPGsINNlIE4Ab86CsPhdPOQZCGwNt/NX0h5NDKQLKOWS/G2XcRUBOQl4mCNbrayUvUTWaIRsCg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.6.3.tgz",
+      "integrity": "sha512-pXrQ4/4myQvjFFOAUmt5pWRrLEZR20gzIJD7MNdUH+5/S5nLI4ZRBo/SYKC6coaYj9pYTfQdBIzcs+3kfJ5uDA==",
       "license": "MIT",
       "dependencies": {
-        "p-queue": "6.6.2",
-        "uuid": "10.0.0"
+        "p-queue": "6.6.2"
       },
       "peerDependencies": {
         "@opentelemetry/api": "*",
@@ -6613,19 +6612,6 @@
       },
       "engines": {
         "node": ">=0.4.10"
-      }
-    },
-    "node_modules/natural/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/negotiator": {
@@ -7373,9 +7359,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -8608,16 +8594,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -67,5 +67,11 @@
   "devDependencies": {
     "archiver": "^7.0.1",
     "js-yaml": "^4.1.1"
+  },
+  "overrides": {
+    "ip-address": "^10.1.1",
+    "langsmith": "^0.6.0",
+    "qs": "^6.15.2",
+    "uuid": "^11.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "nostr:watch-zaps": "node scripts/nostr-watch-zaps.js",
     "nostr:process-mentions": "node scripts/nostr-process-mentions.js",
     "nostr:decrypt-private-zap": "node scripts/nostr-decrypt-private-zap.js",
-    "test:zap-validator": "node tests/zap-receipt-validator.test.js"
+    "test:zap-validator": "node tests/zap-receipt-validator.test.js",
+    "test:reranker": "node tests/clip-reranker.test.js"
   },
   "author": "uj21",
   "license": "ISC",

--- a/tests/clip-reranker.test.js
+++ b/tests/clip-reranker.test.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * Repro + regression for the clip reranker (utils/clipReranker.js).
+ *
+ *   node tests/clip-reranker.test.js
+ *
+ * The reranker is supposed to score each clip 0-10 and DROP low scorers —
+ * ad reads / sponsor spots are explicitly meant to score 0-1. This exercises it
+ * against a known mix (2 obvious ad reads + 3 substantive clips) and asserts the
+ * ads are dropped and the substantive clips survive.
+ *
+ * BASELINE (before the fix): the call uses response_format:{type:'json_object'}
+ * while the prompt asks for a bare JSON array, so gpt-4o-mini returns a flattened
+ * dup-key object like {"i":0,"s":10,"i":1,"s":6} → JSON.parse keeps only the last
+ * pair → parser finds no `scores` → every clip defaults to 5 → NOTHING is dropped.
+ * This test FAILS on baseline (ads survive) and PASSES after the schema fix.
+ *
+ * Requires OPENAI_API_KEY. Exits non-zero on failure.
+ */
+
+require('dotenv').config();
+const { OpenAI } = require('openai');
+const { rerankClips } = require('../utils/clipReranker');
+
+const AD_1 = 'CoreWeave is the essential cloud for AI. Ready for anything, ready for AI. To learn more about how CoreWeave powers the world\'s best AI, go to coreweave.com slash ready for anything.';
+const AD_2 = 'Support for the show comes from CoreWeave. Everywhere you look, AI is expanding what we thought was possible. CoreWeave powers AI pioneers around the world with purpose-built tech.';
+const REAL_1 = 'CoreWeave carries a lot of debt — there\'s a revolving credit line with JPMorgan and the financing structure is aggressive given how capex-heavy the data-center buildout is.';
+const REAL_2 = 'CoreWeave\'s revenue grew triple digits, but customer concentration with Microsoft is a real risk to the long-term margins if that contract renegotiates.';
+const REAL_3 = 'The bull case on CoreWeave is that it locked in GPU supply early and has multi-year take-or-pay contracts; the bear case is the whole thing unwinds if AI capex slows.';
+
+const ADS = [AD_1, AD_2];
+const clips = [
+  { text: AD_1, creator: 'The Vergecast', episode: 'x' },
+  { text: AD_2, creator: 'Pivot', episode: 'y' },
+  { text: REAL_1, creator: 'Odd Lots', episode: 'z' },
+  { text: REAL_2, creator: 'The Compound and Friends', episode: 'w' },
+  { text: REAL_3, creator: 'Forward Guidance', episode: 'v' },
+];
+
+(async () => {
+  if (!process.env.OPENAI_API_KEY) { console.error('SKIP: OPENAI_API_KEY not set'); process.exit(2); }
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+  console.log(`--- input: ${clips.length} clips (${ADS.length} ad reads, ${clips.length - ADS.length} substantive) ---`);
+  const { clips: kept } = await rerankClips({ query: 'CoreWeave', clips, openai, minScore: 4 });
+
+  const keptTexts = new Set(kept.map((c) => c.text));
+  const adsKept = ADS.filter((a) => keptTexts.has(a));
+  const realKept = [REAL_1, REAL_2, REAL_3].filter((r) => keptTexts.has(r));
+
+  console.log(`kept ${kept.length}/${clips.length}`);
+  kept.forEach((c) => console.log(`  • ${(c.text || '').slice(0, 60)}`));
+  console.log(`\nads surviving: ${adsKept.length}/${ADS.length}  |  substantive surviving: ${realKept.length}/3`);
+
+  const failures = [];
+  if (adsKept.length > 0) failures.push(`${adsKept.length} ad read(s) were NOT dropped (reranker not filtering)`);
+  if (realKept.length === 0) failures.push('all substantive clips were dropped (reranker too aggressive / broken)');
+
+  if (failures.length) {
+    console.error(`\nFAIL:\n - ${failures.join('\n - ')}`);
+    process.exit(1);
+  }
+  console.log('\nPASS: ad reads dropped, substantive clips kept.');
+})().catch((e) => { console.error('ERROR:', e.message); process.exit(1); });

--- a/utils/clipReranker.js
+++ b/utils/clipReranker.js
@@ -60,7 +60,7 @@ Person-mismatch penalty (HARD RULE — apply before any topical score):
 - If the clip is [guests: none-tagged], do NOT apply this penalty — score normally on topical/substantive relevance. Empty guest metadata is ambiguous, not exonerating.
 - This penalty does NOT apply when the user's question is a pure topic query with no named person ("Bitcoin custody", "AI agents").
 
-Return ONLY a JSON array: [{"i":0,"s":7},{"i":1,"s":3},...]`;
+Return JSON of the form {"scores":[{"i":0,"s":7},{"i":1,"s":3}, ...]} — exactly one {"i","s"} entry per clip, where i is the clip's index and s is its 0-10 score.`;
 
   const questionForScorer = (typeof userMessage === 'string' && userMessage.trim().length > 0)
     ? userMessage.trim()
@@ -77,7 +77,36 @@ ${clipSummaries.join('\n')}`;
         { role: 'system', content: systemPrompt },
         { role: 'user', content: userPrompt },
       ],
-      response_format: { type: 'json_object' },
+      // Strict schema forces {"scores":[{"i","s"}]}. Without it, json_object +
+      // an "array" prompt makes the model flatten to a dup-key object like
+      // {"i":0,"s":10,"i":1,"s":6} that JSON.parse collapses to one pair, so the
+      // parser found no scores and every clip defaulted to 5 (never filtered).
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'clip_scores',
+          strict: true,
+          schema: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['scores'],
+            properties: {
+              scores: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  additionalProperties: false,
+                  required: ['i', 's'],
+                  properties: {
+                    i: { type: 'integer' },
+                    s: { type: 'integer', minimum: 0, maximum: 10 },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
       temperature: 0.0,
       max_tokens: 600,
     });


### PR DESCRIPTION
This PR contains two independent fixes.

---

## 1. Reranker — force structured JSON output so low-relevance clips are dropped

### Problem
The clip reranker (`utils/clipReranker.js`, shared by `/api/pull` and the new Tape endpoints) scores each clip 0-10 and is supposed to drop low scorers — sponsor/ad reads explicitly score 0-1. **In practice it dropped nothing**: ad reads and off-topic clips passed straight through, polluting downstream synthesis.

### Root cause
The OpenAI call used `response_format: { type: 'json_object' }` while the prompt asked for a bare JSON **array**. gpt-4o-mini reconciled the conflict by emitting a single flattened, duplicate-key object — `{"i":0,"s":10,"i":1,"s":6,"i":2,"s":7}`. `JSON.parse` collapses duplicate keys to the **last** pair; the parser then looked for `parsed.scores`/`parsed.results`, found neither, got an empty score list, so every clip fell through to the default score of `5` and **nothing was filtered**. Same module → same failure on `/api/pull`.

### Fix
- `response_format` → strict `json_schema` mandating `{"scores":[{"i":<int>,"s":<int 0-10>}]}`.
- Prompt aligned to that exact shape.

### Verification — `tests/clip-reranker.test.js` (`npm run test:reranker`)
Feeds 2 ad reads + 3 substantive clips:

| | result |
|---|---|
| **Before** (master) | `5 → 5 kept (0 below threshold)` — 2/2 ads survived ❌ |
| **After** | `5 → 3 kept (2 below threshold)` — 0/2 ads survived, 3/3 substantive kept ✅ |

Requires `OPENAI_API_KEY` (live call; exits `2`/SKIP without it — note it won't run in keyless CI).

---

## 2. Dependency CVEs

Four flagged advisories, all transitive — pinned to patched versions via a `package.json` `overrides` block, lockfile regenerated **lockfile-only** (no node_modules churn; peer tree incl. `@langchain/core@1.1.44` preserved):

| package | change | advisory |
|---|---|---|
| ip-address | 10.1.0 → 10.2.0 | moderate — XSS in Address6 HTML methods (GHSA-v2v4-37r5-5v8g) |
| langsmith | 0.5.19 → 0.6.3 | high — untrusted manifest deserialization (GHSA-3644-q5cj-c5c7) |
| qs | 6.14.2 → 6.15.2 | moderate — DoS in `qs.stringify` (GHSA-q8mj-m7cp-5q26) |
| uuid | 10.0.0 → 11.1.1 | moderate — also collapses `natural`'s nested `uuid@9.0.1` dupe |

**Verified:** all four resolve to patched versions and **10/10 affected modules load cleanly** under a plain `npm install` (uuid v4 valid, qs roundtrip, ip-address, `natural` tokenizer, `@langchain/openai` all OK).

**Not fixed — `elliptic`** (also flagged): still vulnerable at its latest published version (6.6.1); the only remediation is `npm audit fix --force`, which downgrades `bolt11` to 1.0.0 and **breaks Lightning invoice parsing**. Left for a deliberate follow-up. `axios` and `ws` advisories are pre-existing and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)