### PR TITLE
fix(deps): patch axios + ws Dependabot CVEs (elliptic unpatchable)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "umap-js": "^1.4.0",
         "wav": "^1.0.2",
         "web-streams-polyfill": "^4.0.0",
-        "ws": "^8.18.3"
+        "ws": "^8.20.1"
       },
       "devDependencies": {
         "archiver": "^7.0.1",
@@ -3487,6 +3487,41 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -3725,13 +3760,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -5634,6 +5670,42 @@
         "node": ">=12"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -5679,35 +5751,6 @@
       "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/ibm-cloud-sdk-core/node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
-    "node_modules/ibm-cloud-sdk-core/node_modules/axios/node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/ibm-cloud-sdk-core/node_modules/debug": {
@@ -8885,9 +8928,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -62,16 +62,18 @@
     "umap-js": "^1.4.0",
     "wav": "^1.0.2",
     "web-streams-polyfill": "^4.0.0",
-    "ws": "^8.18.3"
+    "ws": "^8.20.1"
   },
   "devDependencies": {
     "archiver": "^7.0.1",
     "js-yaml": "^4.1.1"
   },
   "overrides": {
+    "axios": "^1.16.0",
     "ip-address": "^10.1.1",
     "langsmith": "^0.6.0",
     "qs": "^6.15.2",
-    "uuid": "^11.1.1"
+    "uuid": "^11.1.1",
+    "ws": "^8.20.1"
   }
 }


### PR DESCRIPTION
Clears the remaining Dependabot alerts that have an available fix. All transitive/direct fixes are pinned via `overrides` + a direct-dep bump; lockfile regenerated and verified.

## Fixed

| Package | Change | Alerts | Advisory family |
|---|---|---|---|
| **axios** | `1.15.2` → `1.17.0` | #87–#94 (8) | prototype-pollution MITM, proxy-auth credential leak, ReDoS, DoS |
| **ws** | `8.19.0` → `8.21.0` | #86 | uninitialized memory disclosure (GHSA-58qx-3vcg-4xpx) |

**axios** — the root dependency was already `1.16.0` (patched). The vulnerable copy was **`axios@1.15.2`, hard-pinned by `ibm-cloud-sdk-core@5.4.14`** (`@langchain/community → @ibm-cloud/watsonx-ai → ibm-cloud-sdk-core`). Every one of the 8 advisories is `first_patched_version = 1.16.0`, so an `"axios": "^1.16.0"` override forces the nested copy up (resolves to latest `1.17.0`). Result: a single `axios@1.17.0` in the tree, nested `1.15.2` gone.

**ws** — patched in `8.20.1`. Bumped the direct dep range `^8.18.3 → ^8.20.1` and added a matching override so the transitive copies (stagehand, openai, langchain) dedupe up. Resolves to `8.21.0`.

### Verification
- Single `axios@1.17.0`, `ws@8.21.0` everywhere.
- `ibm-cloud-sdk-core` still loads with the overridden axios; `@langchain/core@1.1.44` preserved.
- **13/13** affected modules load cleanly.
- `npm audit`: **6 → 3** vulnerabilities (the 3 remaining are the elliptic chain below).

## Not fixed — `elliptic` (#23, low)

Left untouched **deliberately**: it is flagged at *every published version* (vulnerable range `<= 6.6.1`, `first_patched_version = none`). There is nothing to upgrade to. npm's only remediation is `npm audit fix --force`, which installs `bolt11@1.0.0` — a **breaking major** that would break Lightning invoice parsing (`bolt11 → secp256k1 → elliptic`). The 3 remaining low `npm audit` findings are exactly this chain. Recommend **dismissing/accepting** alert #23 until `bolt11`'s crypto stack moves off `elliptic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
