### PR TITLE
fix(nostr-bot): reclaim orphaned mentions, retry transient failures, drop dead relay

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "nostr:process-mentions": "node scripts/nostr-process-mentions.js",
     "nostr:decrypt-private-zap": "node scripts/nostr-decrypt-private-zap.js",
     "test:zap-validator": "node tests/zap-receipt-validator.test.js",
-    "test:reranker": "node tests/clip-reranker.test.js"
+    "test:reranker": "node tests/clip-reranker.test.js",
+    "test:relay-pool": "node tests/nostr-relay-pool.test.js"
   },
   "author": "uj21",
   "license": "ISC",

--- a/routes/nostrBotAdminRoutes.js
+++ b/routes/nostrBotAdminRoutes.js
@@ -99,12 +99,16 @@ function buildRouter() {
       return res.status(400).json({ error: 'eventId must be 64-char hex' });
     }
     try {
+      // Reset attemptCount so a mention that already exhausted its
+      // automatic retries (or is stranded in `processing`) becomes
+      // claimable again. `processing` is included so orphaned rows whose
+      // lease hasn't yet expired can be recovered on demand.
       const m = await NostrMention.findOneAndUpdate(
-        { eventId, status: { $in: ['failed', 'ignored'] } },
-        { $set: { status: 'pending', errorMessage: null, processedAt: null }, $inc: { attemptCount: 0 } },
+        { eventId, status: { $in: ['failed', 'ignored', 'processing'] } },
+        { $set: { status: 'pending', errorMessage: null, processedAt: null, attemptCount: 0 } },
         { new: true },
       );
-      if (!m) return res.status(404).json({ error: 'no failed/ignored mention with that id' });
+      if (!m) return res.status(404).json({ error: 'no failed/ignored/processing mention with that id' });
       res.json({ ok: true, mention: { id: m._id, status: m.status } });
     } catch (err) {
       res.status(500).json({ error: err.message });

--- a/server.js
+++ b/server.js
@@ -2238,7 +2238,11 @@ const _server = app.listen(PORT, async () => {
       const NOSTR_BOT_POLL_INTERVAL_MS = (() => {
         const raw = parseInt(process.env.NOSTR_BOT_POLL_INTERVAL_MS, 10);
         if (Number.isFinite(raw) && raw >= 5000) return raw;
-        return 30000; // default: 30 seconds
+        // 15s tick. With the 12-relay pool rotating 3 relays/tick, each
+        // relay is polled once per 60s while the system sweeps 3 fresh
+        // relays every 15s — so mention/zap detection latency stays low
+        // without hammering any single relay.
+        return 15000; // default: 15 seconds
       })();
       console.log(
         `[NostrBot] polling interval = ${NOSTR_BOT_POLL_INTERVAL_MS}ms (override via NOSTR_BOT_POLL_INTERVAL_MS, min 5000)`,

--- a/tests/nostr-relay-pool.test.js
+++ b/tests/nostr-relay-pool.test.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for utils/nostrRelayPool RelayRotation.
+ *
+ *   node tests/nostr-relay-pool.test.js
+ *
+ * Pure node assertions, no test framework. A non-zero exit code
+ * indicates at least one scenario failed.
+ */
+
+const assert = require('assert');
+const { RelayRotation, RELAY_POOL, DEFAULT_SLICE_SIZE } = require('../utils/nostrRelayPool');
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed++;
+  console.log(`  ok - ${name}`);
+}
+
+console.log('RelayRotation');
+
+test('pool has 12 relays, all unique wss URLs', () => {
+  assert.strictEqual(RELAY_POOL.length, 12);
+  assert.strictEqual(new Set(RELAY_POOL).size, 12, 'relays must be unique');
+  for (const url of RELAY_POOL) {
+    assert.ok(/^wss:\/\/.+/.test(url), `bad relay url: ${url}`);
+  }
+});
+
+test('default slice sweeps the whole pool exactly once per rotation', () => {
+  const r = new RelayRotation({});
+  const ticksPerRotation = RELAY_POOL.length / DEFAULT_SLICE_SIZE; // 12/3 = 4
+  assert.ok(Number.isInteger(ticksPerRotation), 'pool should divide evenly by default slice');
+  const seen = new Map();
+  for (let t = 0; t < ticksPerRotation; t++) {
+    const slice = r.next();
+    assert.strictEqual(slice.length, DEFAULT_SLICE_SIZE);
+    for (const url of slice) seen.set(url, (seen.get(url) || 0) + 1);
+  }
+  assert.strictEqual(seen.size, RELAY_POOL.length, 'every relay covered');
+  for (const [url, count] of seen) {
+    assert.strictEqual(count, 1, `${url} polled ${count}x, expected exactly 1 per rotation`);
+  }
+});
+
+test('cursor wraps and continues across rotations', () => {
+  const r = new RelayRotation({});
+  const first = [];
+  const second = [];
+  for (let t = 0; t < 4; t++) first.push(...r.next());
+  for (let t = 0; t < 4; t++) second.push(...r.next());
+  assert.deepStrictEqual(second, first, 'second full rotation should repeat the first');
+});
+
+test('uneven slice size still wraps without gaps over a full cycle', () => {
+  // sliceSize 5 over 12: cursor visits 0,5,10,3(wrap),8,1(wrap)... a full
+  // cycle of 12 ticks must cover every relay an equal number of times.
+  const r = new RelayRotation({ sliceSize: 5 });
+  const seen = new Map();
+  for (let t = 0; t < RELAY_POOL.length; t++) {
+    for (const url of r.next()) seen.set(url, (seen.get(url) || 0) + 1);
+  }
+  assert.strictEqual(seen.size, RELAY_POOL.length, 'every relay covered over a full cycle');
+  const counts = [...seen.values()];
+  assert.ok(counts.every((c) => c === counts[0]), 'coverage should be uniform across relays');
+});
+
+test('sliceSize is clamped to the relay list length', () => {
+  const r = new RelayRotation({ relays: ['wss://a', 'wss://b'], sliceSize: 3 });
+  const slice = r.next();
+  assert.strictEqual(slice.length, 2, 'cannot poll more relays than exist');
+  assert.deepStrictEqual(slice, ['wss://a', 'wss://b']);
+});
+
+test('explicit relays override the pool (test/override path)', () => {
+  const r = new RelayRotation({ relays: ['wss://only.example'], sliceSize: 1 });
+  assert.strictEqual(r.poolSize, 1);
+  assert.deepStrictEqual(r.next(), ['wss://only.example']);
+  assert.deepStrictEqual(r.next(), ['wss://only.example']);
+});
+
+console.log(`\n${passed} passed`);

--- a/utils/NostrBotReplyService.js
+++ b/utils/NostrBotReplyService.js
@@ -21,17 +21,30 @@ const { ENTITLEMENT_TYPES } = require('../constants/entitlementTypes');
  *       and marks the mention `insufficient_balance`.
  *
  * Failures during runPull or relay publish bump `attemptCount` and
- * leave the mention in `failed` state for triage. Replies that
- * already published successfully are NOT re-attempted because the
- * status transition is the gate.
+ * leave the mention in `failed` state. A failed mention is retried on
+ * a later tick until `attemptCount` reaches MAX_ATTEMPTS_PER_MENTION,
+ * after which it stays `failed` for triage. Replies that already
+ * published successfully are NOT re-attempted because the status
+ * transition to `replied` removes them from the claimable set.
  *
- * Concurrency: the atomic findOneAndUpdate "claim" pattern
- * guarantees no two workers process the same mention. Designed to
- * be safe to run from multiple instances if we ever scale out.
+ * Concurrency & crash recovery: the atomic findOneAndUpdate "claim"
+ * pattern guarantees no two workers process the same mention. A claim
+ * also carries a lease (PROCESSING_LEASE_SECONDS) — if the worker that
+ * claimed a mention dies mid-flight (crash, deploy, kill, OOM), the
+ * `processing` row is reclaimed once its lease expires rather than
+ * being stranded forever. This makes the worker safe to run across
+ * restarts and from multiple instances.
  */
 
 const DEFAULT_BATCH_SIZE = 10;
 const MAX_ATTEMPTS_PER_MENTION = 3;
+// A mention claimed (status → processing) but not resolved within this
+// window is considered orphaned — the worker that claimed it crashed,
+// was killed, deployed over, or timed out mid-agent. The next tick
+// reclaims it. Must exceed the agent timeout (180s in agentPullService)
+// with headroom so we never reclaim a row that's still legitimately
+// being worked. 10 minutes gives ~3x the agent timeout.
+const PROCESSING_LEASE_SECONDS = 10 * 60;
 const MENTION_AGE_LIMIT_SECONDS = 24 * 3600; // ignore mentions older than 24h on first ingest
 const RATE_LIMIT_WINDOW_SECONDS = 3600;        // 1h sliding window
 const RATE_LIMIT_MAX_REPLIES_PER_NPUB = 30;    // per author per window
@@ -93,13 +106,35 @@ class NostrBotReplyService {
   }
 
   /**
-   * Atomically transition one pending mention to processing and
+   * Atomically transition one claimable mention to processing and
    * return it. Returns null if there are none left.
+   *
+   * A mention is claimable when it is:
+   *   (a) fresh — status `pending`; or
+   *   (b) a transient failure worth retrying — status `failed` with
+   *       fewer than MAX_ATTEMPTS_PER_MENTION attempts (e.g. an agent
+   *       timeout or a relay publish hiccup); or
+   *   (c) orphaned — status `processing` whose lease has expired
+   *       (the worker that claimed it died/was killed mid-flight).
+   *
+   * `attemptCount` is incremented on every claim and caps retries so a
+   * genuinely poisoned mention can't loop forever. The lease is keyed
+   * on `updatedAt`, which Mongoose bumps on every save, so an actively
+   * progressing row is never reclaimed out from under its worker.
    */
   async _claimNext() {
     const cutoff = Math.floor(Date.now() / 1000) - MENTION_AGE_LIMIT_SECONDS;
+    const leaseExpiry = new Date(Date.now() - PROCESSING_LEASE_SECONDS * 1000);
     return NostrMention.findOneAndUpdate(
-      { status: 'pending', createdAt: { $gte: cutoff } },
+      {
+        createdAt: { $gte: cutoff },
+        attemptCount: { $lt: MAX_ATTEMPTS_PER_MENTION },
+        $or: [
+          { status: 'pending' },
+          { status: 'failed' },
+          { status: 'processing', updatedAt: { $lt: leaseExpiry } },
+        ],
+      },
       { $set: { status: 'processing' }, $inc: { attemptCount: 1 } },
       { sort: { createdAt: 1 }, new: true },
     );
@@ -355,5 +390,6 @@ class NostrBotReplyService {
 
 module.exports = NostrBotReplyService;
 module.exports.MAX_ATTEMPTS_PER_MENTION = MAX_ATTEMPTS_PER_MENTION;
+module.exports.PROCESSING_LEASE_SECONDS = PROCESSING_LEASE_SECONDS;
 module.exports.RATE_LIMIT_WINDOW_SECONDS = RATE_LIMIT_WINDOW_SECONDS;
 module.exports.RATE_LIMIT_MAX_REPLIES_PER_NPUB = RATE_LIMIT_MAX_REPLIES_PER_NPUB;

--- a/utils/NostrMentionWatcher.js
+++ b/utils/NostrMentionWatcher.js
@@ -28,7 +28,7 @@ const RELAYS = [
   'wss://relay.primal.net',
   'wss://relay.damus.io',
   'wss://nos.lol',
-  'wss://relay.nostr.band',
+  'wss://nostr.oxtr.dev',
   'wss://nostr.wine',
 ];
 

--- a/utils/NostrMentionWatcher.js
+++ b/utils/NostrMentionWatcher.js
@@ -2,6 +2,7 @@ const WebSocket = require('ws');
 const { nip19 } = require('nostr-tools');
 const { NostrMention } = require('../models/NostrMention');
 const { getBotPubkeyHex, getBotNpub } = require('./nostrBotIdentity');
+const { RELAY_POOL, RelayRotation, DEFAULT_SLICE_QUERY_TIMEOUT_MS } = require('./nostrRelayPool');
 
 /**
  * NostrMentionWatcher
@@ -24,29 +25,25 @@ const { getBotPubkeyHex, getBotNpub } = require('./nostrBotIdentity');
  * The watcher ignores events authored by the bot itself.
  */
 
-const RELAYS = [
-  'wss://relay.primal.net',
-  'wss://relay.damus.io',
-  'wss://nos.lol',
-  'wss://nostr.oxtr.dev',
-  'wss://nostr.wine',
-];
-
 const LOOKBACK_SECONDS = 600; // 10 minutes — overlap window between polls
-const RELAY_QUERY_TIMEOUT_MS = 12000; // wait at most this long for EOSE
 const SUB_PREFIX = 'jb_mentions_';
 
 class NostrMentionWatcher {
   constructor(options = {}) {
-    this.relays = Array.isArray(options.relays) && options.relays.length > 0
-      ? options.relays
-      : RELAYS;
+    // Each poll sweeps a rotating slice of the relay pool rather than
+    // every relay, so any single relay is polled only once per
+    // rotation. See nostrRelayPool for the cadence rationale. Tests can
+    // still pin a fixed relay set via options.relays.
+    this.rotation = new RelayRotation({
+      relays: options.relays,
+      sliceSize: options.sliceSize,
+    });
     this.lookbackSeconds = Number.isFinite(options.lookbackSeconds)
       ? options.lookbackSeconds
       : LOOKBACK_SECONDS;
     this.queryTimeoutMs = Number.isFinite(options.queryTimeoutMs)
       ? options.queryTimeoutMs
-      : RELAY_QUERY_TIMEOUT_MS;
+      : DEFAULT_SLICE_QUERY_TIMEOUT_MS;
   }
 
   /**
@@ -58,13 +55,14 @@ class NostrMentionWatcher {
     const botNpub = getBotNpub();
     const now = Math.floor(Date.now() / 1000);
     const since = await this._computeSince(botPubkey, now);
+    const relaySlice = this.rotation.next();
 
     console.log(
-      `[NostrMentionWatcher] Polling ${this.relays.length} relays for kind:1 mentions of ${botPubkey.substring(0, 12)}... since ${new Date(since * 1000).toISOString()} (${now - since}s window)`,
+      `[NostrMentionWatcher] Polling ${relaySlice.length}/${this.rotation.poolSize} relays [${relaySlice.join(', ')}] for kind:1 mentions of ${botPubkey.substring(0, 12)}... since ${new Date(since * 1000).toISOString()} (${now - since}s window)`,
     );
 
     const results = await Promise.allSettled(
-      this.relays.map((url) => this._queryRelay(url, botPubkey, since)),
+      relaySlice.map((url) => this._queryRelay(url, botPubkey, since)),
     );
 
     // Dedupe by event id across relays
@@ -121,10 +119,10 @@ class NostrMentionWatcher {
       invalid,
       totalUnique: events.length,
       since,
-      relays: this.relays.length,
+      relays: relaySlice.length,
     };
     console.log(
-      `[NostrMentionWatcher.metrics] new=${newCount} dup=${duplicateCount} self=${skippedSelf} threadProp=${threadPropagation} invalid=${invalid} total=${events.length} relays=${this.relays.length}`,
+      `[NostrMentionWatcher.metrics] new=${newCount} dup=${duplicateCount} self=${skippedSelf} threadProp=${threadPropagation} invalid=${invalid} total=${events.length} relays=${relaySlice.length}/${this.rotation.poolSize}`,
     );
     return summary;
   }
@@ -299,4 +297,4 @@ class NostrMentionWatcher {
 }
 
 module.exports = NostrMentionWatcher;
-module.exports.NOSTR_BOT_RELAYS = RELAYS;
+module.exports.NOSTR_BOT_RELAYS = RELAY_POOL;

--- a/utils/NostrZapWatcher.js
+++ b/utils/NostrZapWatcher.js
@@ -36,7 +36,7 @@ const RELAYS = [
   'wss://relay.primal.net',
   'wss://relay.damus.io',
   'wss://nos.lol',
-  'wss://relay.nostr.band',
+  'wss://nostr.oxtr.dev',
   'wss://nostr.wine',
 ];
 

--- a/utils/NostrZapWatcher.js
+++ b/utils/NostrZapWatcher.js
@@ -5,6 +5,7 @@ const { getBotPubkeyHex, getBotSecretKey } = require('./nostrBotIdentity');
 const { validateZapReceipt } = require('./zapReceiptValidator');
 const { satsToUsdMicro, getBtcUsdRate } = require('./btcPrice');
 const { nostrBotLog } = require('./nostrBotLogger');
+const { RELAY_POOL, RelayRotation, DEFAULT_SLICE_QUERY_TIMEOUT_MS } = require('./nostrRelayPool');
 
 /**
  * NostrZapWatcher
@@ -32,14 +33,6 @@ const { nostrBotLog } = require('./nostrBotLogger');
  * worker debits per call.
  */
 
-const RELAYS = [
-  'wss://relay.primal.net',
-  'wss://relay.damus.io',
-  'wss://nos.lol',
-  'wss://nostr.oxtr.dev',
-  'wss://nostr.wine',
-];
-
 // Background polls reach 12h back so a brief outage or a late-arriving
 // receipt can't drop credit on the floor. Receipt rows are deduped by
 // `receiptId` + `bolt11` unique indexes, so re-querying the same window
@@ -48,7 +41,6 @@ const RELAYS = [
 // zapped you" UX.
 const LOOKBACK_SECONDS = 12 * 3600; // 12 hours — generous overlap window
 const QUICK_POLL_LOOKBACK_SECONDS = 600; // 10 minutes — for on-demand re-polls
-const RELAY_QUERY_TIMEOUT_MS = 15000;
 const QUICK_POLL_RELAY_TIMEOUT_MS = 7000; // shorter wait for snappy on-demand polls
 const SUB_PREFIX = 'jb_zaps_';
 const REQUIRE_VALID_PREIMAGE = false; // most NIP-57 services don't include preimage
@@ -65,15 +57,19 @@ function parseTrustedPubkeys() {
 
 class NostrZapWatcher {
   constructor(options = {}) {
-    this.relays = Array.isArray(options.relays) && options.relays.length > 0
-      ? options.relays
-      : RELAYS;
+    // Recurring background polls sweep a rotating slice of the pool;
+    // the on-demand quickPoll path sweeps the full pool for breadth
+    // (see poll()). Tests can pin a fixed set via options.relays.
+    this.rotation = new RelayRotation({
+      relays: options.relays,
+      sliceSize: options.sliceSize,
+    });
     this.lookbackSeconds = Number.isFinite(options.lookbackSeconds)
       ? options.lookbackSeconds
       : LOOKBACK_SECONDS;
     this.queryTimeoutMs = Number.isFinite(options.queryTimeoutMs)
       ? options.queryTimeoutMs
-      : RELAY_QUERY_TIMEOUT_MS;
+      : DEFAULT_SLICE_QUERY_TIMEOUT_MS;
     this.requireValidPreimage = options.requireValidPreimage === true
       ? true
       : REQUIRE_VALID_PREIMAGE;
@@ -120,14 +116,19 @@ class NostrZapWatcher {
       ? opts.queryTimeoutOverrideMs
       : this.queryTimeoutMs;
     const since = await this._computeSince(now, lookbackSeconds);
-    const tag = opts.lookbackOverrideSeconds ? 'quickPoll' : 'poll';
+    const isQuickPoll = Number.isFinite(opts.lookbackOverrideSeconds);
+    const tag = isQuickPoll ? 'quickPoll' : 'poll';
+    // Background polls rotate through the pool one slice at a time. The
+    // on-demand quickPoll is a rare, latency-sensitive one-shot ("did
+    // this user just zap?") so it sweeps the full pool for max coverage.
+    const relaySlice = isQuickPoll ? this.rotation.relays : this.rotation.next();
 
     console.log(
-      `[NostrZapWatcher.${tag}] Polling ${this.relays.length} relays for kind:9735 #p=${botPubkey.substring(0, 12)}... since ${new Date(since * 1000).toISOString()} (${now - since}s window)`,
+      `[NostrZapWatcher.${tag}] Polling ${relaySlice.length}/${this.rotation.poolSize} relays [${relaySlice.join(', ')}] for kind:9735 #p=${botPubkey.substring(0, 12)}... since ${new Date(since * 1000).toISOString()} (${now - since}s window)`,
     );
 
     const results = await Promise.allSettled(
-      this.relays.map((url) => this._queryRelay(url, botPubkey, since, queryTimeoutMs)),
+      relaySlice.map((url) => this._queryRelay(url, botPubkey, since, queryTimeoutMs)),
     );
 
     // Dedupe by event id across relays
@@ -168,10 +169,10 @@ class NostrZapWatcher {
       retried,
       totalUnique: receipts.length,
       since,
-      relays: this.relays.length,
+      relays: relaySlice.length,
     };
     console.log(
-      `[NostrZapWatcher.metrics] credited=${credited} dup=${duplicate} anonSkipped=${anonymousSkipped} rejected=${rejected} failedDb=${failedDb} retried=${retried} total=${receipts.length} relays=${this.relays.length} tag=${tag}`,
+      `[NostrZapWatcher.metrics] credited=${credited} dup=${duplicate} anonSkipped=${anonymousSkipped} rejected=${rejected} failedDb=${failedDb} retried=${retried} total=${receipts.length} relays=${relaySlice.length}/${this.rotation.poolSize} tag=${tag}`,
     );
     return summary;
   }
@@ -509,4 +510,4 @@ class NostrZapWatcher {
 }
 
 module.exports = NostrZapWatcher;
-module.exports.NOSTR_BOT_RELAYS = RELAYS;
+module.exports.NOSTR_BOT_RELAYS = RELAY_POOL;

--- a/utils/nostrRelayPool.js
+++ b/utils/nostrRelayPool.js
@@ -1,0 +1,110 @@
+/**
+ * nostrRelayPool
+ *
+ * Shared relay pool + round-robin rotation for the Nostr bot's
+ * mention and zap watchers.
+ *
+ * Why rotate instead of polling all relays every tick? Polling a large
+ * relay set on every cycle opens a fresh subscription to each relay
+ * every few seconds — exactly the behavior relays rate-limit or ban.
+ * Instead we keep a pool of high-quality relays and, each tick, poll
+ * only a small rotating slice. Over a full rotation every relay is
+ * swept, but any single relay sees us only once per rotation.
+ *
+ * Cadence math (defaults): pool = 12, slice = 3, tick = 15s →
+ *   - the system touches 3 fresh relays every 15s (low detection TTL),
+ *   - each individual relay is polled once every 12/3 = 4 ticks = 60s
+ *     (gentle; never worse than the per-relay floor).
+ * The watcher's lookback window (600s) far exceeds the 60s revisit
+ * gap, so nothing is missed between a relay's polls — duplicates are
+ * absorbed by the eventId unique index.
+ *
+ * NOTE: mention and zap watchers each own an independent rotation, so a
+ * given relay may be hit by both — once/60s for mentions and once/60s
+ * for zaps, i.e. ~once/30s aggregate worst case. Still within a polite
+ * per-relay budget.
+ *
+ * The pool below is the tunable part — vet/adjust relay membership as
+ * relay reliability changes. The rotation mechanism is independent of
+ * which relays are in it.
+ */
+
+// 12 high-quality public relays. The first six are where this bot's
+// users' clients (Primal Web, Damus, Amethyst, Ditto) actually publish
+// — observed directly in the `r` relay-hint tags of real mentions.
+const RELAY_POOL = [
+  'wss://relay.primal.net',
+  'wss://relay.damus.io',
+  'wss://nos.lol',
+  'wss://nostr.oxtr.dev',
+  'wss://nostr.wine',
+  'wss://relay.nostrplebs.com',
+  'wss://nostr.einundzwanzig.space',
+  'wss://nostr.sidnlabs.nl',
+  'wss://relay.snort.social',
+  'wss://offchain.pub',
+  'wss://nostr.mom',
+  'wss://relay.nostr.bg',
+];
+
+// How many relays to poll per tick. With a 12-relay pool and a 15s
+// tick, slice=3 gives a 60s per-relay revisit interval.
+const DEFAULT_SLICE_SIZE = (() => {
+  const raw = parseInt(process.env.NOSTR_BOT_RELAY_SLICE_SIZE, 10);
+  if (Number.isFinite(raw) && raw >= 1) return raw;
+  return 3;
+})();
+
+// Per-relay query timeout for a rotated slice. Kept below the tick
+// interval so a slow/dead relay in the slice can't push a tick past the
+// next scheduled poll (the poll loop skips re-entrant ticks).
+const DEFAULT_SLICE_QUERY_TIMEOUT_MS = (() => {
+  const raw = parseInt(process.env.NOSTR_BOT_RELAY_SLICE_TIMEOUT_MS, 10);
+  if (Number.isFinite(raw) && raw >= 1000) return raw;
+  return 8000;
+})();
+
+/**
+ * Stateful round-robin selector over a relay list. One instance per
+ * watcher; the cursor persists across poll() calls for the life of the
+ * process and resets harmlessly on restart.
+ */
+class RelayRotation {
+  constructor(options = {}) {
+    const relays = Array.isArray(options.relays) && options.relays.length > 0
+      ? options.relays
+      : RELAY_POOL;
+    this.relays = relays;
+    const requested = Number.isFinite(options.sliceSize) ? options.sliceSize : DEFAULT_SLICE_SIZE;
+    // Never ask for more relays than the pool holds.
+    this.sliceSize = Math.max(1, Math.min(requested, relays.length));
+    this.cursor = 0;
+  }
+
+  /**
+   * Return the next slice of relays, advancing (and wrapping) the
+   * cursor. Wraps cleanly even when sliceSize does not divide the pool
+   * size evenly — the next slice simply continues from where this one
+   * ended.
+   */
+  next() {
+    const out = [];
+    for (let i = 0; i < this.sliceSize; i++) {
+      out.push(this.relays[(this.cursor + i) % this.relays.length]);
+    }
+    this.cursor = (this.cursor + this.sliceSize) % this.relays.length;
+    return out;
+  }
+
+  /** Total relays in the pool (for logging). */
+  get poolSize() {
+    return this.relays.length;
+  }
+}
+
+module.exports = {
+  RELAY_POOL,
+  RelayRotation,
+  DEFAULT_SLICE_SIZE,
+  DEFAULT_SLICE_QUERY_TIMEOUT_MS,
+};


### PR DESCRIPTION
## Problem

Intermittent prod failures where mentions tagging the bot got no reply. Root cause was a mix of a local+prod instance collision **and** latent reliability bugs the collision exposed. Evidence from three real jobs: one `replied` ✅, one `failed`/"agent timeout" (terminal), and one stuck in `processing` with `processedAt: null` and no error.

This PR has two parts: **(A) reliability fixes** and **(B) a round-robin relay pool**.

---

## Part A — reliability fixes

### Root causes
1. **Orphaned `processing` rows never recovered.** `_claimNext` only selected `status: 'pending'`. Any worker that died mid-agent (crash, deploy, kill, OOM) stranded the mention in `processing` forever — no lease, no TTL. Recurs on every restart/deploy, not just collisions.
2. **`failed` mentions never retried.** A transient 504 agent timeout (the same query succeeded seconds later on another mention) became a permanent drop. `MAX_ATTEMPTS_PER_MENTION = 3` was exported but unused.
3. **`/requeue` couldn't rescue stuck jobs** — it only matched `failed`/`ignored`, not `processing`.

### Changes
- `_claimNext` now also claims `failed` and lease-expired `processing` rows, gated by `attemptCount < MAX_ATTEMPTS_PER_MENTION`. New `PROCESSING_LEASE_SECONDS` (10m ≈ 3× the 180s agent timeout) ensures an in-flight row is never reclaimed mid-work (lease keyed on `updatedAt`).
- `/requeue/:eventId` now also recovers `processing` rows and resets `attemptCount`.

**Trade-off:** reclaim is **at-least-once** — if a worker published a reply but died before persisting `replied`, the reclaim can double-post. The publish→save gap is small; accepted over silently dropping a mention.

---

## Part B — round-robin 12-relay pool

Both watchers polled a fixed 5-relay set on **every** tick, and a single dead relay (`relay.nostr.band`) silently degraded every poll cycle.

- New `utils/nostrRelayPool.js`: a **12 high-quality relay** pool (led by the relays this bot's users' clients actually publish to, observed in real mention `r` relay-hints) + a `RelayRotation` round-robin selector.
- Mention + zap **background** polls now sweep a **rotating slice (3)** instead of all relays. Cadence with the 15s tick:
  - system touches **3 fresh relays every 15s** → low detection latency
  - any **single relay polled once per 60s** → never worse than the per-relay floor
  - the 600s lookback far exceeds the 60s revisit gap, so nothing is missed; the eventId unique index absorbs re-sees.
- Server default poll interval lowered **30s → 15s** (still env-overridable).
- Zap **quickPoll** (on-demand "did this user just zap?") still sweeps the **full pool** — rare, latency-sensitive one-shot that needs breadth.
- Slice size + per-slice query timeout are env-overridable (`NOSTR_BOT_RELAY_SLICE_SIZE`, `NOSTR_BOT_RELAY_SLICE_TIMEOUT_MS`).

> Note: the relay **membership list** is the tunable part — worth a vet. The rotation mechanism is independent of which relays are in it.

---

## Testing
- New `tests/nostr-relay-pool.test.js` — rotation coverage, wrap-around, uneven slices, clamp, override (6 passing).
- `tests/zap-receipt-validator.test.js` still passes (14).
- All touched modules load cleanly.

## Rollout
Keep the bot disabled until merged + deployed, then re-enable — the lease auto-heals the existing stranded `processing` rows; no manual Mongo surgery needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
