### PR TITLE
feat(tape): self-contained /api/tape/* finance skin — Read-In, Brief, Split + cache warming

### DIFF
--- a/config/tape-company-cards.yaml
+++ b/config/tape-company-cards.yaml
@@ -1,0 +1,3180 @@
+# Tape company cards — built by scripts/build-company-cards.js
+# Backbone (name/industry/marketCap/weburl) from Finnhub; description/products/execs LLM-drafted (verify before trusting).
+AAPL:
+  name: Apple Inc
+  industry: Technology
+  marketCap: 4603311
+  weburl: https://www.apple.com/
+  description: >-
+    Apple Inc designs, manufactures, and markets consumer electronics, software, and services, known for its innovation
+    and premium products.
+  products:
+    - iPhone
+    - iPad
+    - Mac
+    - Apple Watch
+    - Apple Music
+  execs:
+    - Tim Cook
+  source: finnhub+llm
+ABBV:
+  name: AbbVie Inc
+  industry: Biotechnology
+  marketCap: 405779
+  weburl: https://www.abbvie.com/
+  description: >-
+    AbbVie Inc is a global biopharmaceutical company that focuses on developing advanced therapies for complex diseases,
+    particularly in immunology and oncology.
+  products:
+    - Humira
+    - Imbruvica
+    - Skyrizi
+    - Rinvoq
+    - Venclexta
+  execs:
+    - Richard A. Gonzalez
+  source: finnhub+llm
+ABNB:
+  name: Airbnb Inc
+  industry: Hotels, Restaurants & Leisure
+  marketCap: 80907
+  weburl: https://www.airbnb.com/
+  description: >-
+    Airbnb Inc is an online marketplace that connects people looking to rent out their homes with those looking for
+    accommodations.
+  execs:
+    - Brian Chesky
+  source: finnhub+llm
+ABT:
+  name: Abbott Laboratories
+  industry: Health Care
+  marketCap: 159707
+  weburl: https://www.abbott.com
+  description: >-
+    Abbott Laboratories is a global healthcare company that develops a wide range of medical devices, diagnostics,
+    nutrition products, and pharmaceuticals.
+  products:
+    - Ensure
+    - FreeStyle Libre
+    - Similac
+    - Tenders
+    - Alinity
+  execs:
+    - Robert B. Ford
+  source: finnhub+llm
+ADBE:
+  name: Adobe Inc
+  industry: Technology
+  marketCap: 101349
+  weburl: https://www.adobe.com/
+  description: >-
+    Adobe Inc is a multinational software company known for its creative and multimedia software products, as well as
+    digital marketing solutions.
+  products:
+    - Adobe Photoshop
+    - Adobe Illustrator
+    - Adobe Acrobat
+    - Adobe Creative Cloud
+    - Adobe Experience Cloud
+  execs:
+    - Shantanu Narayen
+  source: finnhub+llm
+AEP:
+  name: American Electric Power Company Inc
+  industry: Utilities
+  marketCap: 70679
+  weburl: https://www.aep.com/
+  description: >-
+    American Electric Power Company Inc is one of the largest electric utilities in the United States, providing
+    electricity to millions of customers across several states.
+  products:
+    - Electric Utility Services
+    - Renewable Energy
+    - Transmission Services
+    - Energy Efficiency Programs
+  execs:
+    - Nicholas K. Akins
+  source: finnhub+llm
+AMAT:
+  name: Applied Materials Inc
+  industry: Semiconductors
+  marketCap: 375854
+  weburl: https://www.appliedmaterials.com/
+  description: >-
+    Applied Materials, Inc. is a leader in materials engineering solutions used to produce advanced semiconductor, flat
+    panel display, and solar photovoltaic products.
+  products:
+    - Semiconductor Equipment
+    - Display Equipment
+    - Solar Equipment
+    - Services and Software
+    - Materials Engineering Solutions
+  execs:
+    - Gary Dickerson
+  source: finnhub+llm
+AMD:
+  name: Advanced Micro Devices Inc
+  industry: Semiconductors
+  marketCap: 792129
+  weburl: https://www.amd.com/
+  description: >-
+    Advanced Micro Devices Inc is a semiconductor company that develops computer processors and related technologies for
+    both consumer and enterprise markets.
+  products:
+    - Ryzen Processors
+    - EPYC Processors
+    - Radeon Graphics
+    - AMD Radeon Software
+    - AMD Infinity Fabric
+  execs:
+    - Lisa Su
+  source: finnhub+llm
+AMGN:
+  name: Amgen Inc
+  industry: Biotechnology
+  marketCap: 191343
+  weburl: https://www.amgen.com/
+  description: >-
+    Amgen Inc is a biotechnology company that discovers, develops, and delivers innovative human therapeutics, focusing
+    on serious illnesses.
+  products:
+    - Enbrel
+    - Neulasta
+    - Prolia
+    - Repatha
+    - Aimovig
+  execs:
+    - Robert A. Bradway
+  source: finnhub+llm
+AMT:
+  name: American Tower Corp
+  industry: Real Estate
+  marketCap: 90390
+  weburl: https://www.americantower.com/
+  description: >-
+    American Tower Corp. is a leading independent owner and operator of wireless and broadcast communications real
+    estate.
+  products:
+    - Cell towers
+    - Broadcast towers
+    - Distributed antenna systems
+    - Data centers
+  execs:
+    - Tom Bartlett
+  source: finnhub+llm
+AMZN:
+  name: Amazon.com Inc
+  industry: Retail
+  marketCap: 2724130
+  weburl: https://www.amazon.com/
+  description: >-
+    Amazon.com Inc is a multinational technology company focusing on e-commerce, cloud computing, digital streaming, and
+    artificial intelligence.
+  products:
+    - Amazon Prime
+    - Amazon Web Services (AWS)
+    - Kindle
+    - Alexa
+    - Amazon Fresh
+  execs:
+    - Andy Jassy
+  source: finnhub+llm
+ANET:
+  name: Arista Networks Inc
+  industry: Communications
+  marketCap: 197770
+  weburl: https://www.arista.com/en/
+  description: >-
+    Arista Networks Inc provides cloud networking solutions for large data center and high-frequency trading
+    environments.
+  products:
+    - CloudVision
+    - EOS (Extensible Operating System)
+    - 7500 Series Switches
+    - 7280 Series Switches
+    - Arista Cognitive Cloud Networking
+  execs:
+    - Jayshree Ullal
+  source: finnhub+llm
+APO:
+  name: Apollo Global Management Inc
+  industry: Financial Services
+  marketCap: 72837
+  weburl: https://www.apollo.com/
+  description: >-
+    Apollo Global Management Inc is an alternative investment management firm specializing in private equity, credit,
+    and real estate investments.
+  products:
+    - Apollo Private Equity
+    - Apollo Credit
+    - Apollo Real Estate
+  execs:
+    - Marc Rowan
+  source: finnhub+llm
+APP:
+  name: Applovin Corp
+  industry: Technology
+  marketCap: 190050
+  weburl: https://www.applovin.com/
+  description: >-
+    Applovin Corp is a technology company that provides a platform for mobile app developers to monetize and market
+    their applications.
+  execs:
+    - Harris B. K. K.
+  source: finnhub+llm
+ARM:
+  name: Arm Holdings PLC
+  industry: Semiconductors
+  marketCap: 418620
+  weburl: https://www.arm.com/
+  description: >-
+    Arm Holdings PLC is a semiconductor and software design company known for its ARM architecture, which is widely used
+    in mobile devices and embedded systems.
+  products:
+    - ARM Cortex Processors
+    - ARM Mali Graphics Processors
+    - ARM Neoverse Processors
+    - IoT Solutions
+    - Software Development Tools
+  source: finnhub+llm
+AVGO:
+  name: Broadcom Inc
+  industry: Semiconductors
+  marketCap: 1872538
+  weburl: https://www.broadcom.com
+  description: >-
+    Broadcom Inc is a global technology company that designs, develops, and supplies a broad range of semiconductor and
+    infrastructure software solutions.
+  products:
+    - Broadcom Wireless
+    - Broadcom Networking
+    - Broadcom Storage
+    - Broadcom Broadband
+    - Broadcom IoT
+  source: finnhub+llm
+AXP:
+  name: American Express Co
+  industry: Financial Services
+  marketCap: 211091
+  weburl: https://www.americanexpress.com/
+  description: >-
+    American Express Co is a multinational financial services corporation known for its charge card, credit card, and
+    travel-related services.
+  products:
+    - American Express Cards
+    - Travel Services
+    - Merchant Services
+    - Business Solutions
+  execs:
+    - Stephen Squeri
+  source: finnhub+llm
+BA:
+  name: Boeing Co
+  industry: Aerospace & Defense
+  marketCap: 170612
+  weburl: https://www.boeing.com
+  description: >-
+    Boeing Co is a major aerospace and defense company that designs, manufactures, and sells airplanes, rotorcraft,
+    rockets, satellites, and telecommunications equipment.
+  products:
+    - Commercial Airplanes
+    - Defense, Space & Security
+    - Global Services
+    - Boeing Business Jets
+  execs:
+    - David L. Calhoun
+  source: finnhub+llm
+BABA:
+  name: Alibaba Group Holding Ltd
+  industry: Retail
+  marketCap: 302456
+  weburl: https://www.alibabagroup.com/
+  description: >-
+    Alibaba Group Holding Ltd is a multinational conglomerate specializing in e-commerce, retail, internet, and
+    technology.
+  products:
+    - Taobao
+    - Tmall
+    - Alibaba Cloud
+    - AliExpress
+    - Ant Group
+  execs:
+    - Daniel Zhang
+  source: finnhub+llm
+BAC:
+  name: Bank of America Corp
+  industry: Banking
+  marketCap: 381335
+  weburl: https://www.bankofamerica.com
+  description: >-
+    Bank of America Corp is a multinational banking and financial services corporation that provides a wide range of
+    banking and financial products.
+  products:
+    - Consumer Banking
+    - Wealth Management
+    - Investment Banking
+    - Credit Cards
+    - Mortgages
+  execs:
+    - Brian Moynihan
+  source: finnhub+llm
+BIDU:
+  name: Baidu Inc
+  industry: Media
+  marketCap: 45887
+  weburl: https://www.baidu.com/
+  description: >-
+    Baidu Inc is a Chinese multinational technology company specializing in Internet-related services and products,
+    including search engines and AI.
+  products:
+    - Baidu Search
+    - Baidu Maps
+    - DuerOS
+    - Apollo Autonomous Driving
+  execs:
+    - Robin Li
+  source: finnhub+llm
+BIIB:
+  name: Biogen Inc
+  industry: Biotechnology
+  marketCap: 29420
+  weburl: https://www.biogen.com/
+  description: >-
+    Biogen Inc is a biotechnology company specializing in the discovery, development, and delivery of innovative
+    therapies for neurological diseases.
+  products:
+    - Aduhelm
+    - Tecfidera
+    - Avonex
+    - Tysabri
+    - Spinraza
+  execs:
+    - Christopher A. Viehbacher
+  source: finnhub+llm
+BLK:
+  name: BlackRock Inc
+  industry: Financial Services
+  marketCap: 162865
+  weburl: https://www.blackrock.com/
+  description: >-
+    BlackRock Inc is the world's largest asset manager, providing investment management, risk management, and advisory
+    services to institutional and retail clients.
+  products:
+    - iShares ETFs
+    - BlackRock Investment Management
+    - Risk Management Services
+    - Advisory Services
+  execs:
+    - Larry Fink
+  source: finnhub+llm
+BMY:
+  name: Bristol-Myers Squibb Co
+  industry: Pharmaceuticals
+  marketCap: 117644
+  weburl: https://www.bms.com
+  description: >-
+    Bristol-Myers Squibb Co is a global biopharmaceutical company focused on discovering, developing, and delivering
+    innovative medicines for serious diseases.
+  products:
+    - Opdivo
+    - Eliquis
+    - Revlimid
+    - Yervoy
+    - Abecma
+  execs:
+    - Giovanni Caforio
+  source: finnhub+llm
+BRK.B:
+  name: Berkshire Hathaway Inc
+  industry: Financial Services
+  marketCap: 1053962
+  weburl: https://www.berkshirehathaway.com/
+  description: >-
+    Berkshire Hathaway Inc is a multinational conglomerate holding company led by Warren Buffett, known for its diverse
+    range of subsidiaries and investments across various industries.
+  products:
+    - Geico
+    - BNSF Railway
+    - Berkshire Hathaway Energy
+    - Dairy Queen
+    - Fruit of the Loom
+  execs:
+    - Warren Buffett
+    - Charlie Munger
+  source: finnhub+llm
+BSX:
+  name: Boston Scientific Corp
+  industry: Health Care
+  marketCap: 73842
+  weburl: https://www.bostonscientific.com/en-US/Home.html
+  description: >-
+    Boston Scientific Corp is a global medical device company that develops and manufactures a wide range of innovative
+    medical solutions for various medical specialties.
+  products:
+    - Cardiovascular Devices
+    - Endoscopy Products
+    - Urology Devices
+    - Neuromodulation Devices
+    - Interventional Oncology Products
+  execs:
+    - Michael F. Mahoney
+  source: finnhub+llm
+BX:
+  name: Blackstone Inc
+  industry: Financial Services
+  marketCap: 141091
+  weburl: https://www.blackstone.com/
+  description: >-
+    Blackstone Inc is an investment firm specializing in private equity, real estate, credit, and hedge fund investment
+    strategies.
+  products:
+    - Blackstone Private Equity
+    - Blackstone Real Estate
+    - Blackstone Credit
+    - Blackstone Hedge Fund Solutions
+  execs:
+    - Stephen A. Schwarzman
+  source: finnhub+llm
+C:
+  name: Citigroup Inc
+  industry: Banking
+  marketCap: 227362
+  weburl: http://www.citigroup.com/
+  description: >-
+    Citigroup Inc is a global financial services corporation that provides a wide range of financial products and
+    services to consumers, corporations, governments, and institutions.
+  products:
+    - Consumer Banking
+    - Corporate Banking
+    - Investment Banking
+    - Wealth Management
+    - Credit Cards
+  execs:
+    - Jane Fraser
+  source: finnhub+llm
+CAT:
+  name: Caterpillar Inc
+  industry: Machinery
+  marketCap: 423367
+  weburl: https://www.caterpillar.com
+  description: >-
+    Caterpillar Inc is a leading manufacturer of construction and mining equipment, diesel and natural gas engines, and
+    industrial gas turbines.
+  products:
+    - Excavators
+    - Bulldozers
+    - Backhoe Loaders
+    - Generators
+    - Mining Equipment
+  execs:
+    - Jim Umpleby
+  source: finnhub+llm
+CCJ:
+  name: Cameco Corp
+  industry: Energy
+  marketCap: 46245
+  weburl: https://www.cameco.com/
+  description: Cameco Corp is one of the world's largest uranium producers, supplying fuel for nuclear power plants.
+  products:
+    - Uranium Production
+    - Fuel Services
+    - Nuclear Fuel Supply
+  execs:
+    - Tim Gitzel
+  source: finnhub+llm
+CDNS:
+  name: Cadence Design Systems Inc
+  industry: Technology
+  marketCap: 107102
+  weburl: https://www.cadence.com/en_US/home.html
+  description: Cadence Design Systems Inc offers software, hardware, and services for electronic design automation and engineering.
+  products:
+    - Allegro Platform
+    - OrCAD
+    - PSpice
+    - Xcelium
+    - JasperGold
+  execs:
+    - Anirudh Devgan
+  source: finnhub+llm
+CEG:
+  name: Constellation Energy Corp
+  industry: Utilities
+  marketCap: 92978
+  weburl: https://www.constellationenergy.com/
+  description: >-
+    Constellation Energy Corp is a leading energy company that provides electricity, natural gas, and renewable energy
+    solutions to residential and commercial customers.
+  products:
+    - Electricity Generation
+    - Natural Gas Supply
+    - Renewable Energy
+    - Energy Efficiency Solutions
+    - Retail Energy Services
+  execs:
+    - Joseph Dominguez
+  source: finnhub+llm
+CI:
+  name: Cigna Group
+  industry: Health Care
+  marketCap: 76445
+  weburl: https://www.thecignagroup.com/
+  description: >-
+    Cigna Group is a global health service company that provides health insurance and related services to individuals
+    and businesses.
+  products:
+    - Health Insurance Plans
+    - Dental Insurance
+    - Disability Insurance
+    - Medicare Plans
+    - Pharmacy Benefit Management
+  execs:
+    - David Cordani
+  source: finnhub+llm
+CL:
+  name: Colgate-Palmolive Co
+  industry: Consumer products
+  marketCap: 70497
+  weburl: https://www.colgatepalmolive.com/
+  description: >-
+    Colgate-Palmolive Company is a consumer products company specializing in oral care, personal care, home care, and
+    pet nutrition.
+  products:
+    - Colgate Toothpaste
+    - Palmolive Dish Soap
+    - Speed Stick Deodorant
+    - Softsoap
+    - Hill's Pet Nutrition
+  execs:
+    - Noel Wallace
+  source: finnhub+llm
+CMCSA:
+  name: Comcast Corp
+  industry: Telecommunication
+  marketCap: 84215
+  weburl: https://corporate.comcast.com/
+  description: >-
+    Comcast Corporation is a global media and technology company that provides cable television, internet, and phone
+    services.
+  products:
+    - Xfinity
+    - NBCUniversal
+    - Sky
+    - Comcast Business
+  execs:
+    - Brian L. Roberts
+  source: finnhub+llm
+CME:
+  name: CME Group Inc
+  industry: Financial Services
+  marketCap: 92990
+  weburl: https://www.cmegroup.com/
+  description: >-
+    CME Group Inc operates the world's largest financial derivatives exchange, offering a wide range of products across
+    various asset classes.
+  products:
+    - CME Futures
+    - CME Options
+    - CME Clearing
+    - CME Globex
+  execs:
+    - Terry Duffy
+  source: finnhub+llm
+CMG:
+  name: Chipotle Mexican Grill Inc
+  industry: Hotels, Restaurants & Leisure
+  marketCap: 37924
+  weburl: https://www.chipotle.com/
+  description: >-
+    Chipotle Mexican Grill Inc is a fast-casual restaurant chain specializing in Mexican cuisine, particularly burritos
+    and tacos made with fresh ingredients.
+  products:
+    - Burritos
+    - Tacos
+    - Salads
+    - Quesadillas
+    - Sofritas
+  execs:
+    - Brian Niccol
+  source: finnhub+llm
+COF:
+  name: Capital One Financial Corp
+  industry: Financial Services
+  marketCap: 113189
+  weburl: https://www.capitalone.com/
+  description: >-
+    Capital One Financial Corp is a bank holding company specializing in credit cards, auto loans, banking, and savings
+    accounts.
+  products:
+    - Capital One Credit Cards
+    - Auto Loans
+    - Savings Accounts
+    - Commercial Banking
+  execs:
+    - Richard D. Fairbank
+  source: finnhub+llm
+COIN:
+  name: Coinbase Global Inc
+  industry: Financial Services
+  marketCap: 39681
+  weburl: https://www.coinbase.com
+  description: >-
+    Coinbase Global Inc is a cryptocurrency exchange platform that allows users to buy, sell, and store various
+    cryptocurrencies.
+  execs:
+    - Brian Armstrong
+  source: finnhub+llm
+COP:
+  name: ConocoPhillips
+  industry: Energy
+  marketCap: 144100
+  weburl: https://www.conocophillips.com/
+  description: >-
+    ConocoPhillips is a global oil and gas exploration and production company, focusing on the development of natural
+    resources.
+  products:
+    - Crude Oil
+    - Natural Gas
+    - Natural Gas Liquids
+    - Refined Products
+    - LNG
+  execs:
+    - Ryan M. Lance
+  source: finnhub+llm
+COST:
+  name: Costco Wholesale Corp
+  industry: Retail
+  marketCap: 438299
+  weburl: https://www.costco.com/
+  description: >-
+    Costco Wholesale Corporation operates a chain of membership-only warehouse clubs, offering a wide selection of
+    merchandise at discounted prices.
+  products:
+    - Membership Warehouse Clubs
+    - Groceries
+    - Electronics
+    - Clothing
+    - Home Goods
+  execs:
+    - Craig Jelinek
+  source: finnhub+llm
+CRM:
+  name: Salesforce Inc
+  industry: Technology
+  marketCap: 152342
+  weburl: https://www.salesforce.com/
+  description: >-
+    Salesforce Inc is a cloud-based software company that provides customer relationship management (CRM) services and
+    applications focused on sales and marketing.
+  products:
+    - Sales Cloud
+    - Service Cloud
+    - Marketing Cloud
+    - Commerce Cloud
+    - Tableau
+  execs:
+    - Marc Benioff
+  source: finnhub+llm
+CRWD:
+  name: CrowdStrike Holdings Inc
+  industry: Technology
+  marketCap: 174526
+  weburl: https://ir.crowdstrike.com/
+  description: CrowdStrike Holdings Inc provides cloud-delivered endpoint protection and cybersecurity solutions.
+  products:
+    - Falcon Platform
+    - Threat Intelligence
+    - Managed Threat Hunting
+    - Endpoint Detection and Response
+    - Cloud Workload Protection
+  execs:
+    - George Kurtz
+  source: finnhub+llm
+CRWV:
+  name: CoreWeave Inc
+  industry: Technology
+  marketCap: 54584
+  weburl: https://www.coreweave.com/
+  description: >-
+    CoreWeave Inc is a cloud computing company that specializes in providing GPU-accelerated infrastructure for various
+    applications, including AI and machine learning.
+  execs:
+    - Daniel Nityanand
+  source: finnhub+llm
+CSCO:
+  name: Cisco Systems Inc
+  industry: Communications
+  marketCap: 492715
+  weburl: https://www.cisco.com/
+  description: >-
+    Cisco Systems Inc designs and sells networking hardware, software, telecommunications equipment, and high-technology
+    services.
+  products:
+    - Cisco Routers
+    - Cisco Switches
+    - Cisco Webex
+    - Cisco Meraki
+    - Cisco Security Solutions
+  execs:
+    - Chuck Robbins
+  source: finnhub+llm
+CSX:
+  name: CSX Corp
+  industry: Road & Rail
+  marketCap: 87416
+  weburl: https://www.csx.com/
+  description: >-
+    CSX Corporation is a leading transportation company that operates a rail network in the eastern United States,
+    providing freight transportation services.
+  products:
+    - Freight Rail Transportation
+    - Intermodal Services
+    - Coal Transportation
+    - Automotive Transport
+    - Agricultural Products
+  execs:
+    - James M. Foote
+  source: finnhub+llm
+CVS:
+  name: CVS Health Corp
+  industry: Health Care
+  marketCap: 122336
+  weburl: https://cvshealth.com/
+  description: >-
+    CVS Health Corp is a healthcare company that provides a range of services including pharmacy, health insurance, and
+    retail health clinics.
+  products:
+    - CVS Pharmacy
+    - Aetna Health Insurance
+    - MinuteClinic
+    - Pharmacy Benefit Management
+    - HealthHUB
+  execs:
+    - Karen S. Lynch
+  source: finnhub+llm
+CVX:
+  name: Chevron Corp
+  industry: Energy
+  marketCap: 374739
+  weburl: https://www.chevron.com/
+  description: >-
+    Chevron Corporation is a multinational energy corporation engaged in all aspects of the energy sector, including oil
+    and gas exploration, production, and refining.
+  products:
+    - Crude Oil
+    - Natural Gas
+    - Refined Products
+    - Chemicals
+    - Renewable Energy
+  execs:
+    - Michael Wirth
+  source: finnhub+llm
+D:
+  name: Dominion Energy Inc
+  industry: Utilities
+  marketCap: 59064
+  weburl: https://www.dominionenergy.com/
+  description: >-
+    Dominion Energy Inc is a power and energy company that provides electricity and natural gas to customers in the
+    eastern United States.
+  products:
+    - Electric Utility Services
+    - Natural Gas Distribution
+    - Renewable Energy
+    - Energy Storage Solutions
+  execs:
+    - Robert M. Blue
+  source: finnhub+llm
+DASH:
+  name: DoorDash Inc
+  industry: Hotels, Restaurants & Leisure
+  marketCap: 68604
+  weburl: https://www.doordash.com/
+  description: >-
+    DoorDash Inc is a food delivery service that connects customers with local restaurants through its online platform
+    and mobile app.
+  execs:
+    - Tony Xu
+  source: finnhub+llm
+DDOG:
+  name: Datadog Inc (Pre-Reincorporation)
+  industry: Technology
+  marketCap: 83652
+  weburl: https://www.datadoghq.com/
+  description: >-
+    Datadog Inc provides monitoring and analytics for cloud-scale applications, enabling organizations to understand
+    their infrastructure and applications.
+  products:
+    - Infrastructure Monitoring
+    - Application Performance Monitoring
+    - Log Management
+    - Real User Monitoring
+    - Synthetic Monitoring
+  execs:
+    - David B. Cohen
+  source: finnhub+llm
+DE:
+  name: Deere & Co
+  industry: Machinery
+  marketCap: 159379
+  weburl: https://www.deere.com/
+  description: >-
+    Deere & Co is a manufacturer of agricultural, construction, and forestry machinery, known for its iconic green and
+    yellow equipment.
+  products:
+    - Tractors
+    - Combine Harvesters
+    - Planters
+    - Construction Equipment
+    - Forestry Equipment
+  execs:
+    - John C. May
+  source: finnhub+llm
+DELL:
+  name: Dell Technologies Inc
+  industry: Technology
+  marketCap: 262239
+  weburl: https://www.dell.com/en-in
+  description: >-
+    Dell Technologies Inc designs, manufactures, and sells a wide range of technology products and services, including
+    computers and servers.
+  products:
+    - Dell XPS Laptops
+    - Dell PowerEdge Servers
+    - Dell EMC Storage Solutions
+    - Alienware Gaming PCs
+    - Dell Technologies Cloud
+  execs:
+    - Michael Dell
+  source: finnhub+llm
+DG:
+  name: Dollar General Corp
+  industry: Retail
+  marketCap: 22848
+  weburl: https://www.dollargeneral.com/
+  description: >-
+    Dollar General Corp is a discount retailer that offers a variety of products, including household goods, groceries,
+    and apparel at low prices.
+  products:
+    - Household Essentials
+    - Groceries
+    - Health and Beauty Products
+    - Seasonal Items
+    - Apparel
+  execs:
+    - Jeff Owen
+  source: finnhub+llm
+DHR:
+  name: Danaher Corp
+  industry: Life Sciences Tools & Services
+  marketCap: 130828
+  weburl: https://www.danaher.com/
+  description: >-
+    Danaher Corp is a global science and technology innovator that designs, manufactures, and markets professional,
+    medical, industrial, and commercial products.
+  products:
+    - Beckman Coulter
+    - Leica Microsystems
+    - Pall Corporation
+    - Videojet
+    - Hach
+  execs:
+    - Rainer M. Blair
+  source: finnhub+llm
+DIS:
+  name: Walt Disney Co
+  industry: Media
+  marketCap: 172835
+  weburl: https://thewaltdisneycompany.com/
+  description: The Walt Disney Company is a diversified international family entertainment and media enterprise.
+  products:
+    - Disney+
+    - ESPN
+    - ABC
+    - Marvel
+    - Pixar
+  execs:
+    - Bob Chapek
+  source: finnhub+llm
+DLTR:
+  name: Dollar Tree Inc
+  industry: Retail
+  marketCap: 21123
+  weburl: https://www.dollartree.com/
+  description: >-
+    Dollar Tree Inc is a discount variety store chain that sells items for $1 or less, including household goods, food,
+    and party supplies.
+  products:
+    - Household Items
+    - Party Supplies
+    - Food and Snacks
+    - Seasonal Decor
+    - Health and Beauty Products
+  execs:
+    - Michael Witynski
+  source: finnhub+llm
+DOW:
+  name: Dow Inc
+  industry: Chemicals
+  marketCap: 24502
+  weburl: https://investors.dow.com/
+  description: Dow Inc. is a global chemical company that produces a wide range of materials and chemicals for various industries.
+  products:
+    - Plastics
+    - Chemicals
+    - Coatings
+    - Silicones
+    - Agricultural sciences
+  execs:
+    - Jim Fitterling
+  source: finnhub+llm
+DPZ:
+  name: Domino's Pizza Inc
+  industry: Hotels, Restaurants & Leisure
+  marketCap: 10361
+  weburl: https://www.dominos.com/
+  description: >-
+    Domino's Pizza Inc is an American pizza delivery and carryout chain known for its wide variety of pizzas and side
+    dishes.
+  products:
+    - Hand-Tossed Pizza
+    - Thin Crust Pizza
+    - Stuffed Cheesy Bread
+    - Chicken Wings
+    - Pasta
+  execs:
+    - Russell Weiner
+  source: finnhub+llm
+DUK:
+  name: Duke Energy Corp
+  industry: Utilities
+  marketCap: 96654
+  weburl: https://www.duke-energy.com/
+  description: >-
+    Duke Energy Corp is one of the largest electric power holding companies in the United States, providing electricity
+    to millions of customers.
+  products:
+    - Electric Utility Services
+    - Natural Gas Distribution
+    - Renewable Energy
+    - Energy Efficiency Programs
+  execs:
+    - Lynn J. Good
+  source: finnhub+llm
+DVN:
+  name: Devon Energy Corp
+  industry: Energy
+  marketCap: 51753
+  weburl: https://www.devonenergy.com/
+  description: >-
+    Devon Energy Corp is an independent oil and natural gas exploration and production company, focusing on onshore
+    resources in North America.
+  products:
+    - Crude Oil
+    - Natural Gas
+    - Natural Gas Liquids
+    - Permian Basin
+    - Eagle Ford
+  execs:
+    - Rick Muncrief
+  source: finnhub+llm
+EA:
+  name: Electronic Arts Inc
+  industry: Media
+  marketCap: 50953
+  weburl: https://www.ea.com/
+  description: >-
+    Electronic Arts Inc is a global leader in digital interactive entertainment, known for developing and publishing
+    video games.
+  products:
+    - FIFA
+    - Madden NFL
+    - The Sims
+    - Battlefield
+    - Apex Legends
+  execs:
+    - Andrew Wilson
+  source: finnhub+llm
+EL:
+  name: Estee Lauder Companies Inc
+  industry: Consumer products
+  marketCap: 30049
+  weburl: https://www.elcompanies.com/en
+  description: >-
+    Estee Lauder Companies Inc is a multinational manufacturer and marketer of skincare, makeup, fragrance, and hair
+    care products.
+  products:
+    - Estée Lauder
+    - Clinique
+    - MAC Cosmetics
+    - Bobbi Brown
+    - La Mer
+  execs:
+    - Fabrizio Freda
+  source: finnhub+llm
+EMR:
+  name: Emerson Electric Co
+  industry: Electrical Equipment
+  marketCap: 77871
+  weburl: https://www.emerson.com/en-us
+  description: >-
+    Emerson Electric Co. is a global technology and engineering company providing solutions for industrial, commercial,
+    and residential markets.
+  products:
+    - Process Management
+    - Industrial Automation
+    - Climate Technologies
+    - Tools & Home Products
+    - Network Power
+  execs:
+    - David N. Farr
+  source: finnhub+llm
+EOG:
+  name: EOG Resources Inc
+  industry: Energy
+  marketCap: 74539
+  weburl: https://www.eogresources.com/
+  description: >-
+    EOG Resources Inc is an independent oil and natural gas company engaged in the exploration, development, and
+    production of oil and natural gas resources.
+  products:
+    - Crude Oil
+    - Natural Gas
+    - Natural Gas Liquids
+    - EOG's Eagle Ford Shale
+    - Permian Basin
+  execs:
+    - Ezra Yacob
+  source: finnhub+llm
+EQIX:
+  name: Equinix Inc
+  industry: Real Estate
+  marketCap: 107230
+  weburl: https://www.equinix.com/
+  description: >-
+    Equinix Inc. is a global data center and colocation provider, enabling businesses to connect and protect their
+    digital assets.
+  products:
+    - Data centers
+    - Colocation services
+    - Interconnection services
+    - Cloud services
+  execs:
+    - Charles Meyers
+  source: finnhub+llm
+ETN:
+  name: Eaton Corporation PLC
+  industry: Electrical Equipment
+  marketCap: 156310
+  weburl: https://www.eaton.com/
+  description: >-
+    Eaton Corporation PLC is a multinational power management company that provides energy-efficient solutions to manage
+    electrical, hydraulic, and mechanical power.
+  products:
+    - Electrical Components
+    - Hydraulics
+    - Aerospace Systems
+    - Vehicle Components
+    - Industrial Controls
+  execs:
+    - Craig Arnold
+  source: finnhub+llm
+EXC:
+  name: Exelon Corp
+  industry: Utilities
+  marketCap: 46706
+  weburl: https://www.exeloncorp.com/
+  description: >-
+    Exelon Corp is a utility services holding company that operates through its subsidiaries, providing electricity and
+    natural gas to customers.
+  products:
+    - Electric Utility Services
+    - Nuclear Power Generation
+    - Renewable Energy
+    - Energy Efficiency Programs
+  execs:
+    - Christopher M. Crane
+  source: finnhub+llm
+F:
+  name: Ford Motor Co
+  industry: Automobiles
+  marketCap: 59412
+  weburl: https://www.ford.com/
+  description: >-
+    Ford Motor Co is an American multinational automaker that designs, manufactures, markets, and services a wide range
+    of vehicles.
+  products:
+    - Ford F-Series
+    - Ford Mustang
+    - Ford Explorer
+    - Ford Escape
+    - Ford Bronco
+  execs:
+    - Jim Farley
+  source: finnhub+llm
+FANG:
+  name: Diamondback Energy Inc
+  industry: Energy
+  marketCap: 55964
+  weburl: https://ir.diamondbackenergy.com/
+  description: >-
+    Diamondback Energy Inc is an independent oil and natural gas company focused on the acquisition, exploration, and
+    development of unconventional oil and natural gas reserves in the Permian Basin.
+  products:
+    - Crude Oil
+    - Natural Gas
+    - Natural Gas Liquids
+    - Permian Basin
+    - Midstream Services
+  execs:
+    - Travis Stice
+  source: finnhub+llm
+FCX:
+  name: Freeport-McMoRan Inc
+  industry: Metals & Mining
+  marketCap: 91738
+  weburl: https://www.fcx.com/
+  description: >-
+    Freeport-McMoRan Inc. is a leading international mining company with a focus on copper, gold, and molybdenum
+    production.
+  products:
+    - Copper
+    - Gold
+    - Molybdenum
+    - Oil and gas
+    - Mining operations
+  execs:
+    - Richard C. Adkerson
+  source: finnhub+llm
+FDX:
+  name: FedEx Corp
+  industry: Logistics & Transportation
+  marketCap: 79103
+  weburl: https://www.fedex.com/en-us/home.html
+  description: >-
+    FedEx Corporation provides logistics and transportation services globally, specializing in overnight shipping and
+    freight services.
+  products:
+    - FedEx Express
+    - FedEx Ground
+    - FedEx Freight
+    - FedEx Office
+    - FedEx Logistics
+  execs:
+    - Raj Subramaniam
+  source: finnhub+llm
+GD:
+  name: General Dynamics Corp
+  industry: Aerospace & Defense
+  marketCap: 93401
+  weburl: https://www.gd.com
+  description: >-
+    General Dynamics Corp is a global aerospace and defense company that provides a wide range of products and services
+    in business aviation, combat vehicles, and information technology.
+  products:
+    - Aerospace
+    - Combat Systems
+    - Marine Systems
+    - Information Technology
+  execs:
+    - Phebe Novakovic
+  source: finnhub+llm
+GE:
+  name: General Electric Co
+  industry: Aerospace & Defense
+  marketCap: 345037
+  weburl: https://www.ge.com/
+  description: >-
+    General Electric Co is a diversified multinational conglomerate involved in various sectors including aviation,
+    healthcare, power, and renewable energy.
+  products:
+    - Aviation
+    - Healthcare
+    - Power
+    - Renewable Energy
+    - Digital Solutions
+  execs:
+    - Larry Culp
+  source: finnhub+llm
+GEV:
+  name: GE Vernova Inc
+  industry: Electrical Equipment
+  marketCap: 254558
+  weburl: https://www.gevernova.com/
+  source: finnhub+llm
+GILD:
+  name: Gilead Sciences, Inc
+  industry: Biotechnology
+  marketCap: 162341
+  weburl: https://www.gilead.com
+  description: >-
+    Gilead Sciences, Inc. is a biopharmaceutical company that discovers, develops, and commercializes innovative
+    medicines in areas of unmet medical need.
+  products:
+    - HIV Medicines
+    - Hepatitis C Treatments
+    - Antiviral Therapies
+    - Oncology Products
+    - Inflammation Treatments
+  execs:
+    - Daniel O'Day
+  source: finnhub+llm
+GIS:
+  name: General Mills Inc
+  industry: Food Products
+  marketCap: 17459
+  weburl: https://www.generalmills.com/
+  description: >-
+    General Mills Inc is a multinational manufacturer and marketer of branded consumer foods, known for its wide range
+    of products in the grocery sector.
+  products:
+    - Cheerios
+    - Betty Crocker
+    - Yoplait
+    - Pillsbury
+    - Nature Valley
+  execs:
+    - Jeff Harmening
+  source: finnhub+llm
+GLW:
+  name: Corning Inc
+  industry: Electrical Equipment
+  marketCap: 158697
+  weburl: https://www.corning.com/
+  description: Corning Inc. is a technology company that specializes in glass, ceramics, and related materials and technologies.
+  products:
+    - Gorilla Glass
+    - Optical fiber
+    - Display technologies
+    - Environmental technologies
+    - Life sciences
+  execs:
+    - Wendell P. Weeks
+  source: finnhub+llm
+GM:
+  name: General Motors Co
+  industry: Automobiles
+  marketCap: 74320
+  weburl: https://www.gm.com/
+  description: >-
+    General Motors Co is a global automotive company that designs, manufactures, and sells vehicles and vehicle parts,
+    and provides automotive financing services.
+  products:
+    - Chevrolet
+    - GMC
+    - Cadillac
+    - Buick
+    - OnStar
+  execs:
+    - Mary Barra
+  source: finnhub+llm
+GOLD:
+  name: Gold.com Inc
+  industry: Distributors
+  marketCap: 1132
+  weburl: https://www.gold.com/
+  source: finnhub+llm
+GOOG:
+  name: Alphabet Inc
+  industry: Media
+  marketCap: 4467169
+  weburl: https://abc.xyz/
+  description: >-
+    Alphabet Inc is the parent company of Google, focusing on internet services and products, including search engines
+    and online advertising.
+  products:
+    - Google Search
+    - YouTube
+    - Google Cloud
+    - Android
+    - Google Ads
+  execs:
+    - Sundar Pichai
+  source: finnhub+llm
+GOOGL:
+  name: Alphabet Inc
+  industry: Media
+  marketCap: 4467169
+  weburl: https://abc.xyz/
+  description: >-
+    Alphabet Inc is the parent company of Google, specializing in internet-related services and products, including
+    search engines, online advertising, and cloud computing.
+  products:
+    - Google Search
+    - YouTube
+    - Google Cloud
+    - Android
+    - Google Ads
+  execs:
+    - Sundar Pichai
+  source: finnhub+llm
+GS:
+  name: Goldman Sachs Group Inc
+  industry: Financial Services
+  marketCap: 313525
+  weburl: https://www.goldmansachs.com/
+  description: >-
+    Goldman Sachs Group Inc is a leading global investment banking, securities, and investment management firm that
+    provides a wide range of financial services.
+  products:
+    - Investment Banking
+    - Asset Management
+    - Securities Trading
+    - Wealth Management
+    - Research
+  execs:
+    - David Solomon
+  source: finnhub+llm
+HAL:
+  name: Halliburton Co
+  industry: Energy
+  marketCap: 33550
+  weburl: https://www.halliburton.com/
+  description: >-
+    Halliburton Co is a multinational corporation that provides products and services to the energy industry,
+    particularly in oil and natural gas exploration and production.
+  products:
+    - Drilling Services
+    - Completion Services
+    - Production Enhancement
+    - Reservoir Management
+    - Oilfield Chemicals
+  execs:
+    - Jeff Miller
+  source: finnhub+llm
+HD:
+  name: Home Depot Inc
+  industry: Retail
+  marketCap: 309690
+  weburl: https://www.homedepot.com/
+  description: >-
+    The Home Depot, Inc. is a home improvement retailer that sells tools, construction products, appliances, and
+    services.
+  products:
+    - Tools
+    - Lumber
+    - Appliances
+    - Garden Supplies
+    - Home Improvement Services
+  execs:
+    - Ted Decker
+  source: finnhub+llm
+HON:
+  name: Honeywell International Inc
+  industry: Industrial Conglomerates
+  marketCap: 137737
+  weburl: https://www.honeywell.com/us/en
+  description: >-
+    Honeywell International Inc is a multinational conglomerate that produces a variety of commercial and consumer
+    products, engineering services, and aerospace systems.
+  products:
+    - Aerospace Systems
+    - Building Technologies
+    - Performance Materials
+    - Safety and Productivity Solutions
+  execs:
+    - Darius Adamczyk
+  source: finnhub+llm
+HOOD:
+  name: Robinhood Markets Inc
+  industry: Financial Services
+  marketCap: 74673
+  weburl: https://robinhood.com
+  description: >-
+    Robinhood Markets Inc is a financial services company that offers commission-free trading of stocks, ETFs, and
+    cryptocurrencies through its mobile app.
+  execs:
+    - Vladimir Tenev
+  source: finnhub+llm
+HPQ:
+  name: HP Inc
+  industry: Technology
+  marketCap: 23233
+  weburl: https://investor.hp.com/
+  description: HP Inc focuses on personal computers, printers, and related supplies and services.
+  products:
+    - HP Spectre Laptops
+    - HP LaserJet Printers
+    - HP Envy Series
+    - HP Instant Ink
+    - HP Gaming PCs
+  execs:
+    - Enrique Lores
+  source: finnhub+llm
+HUM:
+  name: Humana Inc
+  industry: Health Care
+  marketCap: 41535
+  weburl: https://www.humana.com/
+  description: >-
+    Humana Inc is a health insurance company that offers a variety of health and wellness products and services,
+    primarily focused on Medicare and Medicaid.
+  products:
+    - Medicare Advantage Plans
+    - Medicare Prescription Drug Plans
+    - Individual and Family Plans
+    - Group Health Insurance
+    - Wellness Programs
+  execs:
+    - Bruce D. Broussard
+  source: finnhub+llm
+IBM:
+  name: International Business Machines Corp
+  industry: Technology
+  marketCap: 268173
+  weburl: https://www.ibm.com/
+  description: >-
+    International Business Machines Corp provides a wide range of technology and consulting services, including cloud
+    computing and AI.
+  products:
+    - IBM Cloud
+    - IBM Watson
+    - IBM Z Mainframes
+    - IBM Security Solutions
+    - IBM Blockchain
+  execs:
+    - Arvind Krishna
+  source: finnhub+llm
+ICE:
+  name: Intercontinental Exchange Inc
+  industry: Financial Services
+  marketCap: 79008
+  weburl: https://www.ice.com/
+  description: >-
+    Intercontinental Exchange Inc is a global operator of exchanges and clearinghouses, providing trading and risk
+    management services across various asset classes.
+  products:
+    - ICE Futures
+    - ICE Clear
+    - NYSE
+    - Data Services
+  execs:
+    - Jeffrey C. Sprecher
+  source: finnhub+llm
+INTC:
+  name: Intel Corp
+  industry: Semiconductors
+  marketCap: 520493
+  weburl: https://www.intel.com/
+  description: >-
+    Intel Corporation is a multinational corporation and technology company known for designing and manufacturing
+    advanced integrated digital technology platforms, primarily semiconductors.
+  products:
+    - Microprocessors
+    - Chipsets
+    - Solid-State Drives (SSDs)
+    - FPGA (Field-Programmable Gate Arrays)
+    - Networking Products
+  execs:
+    - Pat Gelsinger
+  source: finnhub+llm
+ISRG:
+  name: Intuitive Surgical Inc
+  industry: Health Care
+  marketCap: 150764
+  weburl: https://www.intuitive.com/en-us/about-us/company
+  description: >-
+    Intuitive Surgical Inc is a global technology leader in robotic-assisted minimally invasive surgery, known for its
+    da Vinci Surgical System.
+  products:
+    - da Vinci Surgical System
+    - Ion Endoluminal System
+    - EndoWrist Instruments
+    - Surgical Simulators
+    - Intuitive Surgical Services
+  execs:
+    - Gary Guthart
+  source: finnhub+llm
+ITW:
+  name: Illinois Tool Works Inc
+  industry: Machinery
+  marketCap: 72800
+  weburl: https://www.itw.com/
+  description: >-
+    Illinois Tool Works Inc. is a diversified manufacturer of industrial equipment and consumables, serving various
+    markets worldwide.
+  products:
+    - Packaging Solutions
+    - Welding Products
+    - Polymers & Fluids
+    - Food Equipment
+    - Construction Products
+  execs:
+    - E. Scott Santi
+  source: finnhub+llm
+JD:
+  name: JD.com Inc
+  industry: Retail
+  marketCap: 279030
+  weburl: https://corporate.jd.com/
+  description: >-
+    JD.com Inc is a major Chinese e-commerce company that offers a wide range of products and services, including direct
+    sales and third-party marketplace.
+  products:
+    - JD Mall
+    - JD Logistics
+    - JD Health
+  execs:
+    - Xu Lei
+  source: finnhub+llm
+JNJ:
+  name: Johnson & Johnson
+  industry: Pharmaceuticals
+  marketCap: 561592
+  weburl: https://www.jnj.com/
+  description: >-
+    Johnson & Johnson is a multinational corporation that develops medical devices, pharmaceuticals, and consumer health
+    products, focusing on innovation and quality.
+  products:
+    - Tylenol
+    - Band-Aid
+    - Neutrogena
+    - Johnson's Baby
+    - Janssen Pharmaceuticals
+  execs:
+    - Joaquin Duato
+  source: finnhub+llm
+JPM:
+  name: JPMorgan Chase & Co
+  industry: Banking
+  marketCap: 834802
+  weburl: https://www.jpmorganchase.com/
+  description: >-
+    JPMorgan Chase & Co is a leading global financial services firm that provides investment banking, financial
+    services, and asset management.
+  products:
+    - Investment Banking
+    - Asset Management
+    - Commercial Banking
+    - Consumer Banking
+    - Credit Cards
+  execs:
+    - Jamie Dimon
+  source: finnhub+llm
+KHC:
+  name: Kraft Heinz Co
+  industry: Food Products
+  marketCap: 26378
+  weburl: https://www.kraftheinzcompany.com/
+  description: >-
+    Kraft Heinz Co is a global food and beverage company formed by the merger of Kraft Foods and H.J. Heinz Company,
+    known for its diverse portfolio of iconic brands.
+  products:
+    - Heinz Ketchup
+    - Oscar Mayer
+    - Craft Singles
+    - Jello
+    - Velveeta
+  execs:
+    - Miguel Patricio
+  source: finnhub+llm
+KKR:
+  name: KKR & Co Inc
+  industry: Financial Services
+  marketCap: 83816
+  weburl: https://ir.kkr.com/
+  description: >-
+    KKR & Co Inc is a global investment firm that manages multiple asset classes including private equity, energy,
+    infrastructure, real estate, and credit.
+  products:
+    - KKR Private Equity
+    - KKR Credit
+    - KKR Real Estate
+    - KKR Infrastructure
+  execs:
+    - Henry Kravis
+  source: finnhub+llm
+KLAC:
+  name: KLA Corp
+  industry: Semiconductors
+  marketCap: 260507
+  weburl: https://www.kla.com/
+  description: >-
+    KLA Corporation is a global leader in process control and yield management solutions for the semiconductor and
+    related industries.
+  products:
+    - Wafer Inspection Systems
+    - Metrology Systems
+    - Yield Management Solutions
+    - Software Solutions
+    - Services
+  execs:
+    - Tsu-Jae Liu
+  source: finnhub+llm
+KMI:
+  name: Kinder Morgan Inc
+  industry: Energy
+  marketCap: 70827
+  weburl: https://www.kindermorgan.com/
+  description: >-
+    Kinder Morgan Inc is one of the largest energy infrastructure companies in North America, primarily involved in the
+    transportation and storage of natural gas, crude oil, and other products.
+  products:
+    - Natural Gas Pipelines
+    - Crude Oil Pipelines
+    - Terminals
+    - Natural Gas Storage
+    - CO2 Services
+  execs:
+    - Steven J. Kean
+  source: finnhub+llm
+KO:
+  name: Coca-Cola Co
+  industry: Beverages
+  marketCap: 341337
+  weburl: https://www.coca-colacompany.com/
+  description: >-
+    The Coca-Cola Company is a beverage corporation that produces and sells non-alcoholic beverages, primarily
+    carbonated soft drinks.
+  products:
+    - Coca-Cola
+    - Diet Coke
+    - Sprite
+    - Fanta
+    - Coca-Cola Zero Sugar
+  execs:
+    - James Quincey
+  source: finnhub+llm
+KR:
+  name: Kroger Co
+  industry: Retail
+  marketCap: 38905
+  weburl: https://www.thekrogerco.com/
+  description: >-
+    Kroger Co is one of the largest supermarket chains in the United States, offering groceries, pharmacy services, and
+    various household products.
+  products:
+    - Kroger Grocery Stores
+    - Kroger Pharmacy
+    - Kroger Fuel Centers
+    - Private Label Brands
+    - Kroger Delivery
+  execs:
+    - William McMullen
+  source: finnhub+llm
+LCID:
+  name: Lucid Group Inc
+  industry: Automobiles
+  marketCap: 2022
+  weburl: https://www.lucidmotors.com/
+  description: Lucid Group Inc designs and manufactures electric vehicles, focusing on luxury and performance.
+  products:
+    - Lucid Air
+    - Lucid Gravity
+  execs:
+    - Peter Rawlinson
+  source: finnhub+llm
+LIN:
+  name: Linde PLC
+  industry: Chemicals
+  marketCap: 237980
+  weburl: https://www.linde.com/
+  description: >-
+    Linde PLC is a global leader in industrial gases and engineering, providing products and services to various
+    industries.
+  products:
+    - Industrial Gases
+    - Healthcare Solutions
+    - Engineering Services
+    - Specialty Gases
+  execs:
+    - Severin Schwan
+  source: finnhub+llm
+LLY:
+  name: Eli Lilly and Co
+  industry: Pharmaceuticals
+  marketCap: 1092378
+  weburl: https://www.lilly.com/
+  description: >-
+    Eli Lilly and Co is a global pharmaceutical company that focuses on developing innovative medicines for various
+    health conditions, including diabetes and cancer.
+  products:
+    - Humalog
+    - Trulicity
+    - Cyramza
+    - Taltz
+    - Verzenio
+  execs:
+    - David A. Ricks
+  source: finnhub+llm
+LMT:
+  name: Lockheed Martin Corp
+  industry: Aerospace & Defense
+  marketCap: 120912
+  weburl: https://www.lockheedmartin.com/
+  description: >-
+    Lockheed Martin Corp is a global aerospace, defense, and security company that specializes in advanced technology
+    systems and services.
+  products:
+    - Aeronautics
+    - Missiles and Fire Control
+    - Rotary and Mission Systems
+    - Space Systems
+  execs:
+    - James Taiclet
+  source: finnhub+llm
+LNG:
+  name: Cheniere Energy Inc
+  industry: Energy
+  marketCap: 50313
+  weburl: https://www.cheniere.com/
+  description: >-
+    Cheniere Energy Inc is a leading producer of liquefied natural gas (LNG) in the United States, focusing on LNG
+    export facilities and related infrastructure.
+  products:
+    - LNG Exports
+    - Sabine Pass LNG Terminal
+    - Corpus Christi LNG Terminal
+    - Natural Gas Supply
+    - LNG Shipping
+  execs:
+    - Jack Fusco
+  source: finnhub+llm
+LOW:
+  name: Lowe's Companies Inc
+  industry: Retail
+  marketCap: 118225
+  weburl: https://www.lowes.com/
+  description: >-
+    Lowe's Companies, Inc. is a home improvement retailer that provides a variety of products and services for home
+    improvement, repair, and maintenance.
+  products:
+    - Home Improvement Products
+    - Lawn and Garden Supplies
+    - Appliances
+    - Tools
+    - Building Materials
+  execs:
+    - Marvin Ellison
+  source: finnhub+llm
+LRCX:
+  name: Lam Research Corp
+  industry: Semiconductors
+  marketCap: 396819
+  weburl: https://www.lamresearch.com/
+  description: >-
+    Lam Research Corporation is a supplier of wafer fabrication equipment and services to the semiconductor industry,
+    focusing on etch and deposition technologies.
+  products:
+    - Etch Systems
+    - Deposition Systems
+    - Plasma Doping Systems
+    - Services and Support
+    - Advanced Technology Solutions
+  execs:
+    - Tim Archer
+  source: finnhub+llm
+LULU:
+  name: Lululemon Athletica Inc
+  industry: Textiles, Apparel & Luxury Goods
+  marketCap: 13557
+  weburl: https://shop.lululemon.com/
+  description: >-
+    Lululemon Athletica Inc is a Canadian athletic apparel retailer known for its high-quality yoga and workout
+    clothing.
+  products:
+    - Yoga Pants
+    - Athletic Tops
+    - Shorts
+    - Outerwear
+    - Accessories
+  execs:
+    - Calvin McDonald
+  source: finnhub+llm
+MA:
+  name: Mastercard Inc
+  industry: Financial Services
+  marketCap: 429740
+  weburl: https://www.mastercard.us/
+  description: >-
+    Mastercard Inc is a technology company in the global payments industry, providing transaction processing and payment
+    solutions to consumers and businesses.
+  products:
+    - Mastercard Payment Gateway
+    - Mastercard Send
+    - Mastercard Identity Check
+    - Mastercard Rewards
+  execs:
+    - Michael Miebach
+  source: finnhub+llm
+MCD:
+  name: McDonald's Corp
+  industry: Hotels, Restaurants & Leisure
+  marketCap: 197841
+  weburl: https://www.mcdonalds.com/
+  description: McDonald's Corporation is a global fast-food restaurant chain known for its hamburgers, fries, and breakfast items.
+  products:
+    - Burgers
+    - Fries
+    - Breakfast Items
+    - Salads
+    - McCafé Beverages
+  execs:
+    - Chris Kempczinski
+  source: finnhub+llm
+MDLZ:
+  name: Mondelez International Inc
+  industry: Food Products
+  marketCap: 79625
+  weburl: https://www.mondelezinternational.com/
+  description: >-
+    Mondelez International, Inc. is a multinational confectionery, food, and beverage company known for its snack
+    products.
+  products:
+    - Oreo
+    - Cadbury
+    - Toblerone
+    - Triscuit
+    - BelVita
+  execs:
+    - Dirk Van de Put
+  source: finnhub+llm
+MDT:
+  name: Medtronic PLC
+  industry: Health Care
+  marketCap: 105542
+  weburl: https://www.medtronic.com/
+  description: >-
+    Medtronic PLC is a global leader in medical technology, services, and solutions, focused on alleviating pain,
+    restoring health, and extending life.
+  products:
+    - Insulin Pumps
+    - Pacemakers
+    - Spinal Implants
+    - Heart Valves
+    - Neuromodulation Devices
+  execs:
+    - Geoff Martha
+  source: finnhub+llm
+META:
+  name: Meta Platforms Inc
+  industry: Media
+  marketCap: 1553007
+  weburl: https://www.meta.com/
+  description: >-
+    Meta Platforms Inc, formerly Facebook, Inc., is a technology company that focuses on social media services and
+    products, as well as virtual and augmented reality.
+  products:
+    - Facebook
+    - Instagram
+    - WhatsApp
+    - Oculus
+    - Messenger
+  execs:
+    - Mark Zuckerberg
+  source: finnhub+llm
+MMM:
+  name: 3M Co
+  industry: Industrial Conglomerates
+  marketCap: 80128
+  weburl: https://www.3m.com/
+  description: >-
+    3M Co is a diversified technology company known for its innovative products across various sectors including
+    healthcare, consumer goods, and industrial applications.
+  products:
+    - Adhesives
+    - Medical Products
+    - Consumer Products
+    - Industrial Solutions
+    - Safety and Graphics
+  execs:
+    - Mike Roman
+  source: finnhub+llm
+MO:
+  name: Altria Group Inc
+  industry: Tobacco
+  marketCap: 120366
+  weburl: https://www.altria.com/
+  description: >-
+    Altria Group Inc is an American corporation that is one of the world's largest producers and marketers of tobacco,
+    cigarettes, and related products.
+  products:
+    - Marlboro
+    - Virginia Slims
+    - Black & Mild
+    - Skoal
+    - Copenhagen
+  execs:
+    - Billy Gifford
+  source: finnhub+llm
+MPC:
+  name: Marathon Petroleum Corp
+  industry: Energy
+  marketCap: 78042
+  weburl: https://www.marathonpetroleum.com/
+  description: >-
+    Marathon Petroleum Corp is a leading, integrated, downstream energy company that operates refineries and markets
+    petroleum products.
+  products:
+    - Refining
+    - Retail Fuels
+    - Midstream Services
+    - Marathon Brand Fuels
+    - Marathon Gas Stations
+  execs:
+    - Michael J. Hennigan
+  source: finnhub+llm
+MRK:
+  name: Merck & Co Inc
+  industry: Pharmaceuticals
+  marketCap: 303492
+  weburl: https://www.merck.com/
+  description: >-
+    Merck & Co Inc is a global healthcare company that develops prescription medicines, vaccines, biologic therapies,
+    and animal health products.
+  products:
+    - Keytruda
+    - Gardasil
+    - Januvia
+    - Zetia
+    - Merck Animal Health
+  execs:
+    - Robert M. Davis
+  source: finnhub+llm
+MRNA:
+  name: Moderna Inc
+  industry: Biotechnology
+  marketCap: 19415
+  weburl: https://www.modernatx.com/
+  description: >-
+    Moderna Inc is a biotechnology company pioneering messenger RNA (mRNA) therapeutics and vaccines, notably known for
+    its COVID-19 vaccine.
+  products:
+    - mRNA-1273 (COVID-19 Vaccine)
+    - mRNA Cancer Vaccines
+    - Influenza Vaccine
+    - Zika Virus Vaccine
+    - Cytomegalovirus Vaccine
+  execs:
+    - Stéphane Bancel
+  source: finnhub+llm
+MS:
+  name: Morgan Stanley
+  industry: Financial Services
+  marketCap: 338217
+  weburl: https://www.morganstanley.com/
+  description: >-
+    Morgan Stanley is a global financial services firm that provides investment banking, securities, wealth management,
+    and investment management services.
+  products:
+    - Investment Banking
+    - Wealth Management
+    - Institutional Securities
+    - Investment Management
+  execs:
+    - James Gorman
+  source: finnhub+llm
+MSFT:
+  name: Microsoft Corp
+  industry: Technology
+  marketCap: 3128857
+  weburl: https://www.microsoft.com/en-in/
+  description: >-
+    Microsoft Corp develops, licenses, and supports a wide range of software products, services, and devices, primarily
+    known for its operating systems and productivity software.
+  products:
+    - Windows
+    - Microsoft Office
+    - Azure
+    - Xbox
+    - LinkedIn
+  execs:
+    - Satya Nadella
+  source: finnhub+llm
+MSTR:
+  name: Strategy Inc
+  industry: Technology
+  marketCap: 41095
+  weburl: https://www.strategy.com/
+  description: >-
+    MicroStrategy Inc is a business intelligence company that provides software solutions for data analytics and mobile
+    intelligence.
+  source: finnhub+llm
+MU:
+  name: Micron Technology Inc
+  industry: Semiconductors
+  marketCap: 1041350
+  weburl: https://www.micron.com/
+  description: >-
+    Micron Technology, Inc. is a global leader in memory and storage solutions, providing innovative memory technologies
+    and products for a wide range of applications.
+  products:
+    - DRAM
+    - NAND Flash Memory
+    - Solid-State Drives (SSDs)
+    - 3D NAND
+    - Memory Modules
+  execs:
+    - Sanjay Mehrotra
+  source: finnhub+llm
+NEE:
+  name: Nextera Energy Inc
+  industry: Utilities
+  marketCap: 178213
+  weburl: https://www.nexteraenergy.com/
+  description: >-
+    NextEra Energy Inc is a clean energy company that generates renewable energy from wind and solar projects and is
+    also involved in the utility sector.
+  products:
+    - NextEra Energy Resources
+    - Florida Power & Light Company
+    - Renewable Energy Projects
+    - Energy Storage Solutions
+  execs:
+    - James L. Robo
+  source: finnhub+llm
+NEM:
+  name: Newmont Corporation
+  industry: Metals & Mining
+  marketCap: 108463
+  weburl: https://newmont.com/
+  description: >-
+    Newmont Corporation is the world's largest gold mining company, engaged in the exploration, mining, and production
+    of gold.
+  products:
+    - Gold
+    - Copper
+    - Silver
+    - Exploration
+    - Mining operations
+  execs:
+    - Tom Palmer
+  source: finnhub+llm
+NET:
+  name: Cloudflare Inc
+  industry: Technology
+  marketCap: 89531
+  weburl: https://www.cloudflare.com/
+  description: >-
+    Cloudflare Inc offers content delivery network services, internet security, and distributed domain name server
+    services.
+  products:
+    - Cloudflare CDN
+    - Cloudflare Workers
+    - Cloudflare Access
+    - Cloudflare Magic Transit
+    - Cloudflare DDoS Protection
+  execs:
+    - Matthew Prince
+  source: finnhub+llm
+NFLX:
+  name: Netflix Inc
+  industry: Media
+  marketCap: 342569
+  weburl: https://www.netflix.com/
+  description: >-
+    Netflix Inc is a streaming service that offers a wide variety of award-winning TV shows, movies, anime,
+    documentaries, and more.
+  products:
+    - Netflix Streaming
+    - Netflix Originals
+    - DVD Rental Service
+  execs:
+    - Ted Sarandos
+    - Greg Peters
+  source: finnhub+llm
+NIO:
+  name: NIO Inc
+  industry: Automobiles
+  marketCap: 13568
+  weburl: https://ir.nio.com/
+  description: >-
+    NIO Inc is a Chinese electric vehicle manufacturer known for its premium electric cars and innovative
+    battery-swapping technology.
+  products:
+    - ES6
+    - ES8
+    - EC6
+    - ET7
+    - NIO Power Swap
+  execs:
+    - William Li
+  source: finnhub+llm
+NKE:
+  name: Nike Inc
+  industry: Textiles, Apparel & Luxury Goods
+  marketCap: 63523
+  weburl: https://about.nike.com/
+  description: >-
+    Nike, Inc. is a multinational corporation that designs, develops, and sells athletic footwear, apparel, equipment,
+    and accessories.
+  products:
+    - Footwear
+    - Apparel
+    - Sports Equipment
+    - Athletic Accessories
+    - Nike+ Services
+  execs:
+    - John Donahoe
+  source: finnhub+llm
+NOC:
+  name: Northrop Grumman Corp
+  industry: Aerospace & Defense
+  marketCap: 77574
+  weburl: https://www.northropgrumman.com
+  description: >-
+    Northrop Grumman Corp is an aerospace and defense technology company that provides innovative systems and solutions
+    in autonomous systems, cyber, C4ISR, and logistics.
+  products:
+    - Aerospace Systems
+    - Defense Systems
+    - Cybersecurity Solutions
+    - Space Systems
+  execs:
+    - Kathy Warden
+  source: finnhub+llm
+NOW:
+  name: ServiceNow Inc
+  industry: Technology
+  marketCap: 117497
+  weburl: https://www.servicenow.com/
+  description: >-
+    ServiceNow Inc. is a cloud computing company that provides enterprise cloud solutions for digital workflows and IT
+    service management.
+  products:
+    - IT Service Management (ITSM)
+    - IT Operations Management (ITOM)
+    - Customer Service Management (CSM)
+    - HR Service Delivery
+    - Security Operations
+  execs:
+    - Bill McDermott
+  source: finnhub+llm
+NUE:
+  name: Nucor Corp
+  industry: Metals & Mining
+  marketCap: 58819
+  weburl: https://nucor.com/
+  description: Nucor Corp is a leading steel producer in North America, specializing in steel and steel products.
+  products:
+    - Steel
+    - Rebar
+    - Sheet steel
+    - Structural steel
+    - Steel joists
+  execs:
+    - Leon Topalian
+  source: finnhub+llm
+NVDA:
+  name: NVIDIA Corp
+  industry: Semiconductors
+  marketCap: 5034931
+  weburl: https://www.nvidia.com/
+  description: >-
+    NVIDIA Corp is a technology company primarily known for its graphics processing units (GPUs) for gaming and
+    professional markets, as well as AI and deep learning technologies.
+  products:
+    - GeForce GPUs
+    - Tegra processors
+    - NVIDIA AI
+    - NVIDIA RTX
+    - NVIDIA Omniverse
+  execs:
+    - Jensen Huang
+  source: finnhub+llm
+O:
+  name: Realty Income Corp
+  industry: Real Estate
+  marketCap: 56593
+  weburl: https://www.realtyincome.com/
+  description: >-
+    Realty Income Corp. is a real estate investment trust (REIT) known for its monthly dividend payments and a portfolio
+    of commercial properties.
+  products:
+    - Retail properties
+    - Commercial real estate
+    - Single-tenant properties
+  execs:
+    - Sumit Roy
+  source: finnhub+llm
+OKLO:
+  name: Oklo Inc
+  industry: Utilities
+  marketCap: 10339
+  weburl: https://oklo.com/
+  description: Oklo Inc is a company focused on developing compact nuclear reactors for clean energy generation.
+  source: finnhub+llm
+ORCL:
+  name: Oracle Corp
+  industry: Technology
+  marketCap: 626432
+  weburl: https://www.oracle.com/
+  description: >-
+    Oracle Corp is a multinational computer technology corporation that offers software, cloud solutions, and hardware
+    products, primarily known for its database management systems.
+  products:
+    - Oracle Database
+    - Oracle Cloud
+    - Java
+    - Oracle Applications
+    - Oracle Fusion Middleware
+  execs:
+    - Safra Catz
+  source: finnhub+llm
+OXY:
+  name: Occidental Petroleum Corp
+  industry: Energy
+  marketCap: 57316
+  weburl: https://www.oxy.com/
+  description: >-
+    Occidental Petroleum Corp is an international oil and gas exploration and production company, with a focus on
+    sustainable practices and carbon management.
+  products:
+    - Crude Oil
+    - Natural Gas
+    - Chemicals
+    - Oxy Low Carbon Ventures
+    - Permian Basin
+  execs:
+    - Vicki Hollub
+  source: finnhub+llm
+PANW:
+  name: Palo Alto Networks Inc
+  industry: Technology
+  marketCap: 224769
+  weburl: https://www.paloaltonetworks.com/
+  description: >-
+    Palo Alto Networks Inc. is a cybersecurity company that provides advanced firewalls and cloud-based security
+    solutions to protect organizations from cyber threats.
+  products:
+    - Next-Generation Firewalls
+    - Cloud Security Solutions
+    - Endpoint Protection
+    - Threat Intelligence Services
+    - Security Operations
+  execs:
+    - Nikesh Arora
+  source: finnhub+llm
+PDD:
+  name: PDD Holdings Inc
+  industry: Retail
+  marketCap: 122241
+  weburl: https://www.pddholdings.com/
+  description: PDD Holdings Inc operates Pinduoduo, a Chinese e-commerce platform that connects consumers and farmers directly.
+  products:
+    - Pinduoduo
+    - Duoduo Grocery
+  source: finnhub+llm
+PEP:
+  name: PepsiCo Inc
+  industry: Beverages
+  marketCap: 195790
+  weburl: https://www.pepsico.com/
+  description: >-
+    PepsiCo, Inc. is a multinational food and beverage corporation known for its wide range of snacks, beverages, and
+    food products.
+  products:
+    - Pepsi
+    - Mountain Dew
+    - Lay's
+    - Gatorade
+    - Quaker Oats
+  execs:
+    - Ramon Laguarta
+  source: finnhub+llm
+PFE:
+  name: Pfizer Inc
+  industry: Pharmaceuticals
+  marketCap: 148670
+  weburl: https://www.pfizer.com/
+  description: >-
+    Pfizer Inc is a leading global pharmaceutical company known for its research and development of medications and
+    vaccines across a wide range of therapeutic areas.
+  products:
+    - Lipitor
+    - Viagra
+    - Prevnar
+    - Ibrance
+    - Comirnaty
+  execs:
+    - Albert Bourla
+  source: finnhub+llm
+PG:
+  name: Procter & Gamble Co
+  industry: Consumer products
+  marketCap: 338345
+  weburl: https://us.pg.com/
+  description: >-
+    Procter & Gamble Co. is a consumer goods corporation that produces a wide range of personal care and hygiene
+    products.
+  products:
+    - Tide
+    - Pampers
+    - Gillette
+    - Crest
+    - Head & Shoulders
+  execs:
+    - Jon Moeller
+  source: finnhub+llm
+PH:
+  name: Parker-Hannifin Corp
+  industry: Machinery
+  marketCap: 112435
+  weburl: https://www.parker.com/us/en/home.html
+  description: >-
+    Parker-Hannifin Corporation is a global leader in motion and control technologies, providing precision-engineered
+    solutions for a wide range of industries.
+  products:
+    - Hydraulic Systems
+    - Pneumatic Systems
+    - Filtration Products
+    - Sealing Solutions
+    - Motion Control
+  execs:
+    - Thomas L. Williams
+  source: finnhub+llm
+PLD:
+  name: Prologis Inc
+  industry: Real Estate
+  marketCap: 138240
+  weburl: https://www.prologis.com/
+  description: >-
+    Prologis Inc. is a leading global logistics real estate investment trust (REIT) that focuses on industrial
+    properties.
+  products:
+    - Logistics facilities
+    - Distribution centers
+    - Industrial real estate
+    - Warehousing solutions
+  execs:
+    - Hamid R. Moghadam
+  source: finnhub+llm
+PLTR:
+  name: Palantir Technologies Inc
+  industry: Technology
+  marketCap: 329535
+  weburl: https://www.palantir.com/
+  description: >-
+    Palantir Technologies Inc. is a public American software company that specializes in big data analytics and provides
+    platforms for integrating, visualizing, and analyzing data.
+  products:
+    - Palantir Foundry
+    - Palantir Gotham
+    - Data Integration Solutions
+    - Analytics Tools
+    - AI and Machine Learning Solutions
+  execs:
+    - Alexander Karp
+  source: finnhub+llm
+PM:
+  name: Philip Morris International Inc
+  industry: Tobacco
+  marketCap: 275912
+  weburl: https://www.pmi.com/
+  description: >-
+    Philip Morris International Inc is a leading international tobacco company that manufactures and sells cigarettes
+    and smoke-free products worldwide.
+  products:
+    - Marlboro
+    - IQOS
+    - Chesterfield
+    - L&M
+    - Parliament
+  execs:
+    - Jacek Olczak
+  source: finnhub+llm
+PNC:
+  name: PNC Financial Services Group Inc
+  industry: Banking
+  marketCap: 91867
+  weburl: https://www.pnc.com/
+  description: >-
+    PNC Financial Services Group Inc is a bank holding company that provides a wide range of financial services
+    including retail banking, corporate banking, and asset management.
+  products:
+    - PNC Retail Banking
+    - PNC Wealth Management
+    - PNC Corporate & Institutional Banking
+  execs:
+    - William S. Demchak
+  source: finnhub+llm
+PSX:
+  name: Phillips 66
+  industry: Energy
+  marketCap: 74099
+  weburl: https://www.phillips66.com/
+  description: >-
+    Phillips 66 is a diversified energy manufacturing and logistics company, involved in refining, midstream
+    transportation, and marketing of petroleum products.
+  products:
+    - Refining
+    - Midstream
+    - Chemicals
+    - Lubricants
+    - Petroleum Products
+  execs:
+    - Greg Garland
+  source: finnhub+llm
+PYPL:
+  name: PayPal Holdings Inc
+  industry: Financial Services
+  marketCap: 36797
+  weburl: https://www.paypal.com/
+  description: >-
+    PayPal Holdings Inc is a technology platform that enables digital and mobile payments on behalf of consumers and
+    merchants.
+  products:
+    - PayPal
+    - Venmo
+    - Braintree
+    - PayPal Credit
+    - Xoom
+  execs:
+    - Dan Schulman
+  source: finnhub+llm
+QCOM:
+  name: Qualcomm Inc
+  industry: Semiconductors
+  marketCap: 236644
+  weburl: https://www.qualcomm.com/
+  description: >-
+    Qualcomm Incorporated is a global semiconductor company that designs and markets wireless telecommunications
+    products and services, particularly for mobile devices.
+  products:
+    - Snapdragon Processors
+    - 5G Modems
+    - RF Front-End Solutions
+    - Qualcomm Automotive Solutions
+    - IoT Solutions
+  execs:
+    - Cristiano Amon
+  source: finnhub+llm
+RBLX:
+  name: Roblox Corp
+  industry: Media
+  marketCap: 29971
+  weburl: https://corp.roblox.com/
+  description: >-
+    Roblox Corp is an online platform that allows users to create and play games created by other users, fostering a
+    community of game developers and players.
+  execs:
+    - David Baszucki
+  source: finnhub+llm
+REGN:
+  name: Regeneron Pharmaceuticals Inc
+  industry: Biotechnology
+  marketCap: 66745
+  weburl: https://www.regeneron.com/
+  description: >-
+    Regeneron Pharmaceuticals Inc is a biotechnology company that invents life-transforming medicines for serious
+    diseases, focusing on areas such as ophthalmology, immunology, and oncology.
+  products:
+    - EYLEA
+    - Dupixent
+    - Libtayo
+    - Praluent
+    - Regeneron's Antibody Programs
+  execs:
+    - Leonard S. Schleifer
+  source: finnhub+llm
+RIVN:
+  name: Rivian Automotive Inc
+  industry: Automobiles
+  marketCap: 21131
+  weburl: https://rivian.com/
+  description: >-
+    Rivian Automotive Inc is an electric vehicle manufacturer focused on producing adventure-oriented electric trucks
+    and SUVs.
+  products:
+    - R1T
+    - R1S
+    - Rivian Charging Network
+  execs:
+    - RJ Scaringe
+  source: finnhub+llm
+RTX:
+  name: RTX Corp
+  industry: Aerospace & Defense
+  marketCap: 244719
+  weburl: https://www.rtx.com/
+  description: >-
+    RTX Corp, formerly known as Raytheon Technologies, is a multinational aerospace and defense conglomerate that
+    provides advanced systems and services for commercial, military, and government customers.
+  products:
+    - Aerospace Systems
+    - Defense Systems
+    - Intelligence and Cyber Solutions
+    - Commercial Aviation Services
+  execs:
+    - Gregory J. Hayes
+  source: finnhub+llm
+SBUX:
+  name: Starbucks Corp
+  industry: Hotels, Restaurants & Leisure
+  marketCap: 109041
+  weburl: https://www.starbucks.com/
+  description: >-
+    Starbucks Corporation is a global coffeehouse chain that sells coffee, beverages, and food items, along with
+    coffee-related products.
+  products:
+    - Coffee
+    - Espresso Beverages
+    - Teas
+    - Pastries
+    - Merchandise
+  execs:
+    - Laxman Narasimhan
+  source: finnhub+llm
+SCHW:
+  name: Charles Schwab Corp
+  industry: Financial Services
+  marketCap: 153192
+  weburl: https://www.schwab.com/
+  description: >-
+    Charles Schwab Corp is a financial services company that provides a range of investment and banking services,
+    including brokerage and wealth management.
+  products:
+    - Brokerage Services
+    - Retirement Accounts
+    - Wealth Management
+    - Banking Services
+  execs:
+    - Walter W. Bettinger II
+  source: finnhub+llm
+SHOP:
+  name: Shopify Inc
+  industry: Technology
+  marketCap: 143040
+  weburl: https://www.shopify.com/
+  description: >-
+    Shopify Inc is an e-commerce platform that enables businesses to create online stores and sell products across
+    various channels.
+  execs:
+    - Tobi Lütke
+  source: finnhub+llm
+SHW:
+  name: Sherwin-Williams Co
+  industry: Chemicals
+  marketCap: 74839
+  weburl: https://www.sherwin-williams.com/
+  description: >-
+    Sherwin-Williams Co. is a global leader in the manufacture, distribution, and sale of paints, coatings, and related
+    products.
+  products:
+    - Paints
+    - Coatings
+    - Stains
+    - Industrial finishes
+    - Aerosol products
+  execs:
+    - John G. Morikis
+  source: finnhub+llm
+SLB:
+  name: SLB NV
+  industry: Energy
+  marketCap: 83933
+  weburl: https://www.slb.com/
+  description: >-
+    SLB is a global technology company that provides services and solutions for the oil and gas industry, including
+    exploration and production.
+  products:
+    - Reservoir Characterization
+    - Drilling Services
+    - Production Solutions
+    - Well Services
+    - Digital Solutions
+  execs:
+    - Olivier Le Peuch
+  source: finnhub+llm
+SMCI:
+  name: Super Micro Computer Inc
+  industry: Technology
+  marketCap: 25431
+  weburl: https://www.supermicro.com/en/
+  description: >-
+    Super Micro Computer Inc provides high-performance server technology and solutions for data centers and cloud
+    computing.
+  products:
+    - SuperServer Systems
+    - Storage Solutions
+    - Networking Solutions
+    - High-Density Servers
+    - GPU Systems
+  execs:
+    - Charles Liang
+  source: finnhub+llm
+SMR:
+  name: Nuscale Power Corp
+  industry: Electrical Equipment
+  marketCap: 3920
+  weburl: https://ir.nuscalepower.com/
+  description: >-
+    Nuscale Power Corp is a company that designs and develops small modular reactors (SMRs) for nuclear power
+    generation.
+  source: finnhub+llm
+SNOW:
+  name: Snowflake Inc
+  industry: Technology
+  marketCap: 81881
+  weburl: https://www.snowflake.com/
+  description: >-
+    Snowflake Inc. is a cloud-based data-warehousing company that provides a platform for data storage, processing, and
+    analytics.
+  products:
+    - Snowflake Data Cloud
+    - Data Warehousing Solutions
+    - Data Sharing Services
+    - Data Marketplace
+    - Cloud Data Platform
+  execs:
+    - Frank Slootman
+  source: finnhub+llm
+SNPS:
+  name: Synopsys Inc
+  industry: Technology
+  marketCap: 90744
+  weburl: https://www.synopsys.com/
+  description: Synopsys Inc provides electronic design automation software and services for semiconductor design and manufacturing.
+  products:
+    - Design Compiler
+    - Fusion Compiler
+    - Verilog-AMS
+    - TestMAX
+    - Coverity
+  execs:
+    - Aart de Geus
+  source: finnhub+llm
+SO:
+  name: Southern Co
+  industry: Utilities
+  marketCap: 104884
+  weburl: https://www.southerncompany.com/
+  description: >-
+    Southern Company is a gas and electric utility holding company that provides electricity to customers in the
+    southeastern United States.
+  products:
+    - Electric Utility Services
+    - Natural Gas Distribution
+    - Renewable Energy
+    - Energy Efficiency Programs
+  execs:
+    - Thomas A. Fanning
+  source: finnhub+llm
+SPG:
+  name: Simon Property Group Inc
+  industry: Real Estate
+  marketCap: 67746
+  weburl: https://www.simon.com/
+  description: >-
+    Simon Property Group Inc. is a leading global retail real estate investment trust (REIT) that owns and operates
+    shopping malls and outlets.
+  products:
+    - Shopping malls
+    - Outlet centers
+    - Retail properties
+    - Mixed-use properties
+  execs:
+    - David Simon
+  source: finnhub+llm
+SPGI:
+  name: S&P Global Inc
+  industry: Financial Services
+  marketCap: 125263
+  weburl: https://www.spglobal.com/
+  description: >-
+    S&P Global Inc provides financial information and analytics, including credit ratings, benchmarks, and analytics in
+    various sectors.
+  products:
+    - S&P Ratings
+    - S&P Dow Jones Indices
+    - S&P Global Market Intelligence
+    - S&P Global Platts
+  execs:
+    - Douglas L. Peterson
+  source: finnhub+llm
+SPOT:
+  name: Spotify Technology SA
+  industry: Media
+  marketCap: 100702
+  weburl: https://www.spotify.com/lu-fr/premium/
+  description: Spotify Technology SA is a digital music streaming service that provides access to millions of songs and podcasts.
+  execs:
+    - Daniel Ek
+  source: finnhub+llm
+SRE:
+  name: Sempra
+  industry: Utilities
+  marketCap: 60041
+  weburl: https://www.sempra.com/
+  description: >-
+    Sempra is an energy infrastructure company that focuses on the development and operation of energy assets, including
+    utilities and renewable energy.
+  products:
+    - Electric Utility Services
+    - Natural Gas Distribution
+    - Renewable Energy
+    - Energy Infrastructure
+  execs:
+    - Jeffrey W. Martin
+  source: finnhub+llm
+SYK:
+  name: Stryker Corp
+  industry: Health Care
+  marketCap: 117807
+  weburl: https://www.stryker.com/
+  description: >-
+    Stryker Corp is a medical technology company that develops and manufactures innovative products and services in
+    orthopedics, medical and surgical equipment, and neurotechnology.
+  products:
+    - Orthopedic Implants
+    - Surgical Equipment
+    - Endoscopy Products
+    - Trauma Products
+    - Neurovascular Devices
+  execs:
+    - Kevin A. Lobo
+  source: finnhub+llm
+T:
+  name: AT&T Inc
+  industry: Telecommunication
+  marketCap: 158214
+  weburl: https://www.att.com/
+  description: >-
+    AT&T Inc is a telecommunications conglomerate that provides mobile and fixed telephone services, as well as
+    broadband and digital television.
+  products:
+    - AT&T Wireless
+    - DirecTV
+    - AT&T Internet
+  execs:
+    - John Stankey
+  source: finnhub+llm
+TFC:
+  name: Truist Financial Corp
+  industry: Banking
+  marketCap: 61428
+  weburl: https://www.truist.com/
+  description: >-
+    Truist Financial Corp is a bank holding company formed from the merger of BB&T and SunTrust, offering a variety of
+    financial services.
+  products:
+    - Truist Personal Banking
+    - Truist Wealth
+    - Truist Commercial Banking
+  execs:
+    - William H. Rogers Jr.
+  source: finnhub+llm
+TGT:
+  name: Target Corp
+  industry: Retail
+  marketCap: 55890
+  weburl: https://corporate.target.com/
+  description: >-
+    Target Corporation is a general merchandise retailer that provides a wide range of products including household
+    essentials, clothing, and electronics.
+  products:
+    - Clothing
+    - Home Goods
+    - Electronics
+    - Groceries
+    - Beauty Products
+  execs:
+    - Brian Cornell
+  source: finnhub+llm
+TMO:
+  name: Thermo Fisher Scientific Inc
+  industry: Life Sciences Tools & Services
+  marketCap: 176321
+  weburl: https://corporate.thermofisher.com/us/en/index.html
+  description: >-
+    Thermo Fisher Scientific Inc provides analytical instruments, reagents, and consumables, as well as software and
+    services for laboratories and research institutions.
+  products:
+    - Thermo Scientific
+    - Applied Biosystems
+    - Fisher Scientific
+    - Unity Lab Services
+    - Patheon
+  execs:
+    - Marc N. Casper
+  source: finnhub+llm
+TMUS:
+  name: T-Mobile US Inc
+  industry: Telecommunication
+  marketCap: 193953
+  weburl: https://www.t-mobile.com/
+  description: >-
+    T-Mobile US Inc is a wireless network operator that provides mobile voice, messaging, and data services in the
+    United States.
+  products:
+    - T-Mobile
+    - Metro by T-Mobile
+  execs:
+    - Mike Sievert
+  source: finnhub+llm
+TSLA:
+  name: Tesla Inc
+  industry: Automobiles
+  marketCap: 1506496
+  weburl: https://www.tesla.com/
+  description: Tesla Inc designs, manufactures, and sells electric vehicles and renewable energy products.
+  products:
+    - Model S
+    - Model 3
+    - Model X
+    - Model Y
+    - Solar Roof
+    - Powerwall
+  execs:
+    - Elon Musk
+  source: finnhub+llm
+TTD:
+  name: Trade Desk Inc
+  industry: Media
+  marketCap: 9541
+  weburl: https://www.thetradedesk.com/
+  description: >-
+    The Trade Desk Inc is a technology company that provides a platform for digital advertising, enabling advertisers to
+    purchase and manage data-driven digital ad campaigns.
+  execs:
+    - Jeff Green
+  source: finnhub+llm
+TTWO:
+  name: Take-Two Interactive Software Inc
+  industry: Media
+  marketCap: 39765
+  weburl: https://www.take2games.com/
+  description: >-
+    Take-Two Interactive Software Inc is a video game publisher known for developing and publishing interactive
+    entertainment software.
+  products:
+    - Grand Theft Auto
+    - NBA 2K
+    - Red Dead Redemption
+  execs:
+    - Strauss Zelnick
+  source: finnhub+llm
+TXN:
+  name: Texas Instruments Inc
+  industry: Semiconductors
+  marketCap: 263522
+  weburl: https://www.ti.com/
+  description: >-
+    Texas Instruments Incorporated is a technology company that designs and manufactures semiconductors and various
+    integrated circuits, which it sells to electronics designers and manufacturers globally.
+  products:
+    - Analog Chips
+    - Embedded Processors
+    - DLP Technology
+    - Microcontrollers
+    - Digital Signal Processors (DSPs)
+  execs:
+    - Haviv Ilan
+  source: finnhub+llm
+U:
+  name: Unity Software Inc
+  industry: Technology
+  marketCap: 12891
+  weburl: https://www.unity.com
+  description: >-
+    Unity Software Inc is a leading platform for creating and operating interactive, real-time 3D content, primarily for
+    video games and simulations.
+  execs:
+    - John Riccitiello
+  source: finnhub+llm
+UBER:
+  name: Uber Technologies Inc
+  industry: Road & Rail
+  marketCap: 146624
+  weburl: https://www.uber.com/
+  description: >-
+    Uber Technologies Inc is a technology company that provides ride-hailing services, food delivery, and freight
+    transportation through its mobile app.
+  execs:
+    - Dara Khosrowshahi
+  source: finnhub+llm
+ULTA:
+  name: Ulta Beauty Inc
+  industry: Retail
+  marketCap: 19883
+  weburl: https://www.ulta.com/
+  description: >-
+    Ulta Beauty Inc is a beauty retailer that offers cosmetics, skincare products, fragrances, and hair care products,
+    along with salon services.
+  products:
+    - Cosmetics
+    - Skincare
+    - Fragrance
+    - Hair Care
+    - Salon Services
+  execs:
+    - Dave Kimbell
+  source: finnhub+llm
+UNH:
+  name: UnitedHealth Group Inc
+  industry: Health Care
+  marketCap: 360052
+  weburl: https://www.unitedhealthgroup.com/
+  description: >-
+    UnitedHealth Group Inc is a diversified health care company that offers health care products and insurance services,
+    aiming to improve health care access and quality.
+  products:
+    - UnitedHealthcare
+    - Optum
+    - Medicare Advantage
+    - Medicaid
+    - Health Services
+  execs:
+    - Andrew Witty
+  source: finnhub+llm
+UNP:
+  name: Union Pacific Corp
+  industry: Road & Rail
+  marketCap: 156681
+  weburl: https://www.up.com/index.htm
+  description: >-
+    Union Pacific Corporation operates one of the largest freight rail networks in the United States, transporting a
+    variety of goods across the country.
+  products:
+    - Freight Transportation
+    - Intermodal Services
+    - Bulk Commodities
+    - Automotive Transport
+    - Industrial Products
+  execs:
+    - Lance Fritz
+  source: finnhub+llm
+UPS:
+  name: United Parcel Service Inc
+  industry: Logistics & Transportation
+  marketCap: 90687
+  weburl: https://www.ups.com/
+  description: >-
+    United Parcel Service Inc is a global logistics and package delivery company that provides transportation and
+    logistics services worldwide.
+  products:
+    - Package Delivery
+    - Supply Chain Solutions
+    - Freight Transportation
+    - Logistics Services
+  execs:
+    - Carol Tomé
+  source: finnhub+llm
+USB:
+  name: US Bancorp
+  industry: Banking
+  marketCap: 85144
+  weburl: https://www.usbank.com/
+  description: >-
+    US Bancorp is the parent company of U.S. Bank, providing a range of financial services including banking,
+    investment, mortgage, and payment services.
+  products:
+    - U.S. Bank Personal Banking
+    - U.S. Bank Wealth Management
+    - U.S. Bank Corporate Banking
+  execs:
+    - Andrew Cecere
+  source: finnhub+llm
+V:
+  name: Visa Inc
+  industry: Financial Services
+  marketCap: 614903
+  weburl: https://usa.visa.com/
+  description: >-
+    Visa Inc is a global payments technology company that facilitates digital payments between consumers, merchants,
+    financial institutions, and government entities.
+  products:
+    - VisaNet
+    - Visa Direct
+    - Visa Checkout
+    - Visa Token Service
+  execs:
+    - Ryan McInerney
+  source: finnhub+llm
+VLO:
+  name: Valero Energy Corp
+  industry: Energy
+  marketCap: 72695
+  weburl: https://www.valero.com/
+  description: >-
+    Valero Energy Corp is an international manufacturer and marketer of transportation fuels and petrochemical products,
+    operating refineries and retail locations.
+  products:
+    - Refining
+    - Gasoline
+    - Diesel
+    - Jet Fuel
+    - Valero Retail Stations
+  execs:
+    - Joseph W. Gorder
+  source: finnhub+llm
+VRTX:
+  name: Vertex Pharmaceuticals Inc
+  industry: Biotechnology
+  marketCap: 113588
+  weburl: https://www.vrtx.com/
+  description: >-
+    Vertex Pharmaceuticals Inc is a biotechnology company focused on developing and commercializing innovative therapies
+    for people with serious diseases, particularly cystic fibrosis.
+  products:
+    - Kalydeco
+    - Orkambi
+    - Symdeko
+    - Trikafta
+    - Vertex's Gene Editing Programs
+  execs:
+    - Reshma Kewalramani
+  source: finnhub+llm
+VST:
+  name: Vistra Corp
+  industry: Utilities
+  marketCap: 54027
+  weburl: https://www.vistracorp.com/
+  description: >-
+    Vistra Corp is a leading integrated power company that provides electricity and related services to customers in the
+    United States.
+  products:
+    - Retail Electricity
+    - Power Generation
+    - Energy Storage
+    - Natural Gas
+    - Renewable Energy
+  execs:
+    - Jim Burke
+  source: finnhub+llm
+VZ:
+  name: Verizon Communications Inc
+  industry: Telecommunication
+  marketCap: 199633
+  weburl: https://www.verizon.com/
+  description: >-
+    Verizon Communications Inc is a telecommunications company that offers wireless products and services, as well as
+    broadband and television services.
+  products:
+    - Verizon Wireless
+    - Fios
+    - Verizon Business
+  execs:
+    - Hans Vestberg
+  source: finnhub+llm
+WBD:
+  name: Warner Bros Discovery Inc
+  industry: Media
+  marketCap: 67718
+  weburl: https://www.wbd.com/
+  description: >-
+    Warner Bros Discovery Inc is a media and entertainment company that creates and distributes a wide range of content
+    across various platforms.
+  products:
+    - HBO Max
+    - Warner Bros. Pictures
+    - DC Entertainment
+  execs:
+    - David Zaslav
+  source: finnhub+llm
+WFC:
+  name: Wells Fargo & Co
+  industry: Banking
+  marketCap: 237287
+  weburl: https://www.wellsfargo.com
+  description: >-
+    Wells Fargo & Co is a diversified financial services company providing banking, investment, mortgage, and consumer
+    and commercial finance.
+  products:
+    - Consumer Banking
+    - Commercial Banking
+    - Investment Banking
+    - Wealth Management
+    - Home Loans
+  execs:
+    - Charles W. Scharf
+  source: finnhub+llm
+WMB:
+  name: Williams Companies Inc
+  industry: Energy
+  marketCap: 87310
+  weburl: https://www.williams.com/
+  description: >-
+    Williams Companies Inc is a leading provider of natural gas infrastructure, focusing on the transportation and
+    processing of natural gas and natural gas liquids.
+  products:
+    - Natural Gas Transportation
+    - Natural Gas Processing
+    - NGL Services
+    - Transco Pipeline
+    - Northwest Pipeline
+  execs:
+    - Alan S. Armstrong
+  source: finnhub+llm
+WMT:
+  name: Walmart Inc
+  industry: Retail
+  marketCap: 921148
+  weburl: https://corporate.walmart.com/
+  description: >-
+    Walmart Inc is a multinational retail corporation that operates a chain of hypermarkets, discount department stores,
+    and grocery stores.
+  products:
+    - Walmart Supercenters
+    - Sam's Club
+    - Walmart Grocery
+  execs:
+    - Doug McMillon
+  source: finnhub+llm
+XOM:
+  name: Exxon Mobil Corp
+  industry: Energy
+  marketCap: 602095
+  weburl: https://corporate.exxonmobil.com/
+  description: >-
+    Exxon Mobil Corporation is one of the world's largest publicly traded oil and gas companies, involved in the
+    exploration, production, and distribution of energy resources.
+  products:
+    - Crude Oil
+    - Natural Gas
+    - Petroleum Products
+    - Chemical Products
+    - Lubricants
+  execs:
+    - Darren W. W. Wood
+  source: finnhub+llm
+YUM:
+  name: Yum! Brands Inc
+  industry: Hotels, Restaurants & Leisure
+  marketCap: 40778
+  weburl: https://www.yum.com/
+  description: >-
+    Yum! Brands Inc is a global fast-food corporation that operates several well-known restaurant chains, focusing on
+    pizza, chicken, and Mexican food.
+  products:
+    - Pizza Hut
+    - KFC
+    - Taco Bell
+    - WingStreet
+    - The Habit Burger Grill
+  execs:
+    - David Gibbs
+  source: finnhub+llm
+ZS:
+  name: Zscaler Inc
+  industry: Technology
+  marketCap: 22596
+  weburl: https://www.zscaler.com/
+  description: >-
+    Zscaler Inc offers cloud-based information security services, focusing on secure internet access and private
+    application access.
+  products:
+    - Zscaler Internet Access
+    - Zscaler Private Access
+    - Zscaler Digital Experience
+    - Zscaler Cloud Security Platform
+  execs:
+    - Jay Chaudhry
+  source: finnhub+llm
+ZTS:
+  name: Zoetis Inc
+  industry: Pharmaceuticals
+  marketCap: 32570
+  weburl: https://www.zoetis.com/
+  description: >-
+    Zoetis Inc is a global leader in animal health, providing medicines and vaccines for livestock and companion
+    animals.
+  products:
+    - Vaccines
+    - Antibiotics
+    - Parasiticides
+    - Diagnostics
+    - Nutritional products
+  execs:
+    - Kristin Peck
+  source: finnhub+llm

--- a/config/tape-company-cards.yaml
+++ b/config/tape-company-cards.yaml
@@ -95,6 +95,34 @@ AEP:
   execs:
     - Nicholas K. Akins
   source: finnhub+llm
+AGIO:
+  name: Agios Pharmaceuticals Inc
+  industry: Biotechnology
+  marketCap: 1695
+  weburl: https://www.agios.com/
+  description: >-
+    Agios Pharmaceuticals Inc is a biotechnology company focused on discovering and developing innovative medicines for
+    patients with cancer and rare genetic diseases.
+  products:
+    - IDHIFA
+    - TIBSOVO
+    - AG-221
+  execs:
+    - David Schenkein
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:46:07.810Z'
+ALNY:
+  name: Alnylam Pharmaceuticals Inc
+  industry: Biotechnology
+  marketCap: 40405
+  weburl: https://www.alnylam.com/
+  description: >-
+    Alnylam Pharmaceuticals Inc is a biotechnology company focused on the development of RNA interference (RNAi)
+    therapeutics for genetic diseases.
+  execs:
+    - Yvonne Greenstreet
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:43:11.758Z'
 AMAT:
   name: Applied Materials Inc
   industry: Semiconductors
@@ -196,6 +224,22 @@ ANET:
   execs:
     - Jayshree Ullal
   source: finnhub+llm
+APLS:
+  name: Apellis Pharmaceuticals Inc
+  industry: Biotechnology
+  marketCap: 5253
+  weburl: https://apellis.com/
+  description: >-
+    Apellis Pharmaceuticals Inc is a biotechnology company focused on developing therapies for patients with rare
+    diseases and autoimmune disorders.
+  products:
+    - APL-2
+    - C3 Inhibition
+    - Complement Therapeutics
+  execs:
+    - Cedric Francois
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:46:07.810Z'
 APO:
   name: Apollo Global Management Inc
   industry: Financial Services
@@ -222,6 +266,22 @@ APP:
   execs:
     - Harris B. K. K.
   source: finnhub+llm
+ARGX:
+  name: argenx SE
+  industry: Biotechnology
+  marketCap: 43034
+  weburl: https://www.argenx.com/
+  description: >-
+    argenx SE is a biotechnology company that develops innovative therapies for the treatment of severe autoimmune
+    diseases and cancer.
+  products:
+    - Efgartigimod
+    - ARGX-113
+    - ARGX-110
+  execs:
+    - Tim Van Hauwermeiren
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:46:07.810Z'
 ARM:
   name: Arm Holdings PLC
   industry: Semiconductors
@@ -237,6 +297,34 @@ ARM:
     - IoT Solutions
     - Software Development Tools
   source: finnhub+llm
+ARVN:
+  name: Arvinas Inc
+  industry: Pharmaceuticals
+  marketCap: 485
+  weburl: https://www.arvinas.com/
+  description: >-
+    Arvinas Inc is a biopharmaceutical company focused on developing therapies that utilize protein degradation to treat
+    diseases.
+  products:
+    - ARV-471
+    - ARV-110
+    - PROTAC technology
+  execs:
+    - John Houston
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:46:07.810Z'
+ARWR:
+  name: Arrowhead Pharmaceuticals Inc
+  industry: Biotechnology
+  marketCap: 10306
+  weburl: https://arrowheadpharma.com/
+  description: >-
+    Arrowhead Pharmaceuticals Inc is a biotechnology company focused on developing medicines that treat intractable
+    diseases by targeting the underlying causes at the genetic level.
+  execs:
+    - Christopher Anzalone
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:43:11.758Z'
 AVGO:
   name: Broadcom Inc
   industry: Semiconductors
@@ -268,6 +356,18 @@ AXP:
   execs:
     - Stephen Squeri
   source: finnhub+llm
+AXSM:
+  name: Axsome Therapeutics Inc
+  industry: Pharmaceuticals
+  marketCap: 12435
+  weburl: https://www.axsome.com/
+  description: >-
+    Axsome Therapeutics Inc is a pharmaceutical company dedicated to developing novel therapies for the management of
+    central nervous system disorders.
+  execs:
+    - Herriot Tabuteau
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:43:11.758Z'
 BA:
   name: Boeing Co
   industry: Aerospace & Defense
@@ -318,6 +418,13 @@ BAC:
   execs:
     - Brian Moynihan
   source: finnhub+llm
+BEAM:
+  name: Beam Therapeutics Inc
+  industry: Biotechnology
+  marketCap: 3033
+  weburl: https://beamtx.com/
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:46:07.810Z'
 BIDU:
   name: Baidu Inc
   industry: Media
@@ -367,6 +474,13 @@ BLK:
   execs:
     - Larry Fink
   source: finnhub+llm
+BMRN:
+  name: BioMarin Pharmaceutical Inc
+  industry: Biotechnology
+  marketCap: 10996
+  weburl: https://www.biomarin.com/
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:46:07.810Z'
 BMY:
   name: Bristol-Myers Squibb Co
   industry: Pharmaceuticals
@@ -613,6 +727,18 @@ COF:
   execs:
     - Richard D. Fairbank
   source: finnhub+llm
+COHR:
+  name: Coherent Corp
+  industry: Electrical Equipment
+  marketCap: 75918
+  weburl: https://www.coherent.com/
+  description: >-
+    Coherent Corp is an electrical equipment company that designs and manufactures lasers and laser-based technology for
+    various applications.
+  execs:
+    - Andy Mattes
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:43:11.758Z'
 COIN:
   name: Coinbase Global Inc
   industry: Financial Services
@@ -675,6 +801,18 @@ CRM:
   execs:
     - Marc Benioff
   source: finnhub+llm
+CRSP:
+  name: CRISPR Therapeutics AG
+  industry: Biotechnology
+  marketCap: 5019
+  weburl: https://crisprtx.com/
+  description: >-
+    CRISPR Therapeutics AG is a biotechnology company focused on developing transformative gene-based medicines for
+    serious diseases using its proprietary CRISPR/Cas9 gene-editing platform.
+  execs:
+    - Samant Virk
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:43:11.758Z'
 CRWD:
   name: CrowdStrike Holdings Inc
   industry: Technology
@@ -769,6 +907,13 @@ CVX:
   execs:
     - Michael Wirth
   source: finnhub+llm
+CYTK:
+  name: Cytokinetics Inc
+  industry: Biotechnology
+  marketCap: 8841
+  weburl: https://cytokinetics.com/
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:46:07.810Z'
 D:
   name: Dominion Energy Inc
   industry: Utilities
@@ -913,6 +1058,20 @@ DLTR:
   execs:
     - Michael Witynski
   source: finnhub+llm
+DNLI:
+  name: Denali Therapeutics Inc
+  industry: Biotechnology
+  marketCap: 3095
+  weburl: https://www.denalitherapeutics.com
+  description: Denali Therapeutics Inc is a biotechnology company focused on developing therapies for neurodegenerative diseases.
+  products:
+    - DNL201
+    - DNL310
+    - DNL151
+  execs:
+    - Ryan Watts
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:46:07.810Z'
 DOW:
   name: Dow Inc
   industry: Chemicals
@@ -1095,6 +1254,13 @@ EXC:
   execs:
     - Christopher M. Crane
   source: finnhub+llm
+EXEL:
+  name: Exelixis Inc
+  industry: Biotechnology
+  marketCap: 13231
+  weburl: https://www.exelixis.com/
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:46:07.810Z'
 F:
   name: Ford Motor Co
   industry: Automobiles
@@ -1342,6 +1508,13 @@ HAL:
   execs:
     - Jeff Miller
   source: finnhub+llm
+HALO:
+  name: Halozyme Therapeutics Inc
+  industry: Biotechnology
+  marketCap: 8432
+  weburl: https://www.halozyme.com/
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:46:07.810Z'
 HD:
   name: Home Depot Inc
   industry: Retail
@@ -1451,6 +1624,25 @@ ICE:
   execs:
     - Jeffrey C. Sprecher
   source: finnhub+llm
+INCY:
+  name: Incyte Corp
+  industry: Biotechnology
+  marketCap: 20797
+  weburl: https://www.incyte.com/
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:46:07.810Z'
+INSM:
+  name: Insmed Inc
+  industry: Biotechnology
+  marketCap: 20484
+  weburl: https://insmed.com/
+  description: >-
+    Insmed Inc is a biotechnology company focused on developing therapies for patients with serious and rare diseases,
+    particularly those related to pulmonary conditions.
+  execs:
+    - Will Lewis
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:43:11.758Z'
 INTC:
   name: Intel Corp
   industry: Semiconductors
@@ -1468,6 +1660,13 @@ INTC:
   execs:
     - Pat Gelsinger
   source: finnhub+llm
+IONS:
+  name: Ionis Pharmaceuticals Inc
+  industry: Biotechnology
+  marketCap: 12311
+  weburl: https://www.ionis.com/
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:46:07.810Z'
 ISRG:
   name: Intuitive Surgical Inc
   industry: Health Care
@@ -1652,6 +1851,13 @@ KR:
   execs:
     - William McMullen
   source: finnhub+llm
+KRYS:
+  name: Krystal Biotech Inc
+  industry: Biotechnology
+  marketCap: 9097
+  weburl: https://www.krystalbio.com/
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:46:07.810Z'
 LCID:
   name: Lucid Group Inc
   industry: Automobiles
@@ -1812,6 +2018,13 @@ MCD:
   execs:
     - Chris Kempczinski
   source: finnhub+llm
+MDGL:
+  name: Madrigal Pharmaceuticals Inc
+  industry: Biotechnology
+  marketCap: 11291
+  weburl: https://www.madrigalpharma.com/
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:46:07.810Z'
 MDLZ:
   name: Mondelez International Inc
   industry: Food Products
@@ -2007,6 +2220,13 @@ MU:
   execs:
     - Sanjay Mehrotra
   source: finnhub+llm
+NBIX:
+  name: Neurocrine Biosciences Inc
+  industry: Biotechnology
+  marketCap: 16578
+  weburl: https://www.neurocrine.com/
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:46:07.810Z'
 NEE:
   name: Nextera Energy Inc
   industry: Utilities
@@ -2140,6 +2360,18 @@ NOW:
   execs:
     - Bill McDermott
   source: finnhub+llm
+NTLA:
+  name: Intellia Therapeutics Inc
+  industry: Biotechnology
+  marketCap: 1867
+  weburl: https://www.intelliatx.com/
+  description: >-
+    Intellia Therapeutics Inc is a biotechnology company pioneering the development of CRISPR/Cas9-based therapies for
+    genetic diseases.
+  execs:
+    - John Leonard
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:43:11.758Z'
 NUE:
   name: Nucor Corp
   industry: Metals & Mining
@@ -2155,6 +2387,20 @@ NUE:
   execs:
     - Leon Topalian
   source: finnhub+llm
+NVAX:
+  name: Novavax Inc
+  industry: Biotechnology
+  marketCap: 1574
+  weburl: https://www.novavax.com/?locale=US
+  description: Novavax Inc is a biotechnology company that develops vaccines to prevent infectious diseases.
+  products:
+    - NVX-CoV2373 (COVID-19 vaccine)
+    - NanoFlu
+    - RSV F protein vaccine
+  execs:
+    - Stanley C. Erck
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:46:07.810Z'
 NVDA:
   name: NVIDIA Corp
   industry: Semiconductors
@@ -2439,6 +2685,13 @@ QCOM:
   execs:
     - Cristiano Amon
   source: finnhub+llm
+RARE:
+  name: Ultragenyx Pharmaceutical Inc
+  industry: Biotechnology
+  marketCap: 2157
+  weburl: https://www.ultragenyx.com/
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:46:07.810Z'
 RBLX:
   name: Roblox Corp
   industry: Media
@@ -2498,6 +2751,27 @@ RTX:
   execs:
     - Gregory J. Hayes
   source: finnhub+llm
+RVMD:
+  name: Revolution Medicines Inc
+  industry: Biotechnology
+  marketCap: 32169
+  weburl: https://www.revmed.com/
+  description: Revolution Medicines Inc is a biotechnology company focused on developing targeted therapies for cancer.
+  products:
+    - RMC-4630
+    - RMC-5552
+    - RMC-6291
+  execs:
+    - Mark Goldsmith
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:46:07.810Z'
+RXRX:
+  name: Recursion Pharmaceuticals Inc
+  industry: Biotechnology
+  marketCap: 1752
+  weburl: https://www.recursion.com/
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:46:07.810Z'
 SBUX:
   name: Starbucks Corp
   industry: Hotels, Restaurants & Leisure
@@ -2707,6 +2981,18 @@ SRE:
   execs:
     - Jeffrey W. Martin
   source: finnhub+llm
+SRPT:
+  name: Sarepta Therapeutics Inc
+  industry: Biotechnology
+  marketCap: 1671
+  weburl: https://www.sarepta.com/
+  description: >-
+    Sarepta Therapeutics Inc is a biotechnology company focused on developing innovative genetic medicine to treat rare
+    diseases, particularly muscular dystrophies.
+  execs:
+    - Doug Ingram
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:43:11.758Z'
 SYK:
   name: Stryker Corp
   industry: Health Care
@@ -2771,6 +3057,22 @@ TGT:
   execs:
     - Brian Cornell
   source: finnhub+llm
+TGTX:
+  name: TG Therapeutics Inc
+  industry: Biotechnology
+  marketCap: 6237
+  weburl: https://www.tgtherapeutics.com/
+  description: >-
+    TG Therapeutics Inc is a biotechnology company focused on developing and commercializing innovative therapies for
+    the treatment of B-cell diseases.
+  products:
+    - TG-1101 (ublituximab)
+    - TG-1202 (umbralisib)
+    - B-cell malignancies
+  execs:
+    - Michael S. Weiss
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:46:07.810Z'
 TMO:
   name: Thermo Fisher Scientific Inc
   industry: Life Sciences Tools & Services
@@ -2818,6 +3120,18 @@ TSLA:
   execs:
     - Elon Musk
   source: finnhub+llm
+TSM:
+  name: Taiwan Semiconductor Manufacturing Co Ltd
+  industry: Semiconductors
+  marketCap: 62885995
+  weburl: https://www.tsmc.com/
+  description: >-
+    Taiwan Semiconductor Manufacturing Co Ltd is the world's largest dedicated independent semiconductor foundry,
+    providing advanced manufacturing services for integrated circuits.
+  execs:
+    - C.C. Wei
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:43:11.758Z'
 TTD:
   name: Trade Desk Inc
   industry: Media
@@ -2829,6 +3143,18 @@ TTD:
   execs:
     - Jeff Green
   source: finnhub+llm
+TTMI:
+  name: TTM Technologies Inc
+  industry: Electrical Equipment
+  marketCap: 17782
+  weburl: https://www.ttm.com/
+  description: >-
+    TTM Technologies Inc is an electrical equipment company that provides advanced technology solutions in the field of
+    printed circuit boards and electronics manufacturing services.
+  execs:
+    - Tom Edman
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:43:11.758Z'
 TTWO:
   name: Take-Two Interactive Software Inc
   industry: Media
@@ -2844,6 +3170,18 @@ TTWO:
   execs:
     - Strauss Zelnick
   source: finnhub+llm
+TVTX:
+  name: Travere Therapeutics Inc
+  industry: Biotechnology
+  marketCap: 4409
+  weburl: https://travere.com/
+  description: >-
+    Travere Therapeutics Inc is a biotechnology company focused on developing and commercializing innovative therapies
+    for rare diseases.
+  execs:
+    - Eric Dube
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:43:11.758Z'
 TXN:
   name: Texas Instruments Inc
   industry: Semiconductors
@@ -2981,6 +3319,16 @@ V:
   execs:
     - Ryan McInerney
   source: finnhub+llm
+VKTX:
+  name: Viking Therapeutics Inc
+  industry: Biotechnology
+  marketCap: 3801
+  weburl: https://vikingtherapeutics.com/
+  description: >-
+    Viking Therapeutics Inc is a biotechnology company focused on the development of novel therapies for metabolic and
+    endocrine disorders.
+  source: finnhub+llm
+  builtAt: '2026-06-05T22:43:11.758Z'
 VLO:
   name: Valero Energy Corp
   industry: Energy

--- a/config/tape-hot-tickers.yaml
+++ b/config/tape-hot-tickers.yaml
@@ -1,0 +1,93 @@
+# Generic "most-likely a user picks" order for daily Read-In cache warming.
+#
+# The warmer (scripts/warm-readins.js) walks getWarmTickers() in order and warms
+# each Read-In until it hits the cost/count cap (TAPE_WARM_USD_CAP / default $2,
+# TAPE_WARM_MAX_TICKERS / default 150). getWarmTickers() = `priority` below
+# (intersected with the carded universe, in this order) followed by the remaining
+# carded tickers by market cap, deduped. So this list is a *preference order*, not
+# an allowlist — anything here that isn't carded is simply skipped, and the carded
+# tail still gets warmed if budget remains.
+#
+# FUTURE (see memory project-tape-future-ideas #3): personalization layers a
+# per-user conversational watchlist ahead of this generic order via
+# getWarmTickers({ userId }). The warm machinery does not change — only the
+# provider's ordering. Keep this file the *generic* baseline.
+
+priority:
+  # Mega-cap tech / the names a generic user reaches for first
+  - NVDA
+  - AAPL
+  - TSLA
+  - MSFT
+  - AMZN
+  - GOOGL
+  - META
+  - AMD
+  - AVGO
+  - NFLX
+  - ORCL
+  - CRM
+  - INTC
+  - MU
+  - QCOM
+  - MRVL
+  - ARM
+  - SMCI
+  - DELL
+  - CSCO
+  - IBM
+  # Retail-favorite / high-attention / momentum
+  - PLTR
+  - HOOD
+  - COIN
+  - MSTR
+  - UBER
+  - ABNB
+  - SHOP
+  - SOFI
+  - PYPL
+  - RIVN
+  - LCID
+  - GME
+  - BABA
+  # Crypto / gold proxies
+  - IBIT
+  - GLD
+  # Financials
+  - JPM
+  - BAC
+  - GS
+  - WFC
+  - C
+  - V
+  - MA
+  - BRK.B
+  # Energy
+  - XOM
+  - CVX
+  - OXY
+  # Healthcare / pharma the public knows
+  - LLY
+  - PFE
+  - MRNA
+  - JNJ
+  - UNH
+  # Consumer / retail / staples
+  - WMT
+  - COST
+  - TGT
+  - HD
+  - NKE
+  - SBUX
+  - MCD
+  - KO
+  - PEP
+  - DIS
+  # Industrials / autos / misc household names
+  - BA
+  - CAT
+  - GE
+  - F
+  - GM
+  - T
+  - VZ

--- a/config/tape-taste.yaml
+++ b/config/tape-taste.yaml
@@ -32,15 +32,55 @@ mainstream_allow:
   - goalhanger
 
 mainstream_deny:
-  - simply bitcoin
-  - bankless
-  - tftc
-  - what bitcoin did
   - guy swann
-  - bitcoin audible
   - no agenda
   - empire
   - hivemind
+
+# High-signal bitcoin-native shows. EXCLUDED from normal mainstream queries (so
+# they don't pollute a Fed/oil brief), but ADMITTED when the topic is bitcoin /
+# hard-money relevant (see bitcoin_relevance_terms) — for those topics they are
+# the authoritative sources, not noise.
+bitcoin_allow:
+  - simply bitcoin
+  - coin stories
+  - natalie brunell
+  - the pomp podcast
+  - what bitcoin did
+  - tftc
+  - bankless
+  - the breakdown
+  - bitcoin audible
+  - the wolf of all streets
+  - the peter mccormack show
+  - bitcoin & markets
+
+# A topic is "bitcoin/hard-money relevant" if its text contains any of these —
+# then bitcoin_allow shows are admitted alongside the mainstream allowlist.
+bitcoin_relevance_terms:
+  - bitcoin
+  - btc
+  - crypto
+  - cryptocurrency
+  - digital asset
+  - digital gold
+  - debasement
+  - inflation
+  - hard asset
+  - hard money
+  - sound money
+  - store of value
+  - fiat
+  - currency
+  - monetary
+  - dollar
+  - gold
+  - satoshi
+  - halving
+  - stablecoin
+  - ethereum
+  - microstrategy
+  - saylor
 
 # How a "dedicated" episode is detected.
 # Options: 'last-name' (default), 'full-name', 'exact-title'.

--- a/config/tape-taste.yaml
+++ b/config/tape-taste.yaml
@@ -1,0 +1,85 @@
+# Editorial taste config for the Tape skin (spec §6).
+#
+# Shapes the recipes in person-quotes and topic-quotes. Reloaded automatically
+# when this file's mtime changes (see services/tape/tapeTaste.js) — edit + save,
+# no restart needed.
+#
+# A clip is "mainstream" if `creator` matches an allow entry (case-insensitive
+# substring) AND no deny entry.
+
+mainstream_allow:
+  - bloomberg
+  - bloomberg surveillance
+  - bloomberg intelligence
+  - macro voices
+  - macrovoices
+  - forward guidance
+  - real vision
+  - the compound
+  - the compound and friends
+  - odd lots
+  - prof g markets
+  - all-in
+  - capital allocators
+  - decoder
+  - hidden forces
+  - investor's podcast
+  - tim ferriss
+  - grant williams
+  - masters in business
+  - animal spirits
+  - the daily
+  - goalhanger
+
+mainstream_deny:
+  - simply bitcoin
+  - bankless
+  - tftc
+  - what bitcoin did
+  - guy swann
+  - bitcoin audible
+  - no agenda
+  - empire
+  - hivemind
+
+# How a "dedicated" episode is detected.
+# Options: 'last-name' (default), 'full-name', 'exact-title'.
+dedicated_match: last-name
+
+confidence_signals:
+  dedicated_weight: 0.4
+  mainstream_weight: 0.3
+  span_weight: 0.3
+  # Tier thresholds (combined weighted score):
+  high_min: 0.7
+  medium_min: 0.4
+
+# Keyword classifier for topic-quotes groupBy: "bull-bear".
+bull_keywords:
+  - rally
+  - upside
+  - bullish
+  - buy
+  - long
+  - growth
+  - outperform
+  - breakout
+  - boom
+  - optimistic
+  - higher
+  - surge
+
+bear_keywords:
+  - crash
+  - downside
+  - bearish
+  - sell
+  - short
+  - recession
+  - underperform
+  - bubble
+  - bust
+  - pessimistic
+  - lower
+  - plunge
+  - risk

--- a/config/tape-taste.yaml
+++ b/config/tape-taste.yaml
@@ -4,38 +4,78 @@
 # when this file's mtime changes (see services/tape/tapeTaste.js) — edit + save,
 # no restart needed.
 #
-# A clip is "mainstream" if `creator` matches an allow entry (case-insensitive
-# substring) AND no deny entry.
+# SOURCE GATING — a clip is "mainstream" if its feedId is in `feed_allow` below
+# (the CANONICAL, precise signal) OR — as a resilience fallback for feeds not yet
+# mapped — its `creator` matches a `mainstream_allow` substring; minus any deny.
+#
+# Prefer feed_allow: creator-substring is fragile (e.g. "founders" wrongly matched
+# "The Official SaaStr Podcast ... | Founders | Investors") and misses the ~3% of
+# docs with a null creator. feed_allow is exact and corpus-verified.
 
+# Creator-substring FALLBACK only (for feeds not in feed_allow). Keep to
+# DISTINCTIVE show names — generic words cause false matches.
 mainstream_allow:
   - bloomberg
-  - bloomberg surveillance
-  - bloomberg intelligence
   - macro voices
-  - macrovoices
   - forward guidance
   - real vision
   - the compound
-  - the compound and friends
   - odd lots
   - prof g markets
   - all-in
   - capital allocators
-  - decoder
   - hidden forces
   - investor's podcast
   - tim ferriss
   - grant williams
   - masters in business
   - animal spirits
-  - the daily
-  - goalhanger
+  - macro hive
+  - invest like the best
 
 mainstream_deny:
   - guy swann
   - no agenda
   - empire
   - hivemind
+
+# CANONICAL mainstream allowlist — match by feedId (string). Corpus-verified
+# (scripts that sample the corpus map creator -> feedId). The comment is the show
+# the feedId corresponds to. Add new shows by looking up their feedId in the
+# corpus. This is exact: no substring false-positives, catches null-creator docs.
+feed_allow:
+  "4114115": bloomberg surveillance
+  "4143163": bloomberg intelligence
+  "49438": macro voices
+  "4502930": forward guidance
+  "541102": real vision finance & investing
+  "743660": the compound and friends
+  "399817": the compound
+  "4114173": odd lots
+  "6899881": prof g markets
+  "1015378": all-in
+  "222998": capital allocators
+  "2123": decoder with nilay patel
+  "203667": hidden forces
+  "793331": the investor's podcast (we study billionaires)
+  "739525": the tim ferriss show
+  "446935": the grant williams podcast
+  "4112705": masters in business
+  "982387": invest like the best (patrick o'shaughnessy)
+  "436525": the a16z show
+  "5434524": a16z crypto show
+  "714247": founders (david senra)
+  "48166": acquired
+  "4520099": acq2 by acquired
+  "522818": the knowledge project
+  "743229": the daily
+  "524900": macro hive conversations
+  "714258": how i built this with guy raz
+  "551334": planet money
+  "254103": squawk pod (cnbc)
+  "174725": pivot
+  "743157": the meb faber show
+  "745287": lex fridman podcast
 
 # High-signal bitcoin-native shows. EXCLUDED from normal mainstream queries (so
 # they don't pollute a Fed/oil brief), but ADMITTED when the topic is bitcoin /
@@ -94,7 +134,13 @@ confidence_signals:
   high_min: 0.7
   medium_min: 0.4
 
-# Keyword classifier for topic-quotes groupBy: "bull-bear".
+# Bull/bear keyword classifier (taste.classifyBullBear). USED ONLY by the
+# NARRATIVE kind's `groupBy: "bull-bear"` lens (services/tape/topicQuotes.js) — it
+# tags each clip bull/bear/neutral by keyword counting.
+# NOT used by the shipping kinds: Read-in's bear slot and Split's camps run the
+# LLM stance classifier (services/tape/stanceClassifier.js) instead, which is far
+# more accurate. Kept for Narrative (not in this release). If Narrative is ever
+# promoted, route its groupBy through the stance classifier and delete these.
 bull_keywords:
   - rally
   - upside
@@ -108,6 +154,28 @@ bull_keywords:
   - optimistic
   - higher
   - surge
+  - accumulate
+  - overweight
+  - undervalued
+  - conviction
+  - tailwind
+  - momentum
+  - beat
+  - beats
+  - record
+  - all-time high
+  - melt-up
+  - squeeze
+  - re-rate
+  - rerating
+  - compounder
+  - moat
+  - secular
+  - strong
+  - soar
+  - ripping
+  - upgrade
+  - raised guidance
 
 bear_keywords:
   - crash
@@ -123,3 +191,26 @@ bear_keywords:
   - lower
   - plunge
   - risk
+  - overvalued
+  - expensive
+  - priced for perfection
+  - headwind
+  - decline
+  - capitulation
+  - selloff
+  - drawdown
+  - correction
+  - collapse
+  - downgrade
+  - cut guidance
+  - miss
+  - dilution
+  - bankruptcy
+  - falling knife
+  - deteriorating
+  - slowdown
+  - contraction
+  - margin compression
+  - rolling over
+  - short thesis
+  - avoid

--- a/constants/agentModels.js
+++ b/constants/agentModels.js
@@ -246,6 +246,15 @@ const AGENT_MODELS = {
     label: 'GPT-4o mini (OpenAI)',
     maxSynthesisTokens: parseInt(process.env.OPENAI_GPT4O_MINI_MAX_SYNTHESIS_TOKENS || '4096', 10),
   },
+  'gpt-4o': {
+    key: 'gpt-4o',
+    provider: 'openai',
+    id: process.env.OPENAI_GPT4O_MODEL || 'gpt-4o',
+    inputPer1M: parseFloat(process.env.OPENAI_GPT4O_INPUT_PER_1M || '2.50'),
+    outputPer1M: parseFloat(process.env.OPENAI_GPT4O_OUTPUT_PER_1M || '10.00'),
+    label: 'GPT-4o (OpenAI)',
+    maxSynthesisTokens: parseInt(process.env.OPENAI_GPT4O_MAX_SYNTHESIS_TOKENS || '4096', 10),
+  },
 };
 
 // Default routing: hardcoded to 'quality' (currently the DeepSeek V4-Flash

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "nostr:process-mentions": "node scripts/nostr-process-mentions.js",
     "nostr:decrypt-private-zap": "node scripts/nostr-decrypt-private-zap.js",
     "test:zap-validator": "node tests/zap-receipt-validator.test.js",
-    "test:reranker": "node tests/clip-reranker.test.js"
+    "test:reranker": "node tests/clip-reranker.test.js",
+    "test:tape-eval": "node scripts/tape-eval.js"
   },
   "author": "uj21",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "nostr:watch-zaps": "node scripts/nostr-watch-zaps.js",
     "nostr:process-mentions": "node scripts/nostr-process-mentions.js",
     "nostr:decrypt-private-zap": "node scripts/nostr-decrypt-private-zap.js",
-    "test:zap-validator": "node tests/zap-receipt-validator.test.js"
+    "test:zap-validator": "node tests/zap-receipt-validator.test.js",
+    "test:tape-quote": "node tests/tape-finnhub-quote.test.js"
   },
   "author": "uj21",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "nostr:decrypt-private-zap": "node scripts/nostr-decrypt-private-zap.js",
     "test:zap-validator": "node tests/zap-receipt-validator.test.js",
     "test:reranker": "node tests/clip-reranker.test.js",
-    "test:tape-eval": "node scripts/tape-eval.js"
+    "test:tape-eval": "node scripts/tape-eval.js",
+    "cards:build": "node scripts/build-company-cards.js",
+    "cards:hydrate": "node scripts/hydrate-stale-cards.js"
   },
   "author": "uj21",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "nostr:process-mentions": "node scripts/nostr-process-mentions.js",
     "nostr:decrypt-private-zap": "node scripts/nostr-decrypt-private-zap.js",
     "test:zap-validator": "node tests/zap-receipt-validator.test.js",
-    "test:tape-quote": "node tests/tape-finnhub-quote.test.js"
+    "test:tape-quote": "node tests/tape-finnhub-quote.test.js",
+    "test:tape-narrative": "node tests/tape-narrative-compliance.test.js"
   },
   "author": "uj21",
   "license": "ISC",

--- a/routes/tapeRoutes.js
+++ b/routes/tapeRoutes.js
@@ -15,7 +15,8 @@ const express = require('express');
 
 const { signTapeToken, requireTapeAuth, passwordMatches } = require('../services/tape/tapeAuth');
 const { tapeError } = require('../services/tape/tapeErrors');
-const { withCachedEndpoint, checkRateLimit, logTape } = require('../services/tape/tapeEndpoint');
+const { withCachedEndpoint, withKindEndpoint, checkRateLimit, logTape } = require('../services/tape/tapeEndpoint');
+const { runDossier, runBrief, runSplit, runNarrative, runReadin } = require('../services/tape/kindOrchestrator');
 const { TIER, qualTtlSec } = require('../services/tape/tapeFreshness');
 const { hashBody, candidateIds } = require('../services/tape/tapeShared');
 const { TapeHttpError } = require('../services/tape/tapeErrors');
@@ -101,6 +102,14 @@ function createTapeRoutes({ openai } = {}) {
 
   // --- POST /synthesize (custom: streaming + cost guards) ---
   router.post('/synthesize', createSynthesizeHandler());
+
+  // --- Kind-level endpoints (consolidated: retrieve→synthesize→parse→hydrate) ---
+  // The client-facing surface going forward; the primitives above are internal.
+  router.post('/dossier', withKindEndpoint({ kind: 'dossier', hourlyLimit: 30, run: (body, ctx) => runDossier(body, { ...ctx, openai }) }));
+  router.post('/brief', withKindEndpoint({ kind: 'brief', hourlyLimit: 30, run: (body, ctx) => runBrief(body, { ...ctx, openai }) }));
+  router.post('/split', withKindEndpoint({ kind: 'split', hourlyLimit: 30, run: (body, ctx) => runSplit(body, { ...ctx, openai }) }));
+  router.post('/narrative', withKindEndpoint({ kind: 'narrative', hourlyLimit: 30, run: (body, ctx) => runNarrative(body, { ...ctx, openai }) }));
+  router.post('/readin', withKindEndpoint({ kind: 'readin', hourlyLimit: 30, run: (body, ctx) => runReadin(body, { ...ctx, openai }) }));
 
   return router;
 }

--- a/routes/tapeRoutes.js
+++ b/routes/tapeRoutes.js
@@ -105,11 +105,11 @@ function createTapeRoutes({ openai } = {}) {
 
   // --- Kind-level endpoints (consolidated: retrieve→synthesize→parse→hydrate) ---
   // The client-facing surface going forward; the primitives above are internal.
-  router.post('/dossier', withKindEndpoint({ kind: 'dossier', hourlyLimit: 30, run: (body, ctx) => runDossier(body, { ...ctx, openai }) }));
-  router.post('/brief', withKindEndpoint({ kind: 'brief', hourlyLimit: 30, run: (body, ctx) => runBrief(body, { ...ctx, openai }) }));
-  router.post('/split', withKindEndpoint({ kind: 'split', hourlyLimit: 30, run: (body, ctx) => runSplit(body, { ...ctx, openai }) }));
-  router.post('/narrative', withKindEndpoint({ kind: 'narrative', hourlyLimit: 30, run: (body, ctx) => runNarrative(body, { ...ctx, openai }) }));
-  router.post('/readin', withKindEndpoint({ kind: 'readin', hourlyLimit: 30, run: (body, ctx) => runReadin(body, { ...ctx, openai }) }));
+  router.post('/dossier', withKindEndpoint({ kind: 'dossier', hourlyLimit: 30, openai, run: (body, ctx) => runDossier(body, { ...ctx, openai }) }));
+  router.post('/brief', withKindEndpoint({ kind: 'brief', hourlyLimit: 30, openai, run: (body, ctx) => runBrief(body, { ...ctx, openai }) }));
+  router.post('/split', withKindEndpoint({ kind: 'split', hourlyLimit: 30, openai, run: (body, ctx) => runSplit(body, { ...ctx, openai }) }));
+  router.post('/narrative', withKindEndpoint({ kind: 'narrative', hourlyLimit: 30, openai, run: (body, ctx) => runNarrative(body, { ...ctx, openai }) }));
+  router.post('/readin', withKindEndpoint({ kind: 'readin', hourlyLimit: 30, openai, run: (body, ctx) => runReadin(body, { ...ctx, openai }) }));
 
   return router;
 }

--- a/routes/tapeRoutes.js
+++ b/routes/tapeRoutes.js
@@ -63,14 +63,21 @@ function createTapeRoutes({ openai } = {}) {
     }
   });
 
+  // Retrieval cache version — bump to evict stale entries when retrieval logic
+  // changes (e.g. theme expansion, ticker filtering). v2 busts pre-expansion
+  // empties like the poisoned "gold prognosis" result.
+  const RV = 'v2';
+  const hasCandidates = (body) => Array.isArray(body.candidates) && body.candidates.length > 0;
+
   // --- POST /person-quotes ---
   router.post('/person-quotes', withCachedEndpoint({
     endpoint: 'person-quotes',
     hourlyLimit: 120,
     tier: TIER.QUALITATIVE,
     ttlSec: () => qualTtlSec(),
-    cacheKey: (req) => `tape:pq:v1:${hashBody(req.body)}`,
+    cacheKey: (req) => `tape:pq:${RV}:${hashBody(req.body)}`,
     idsOf: candidateIds,
+    cacheable: hasCandidates,
     handler: async (req) => {
       const { body, underlying } = await personQuotes(req.body, { openai });
       return { body, fetchedAt: new Date().toISOString(), underlying };
@@ -83,8 +90,9 @@ function createTapeRoutes({ openai } = {}) {
     hourlyLimit: 120,
     tier: TIER.QUALITATIVE,
     ttlSec: () => qualTtlSec(),
-    cacheKey: (req) => `tape:tq:v1:${hashBody(req.body)}`,
+    cacheKey: (req) => `tape:tq:${RV}:${hashBody(req.body)}`,
     idsOf: candidateIds,
+    cacheable: hasCandidates,
     handler: async (req) => {
       const { body, underlying } = await topicQuotes(req.body, { openai });
       return { body, fetchedAt: new Date().toISOString(), underlying };

--- a/routes/tapeRoutes.js
+++ b/routes/tapeRoutes.js
@@ -1,0 +1,100 @@
+/**
+ * Tape skin backend — self-contained /api/tape/* module.
+ *
+ * Mounts: auth + Yahoo/Finnhub quote proxy + person-quotes + topic-quotes +
+ * synthesize. Reuses the existing service layer (searchQuotes, corpusService,
+ * the agent provider abstraction) — see services/tape/* for the recipes and
+ * ./plans/i-am-making-a-gentle-treehouse.md for the design.
+ *
+ * Usage (server.js):
+ *   const createTapeRoutes = require('./routes/tapeRoutes');
+ *   app.use('/api/tape', createTapeRoutes({ openai }));
+ */
+
+const express = require('express');
+
+const { signTapeToken, requireTapeAuth, passwordMatches } = require('../services/tape/tapeAuth');
+const { tapeError } = require('../services/tape/tapeErrors');
+const { withCachedEndpoint, checkRateLimit, logTape } = require('../services/tape/tapeEndpoint');
+const { TIER, qualTtlSec } = require('../services/tape/tapeFreshness');
+const { hashBody, candidateIds } = require('../services/tape/tapeShared');
+const { TapeHttpError } = require('../services/tape/tapeErrors');
+const { getTickerQuote } = require('../services/tape/tickerQuote');
+const { personQuotes } = require('../services/tape/personQuotes');
+const { topicQuotes } = require('../services/tape/topicQuotes');
+const { createSynthesizeHandler } = require('../services/tape/synthesize');
+
+function createTapeRoutes({ openai } = {}) {
+  const router = express.Router();
+
+  // --- POST /auth (unauthenticated; mints the demo JWT) ---
+  router.post('/auth', (req, res) => {
+    const { password } = req.body || {};
+    if (!passwordMatches(password)) {
+      return tapeError(res, 401, 'auth-failed', 'Wrong password');
+    }
+    try {
+      const { token, expiresAt, scope } = signTapeToken();
+      logTape({ endpoint: 'auth', status: 200 });
+      return res.status(200).json({ token, expiresAt, scope });
+    } catch (err) {
+      return tapeError(res, 500, 'auth-misconfigured', 'Auth not configured', err.message);
+    }
+  });
+
+  // All routes below require a valid, current Tape JWT.
+  router.use(requireTapeAuth);
+
+  // --- GET /quote/:slug (Yahoo/Finnhub proxy) ---
+  router.get('/quote/:slug', async (req, res) => {
+    const startedAt = Date.now();
+    try {
+      if (!(await checkRateLimit(req, res, 'quote', 600))) return;
+      const body = await getTickerQuote(req.params.slug);
+      logTape({ endpoint: 'quote', jwt_sub: req.tape?.sub, slug: req.params.slug, cache: body._meta?.cached ? 'hit' : 'miss', stale: body._meta?.stale || false, status: 200, elapsed_ms: Date.now() - startedAt });
+      return res.status(200).json(body);
+    } catch (err) {
+      if (err instanceof TapeHttpError) {
+        logTape({ endpoint: 'quote', jwt_sub: req.tape?.sub, slug: req.params.slug, status: err.status, error: err.slug, elapsed_ms: Date.now() - startedAt });
+        return tapeError(res, err.status, err.slug, err.title, err.detail, err.extra);
+      }
+      logTape({ endpoint: 'quote', jwt_sub: req.tape?.sub, status: 502, error: 'upstream', detail: err.message });
+      return tapeError(res, 502, 'upstream-failure', 'Upstream failure', err.message);
+    }
+  });
+
+  // --- POST /person-quotes ---
+  router.post('/person-quotes', withCachedEndpoint({
+    endpoint: 'person-quotes',
+    hourlyLimit: 120,
+    tier: TIER.QUALITATIVE,
+    ttlSec: () => qualTtlSec(),
+    cacheKey: (req) => `tape:pq:v1:${hashBody(req.body)}`,
+    idsOf: candidateIds,
+    handler: async (req) => {
+      const { body, underlying } = await personQuotes(req.body, { openai });
+      return { body, fetchedAt: new Date().toISOString(), underlying };
+    },
+  }));
+
+  // --- POST /topic-quotes ---
+  router.post('/topic-quotes', withCachedEndpoint({
+    endpoint: 'topic-quotes',
+    hourlyLimit: 120,
+    tier: TIER.QUALITATIVE,
+    ttlSec: () => qualTtlSec(),
+    cacheKey: (req) => `tape:tq:v1:${hashBody(req.body)}`,
+    idsOf: candidateIds,
+    handler: async (req) => {
+      const { body, underlying } = await topicQuotes(req.body, { openai });
+      return { body, fetchedAt: new Date().toISOString(), underlying };
+    },
+  }));
+
+  // --- POST /synthesize (custom: streaming + cost guards) ---
+  router.post('/synthesize', createSynthesizeHandler());
+
+  return router;
+}
+
+module.exports = createTapeRoutes;

--- a/routes/tapeRoutes.js
+++ b/routes/tapeRoutes.js
@@ -24,6 +24,20 @@ const { getTickerQuote } = require('../services/tape/tickerQuote');
 const { personQuotes } = require('../services/tape/personQuotes');
 const { topicQuotes } = require('../services/tape/topicQuotes');
 const { createSynthesizeHandler } = require('../services/tape/synthesize');
+const { warmReadins, getWarmTickers, effectiveLimit } = require('../services/tape/warmReadins');
+const crypto = require('crypto');
+
+/** Timing-safe check of SHARED_HMAC_SECRET in Authorization: Bearer or x-warm-secret. */
+function warmAuthorized(req) {
+  const secret = process.env.SHARED_HMAC_SECRET || '';
+  if (!secret) return false; // route disabled until the secret is configured
+  const presented = String(req.headers.authorization || '').replace(/^Bearer\s+/i, '')
+    || String(req.headers['x-warm-secret'] || '');
+  if (!presented) return false;
+  const a = Buffer.from(presented);
+  const b = Buffer.from(secret);
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
 
 function createTapeRoutes({ openai } = {}) {
   const router = express.Router();
@@ -41,6 +55,54 @@ function createTapeRoutes({ openai } = {}) {
     } catch (err) {
       return tapeError(res, 500, 'auth-misconfigured', 'Auth not configured', err.message);
     }
+  });
+
+  // --- POST /warm (shared-secret; manually arm the in-process Read-In cache warm) ---
+  // Runs in the SAME process so it populates the live in-memory cache (no Redis →
+  // a restart or a separate process can't do this). Gated by SHARED_HMAC_SECRET,
+  // NOT the demo JWT — so it's mounted above requireTapeAuth. Body (all optional):
+  //   { dryRun: true }   → authenticate + return the planned ticker list, NO synthesis (free)
+  //   { only: ["NVDA"] } → warm just these tickers
+  //   { limit: 5 }       → warm the top N of the generic order
+  //   { wait: true }     → await the run and return the summary (use only with a small subset)
+  // Default (no wait): kicks the full warm off in the background, returns 202.
+  let warmInFlight = false;
+  router.post('/warm', async (req, res) => {
+    if (!warmAuthorized(req)) {
+      return tapeError(res, 401, 'unauthorized', 'Unauthorized', 'Missing or invalid warm secret');
+    }
+    const body = req.body || {};
+    const only = Array.isArray(body.only) && body.only.length ? body.only.map(String) : undefined;
+    const limit = Number.isFinite(body.limit) ? body.limit : undefined;
+
+    // dryRun: prove receive + auth without spending a single token.
+    if (body.dryRun === true) {
+      const planned = only || getWarmTickers().slice(0, Number.isFinite(limit) ? limit : effectiveLimit());
+      logTape({ endpoint: 'warm', mode: 'dry-run', count: planned.length, status: 200 });
+      return res.status(200).json({ ok: true, dryRun: true, count: planned.length, tickers: planned });
+    }
+
+    if (warmInFlight) {
+      return tapeError(res, 409, 'warm-in-progress', 'Warm in progress', 'A cache warm is already running on this instance.');
+    }
+    const doWarm = async () => {
+      warmInFlight = true;
+      try { return await warmReadins({ openai, only, limit, log: (m) => console.log(m) }); }
+      finally { warmInFlight = false; }
+    };
+
+    if (body.wait === true) {
+      try {
+        const result = await doWarm();
+        return res.status(200).json({ ok: true, ...result });
+      } catch (err) {
+        return tapeError(res, 502, 'warm-failed', 'Warm failed', err.message);
+      }
+    }
+    // Fire-and-forget: a full warm takes ~30 min, far longer than an HTTP timeout.
+    doWarm().catch((err) => console.error('[TapeWarm] arm error:', err.message));
+    logTape({ endpoint: 'warm', mode: 'async', status: 202 });
+    return res.status(202).json({ ok: true, started: true, message: 'Warm started in background; watch [TapeWarm] logs.' });
   });
 
   // All routes below require a valid, current Tape JWT.

--- a/scripts/arm-warm.js
+++ b/scripts/arm-warm.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Manually arm the in-process Read-In cache warm via the /api/tape/warm route.
+ * Use this to rebuild the live cache on demand (e.g. after a deploy or to shift
+ * the warm to off-hours) WITHOUT restarting — a restart would wipe the in-memory
+ * cache. Authenticates with the shared TAPE_WARM_SECRET.
+ *
+ *   node scripts/arm-warm.js --dry-run                 # auth + list planned tickers, NO synthesis (free)
+ *   node scripts/arm-warm.js --only NVDA,TSLA --wait   # warm just these, wait for the summary
+ *   node scripts/arm-warm.js --limit 5                 # warm top 5 (background)
+ *   node scripts/arm-warm.js                           # full warm (background, ~30 min)
+ *
+ * Targets:
+ *   default        staging (STAGING_URL below)
+ *   --local        http://localhost:4150
+ *   TAPE_WARM_BASE_URL=<url>   explicit override (wins over both)
+ * Env:
+ *   SHARED_HMAC_SECRET  shared secret (must match the server's SHARED_HMAC_SECRET)
+ */
+
+require('dotenv').config();
+
+const STAGING_URL = 'https://pullthatupjamie-explore-alpha-xns9k.ondigitalocean.app';
+
+const argv = process.argv.slice(2);
+const has = (f) => argv.includes(f);
+const opt = (f) => { const i = argv.indexOf(f); return i >= 0 && argv[i + 1] ? argv[i + 1] : null; };
+
+const BASE = process.env.TAPE_WARM_BASE_URL || (has('--local') ? 'http://localhost:4150' : STAGING_URL);
+const SECRET = process.env.SHARED_HMAC_SECRET || '';
+
+const body = {};
+if (has('--dry-run')) body.dryRun = true;
+if (has('--wait')) body.wait = true;
+if (opt('--only')) body.only = opt('--only').split(',').map((s) => s.trim()).filter(Boolean);
+if (opt('--limit')) body.limit = parseInt(opt('--limit'), 10);
+
+(async () => {
+  if (!SECRET) { console.error('TAPE_WARM_SECRET not set in env.'); process.exit(1); }
+  const url = `${BASE.replace(/\/$/, '')}/api/tape/warm`;
+  console.log(`POST ${url}  body=${JSON.stringify(body)}`);
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${SECRET}` },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  let json; try { json = JSON.parse(text); } catch (_) { json = text; }
+  console.log(`HTTP ${res.status}`);
+  console.log(typeof json === 'string' ? json : JSON.stringify(json, null, 2));
+  process.exit(res.ok ? 0 : 1);
+})().catch((e) => { console.error(e.message); process.exit(1); });

--- a/scripts/build-company-cards.js
+++ b/scripts/build-company-cards.js
@@ -28,6 +28,8 @@ const LLM_MODEL = process.env.TAPE_CARD_LLM_MODEL || 'gpt-4o-mini';
 const argv = process.argv.slice(2);
 const has = (f) => argv.includes(f);
 const optN = (f, d) => { const i = argv.indexOf(f); return i >= 0 && argv[i + 1] ? parseInt(argv[i + 1], 10) : d; };
+const optList = (f) => { const i = argv.indexOf(f); return i >= 0 && argv[i + 1] ? argv[i + 1].split(',').map((s) => s.trim().toUpperCase()).filter(Boolean) : null; };
+const BUILD_TS = new Date().toISOString(); // stamps builtAt so the hydration job can find stale cards
 
 // ~250 top US-listed names across sectors + the Tape demo set. Edit freely.
 const UNIVERSE = [
@@ -57,6 +59,12 @@ const UNIVERSE = [
   'BABA', 'PDD', 'JD', 'BIDU', 'NIO',
   // ETFs / commodity proxies in the demo set
   'IBIT', 'GLD',
+  // User-added (2026-06-05): biotech + optics/semis
+  'TVTX', 'AXSM', 'VKTX', 'CRSP', 'NTLA', 'INSM', 'ALNY', 'SRPT', 'ARWR',
+  'COHR', 'TTMI', 'TSM',
+  // +20 biotech (2026-06-05)
+  'BEAM', 'RXRX', 'EXEL', 'INCY', 'BMRN', 'NBIX', 'RARE', 'IONS', 'HALO', 'CYTK',
+  'MDGL', 'KRYS', 'APLS', 'ARGX', 'DNLI', 'TGTX', 'AGIO', 'RVMD', 'ARVN', 'NVAX',
 ];
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -128,7 +136,8 @@ async function main() {
 
   const existing = fs.existsSync(OUT) ? (yaml.load(fs.readFileSync(OUT, 'utf8')) || {}) : {};
   const force = has('--force');
-  let universe = [...new Set(UNIVERSE)];
+  const only = optList('--only'); // rebuild just these (used by the hydration job)
+  let universe = only && only.length ? only : [...new Set(UNIVERSE)];
   const limit = optN('--limit', 0);
   if (limit > 0) universe = universe.slice(0, limit);
   const todo = force ? universe : universe.filter((t) => !existing[t]);
@@ -173,6 +182,7 @@ async function main() {
       ...(Array.isArray(e.products) && e.products.length ? { products: e.products } : {}),
       ...(Array.isArray(e.execs) && e.execs.length ? { execs: e.execs } : {}),
       source: useLlm ? 'finnhub+llm' : 'finnhub',
+      builtAt: BUILD_TS,
     };
   }
 

--- a/scripts/build-company-cards.js
+++ b/scripts/build-company-cards.js
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+/**
+ * Build config/tape-company-cards.yaml for the Tape company-card layer.
+ *
+ *   node scripts/build-company-cards.js              # all, skip existing
+ *   node scripts/build-company-cards.js --force      # rebuild every ticker
+ *   node scripts/build-company-cards.js --limit 10   # first N (smoke)
+ *   node scripts/build-company-cards.js --no-llm     # Finnhub backbone only
+ *
+ * Per ticker:
+ *   - Finnhub profile2  → name, industry, marketCap, weburl, exchange (RELIABLE)
+ *   - gpt-4o-mini batch → description, products[], execs[] (BEST-EFFORT; the
+ *     prompt is conservative — leave fields empty rather than guess).
+ *
+ * Finnhub free tier is ~60 calls/min, so calls are spaced ~1.1s. Idempotent:
+ * existing cards are preserved unless --force.
+ */
+
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const { OpenAI } = require('openai');
+
+const OUT = path.join(__dirname, '..', 'config', 'tape-company-cards.yaml');
+const FINNHUB = 'https://finnhub.io/api/v1';
+const LLM_MODEL = process.env.TAPE_CARD_LLM_MODEL || 'gpt-4o-mini';
+const argv = process.argv.slice(2);
+const has = (f) => argv.includes(f);
+const optN = (f, d) => { const i = argv.indexOf(f); return i >= 0 && argv[i + 1] ? parseInt(argv[i + 1], 10) : d; };
+
+// ~250 top US-listed names across sectors + the Tape demo set. Edit freely.
+const UNIVERSE = [
+  // Mega-cap tech / AI
+  'AAPL', 'MSFT', 'GOOGL', 'GOOG', 'AMZN', 'NVDA', 'META', 'AVGO', 'ORCL', 'CRM', 'ADBE', 'AMD', 'INTC', 'QCOM', 'TXN', 'MU', 'AMAT', 'LRCX', 'KLAC', 'ARM', 'PLTR', 'SNOW', 'NOW', 'PANW', 'CRWD', 'NET', 'DDOG', 'ZS', 'SNPS', 'CDNS', 'ANET', 'DELL', 'HPQ', 'IBM', 'CSCO', 'SMCI', 'CRWV', 'APP', 'TTD', 'U', 'RBLX', 'SHOP', 'UBER', 'ABNB', 'DASH', 'SPOT', 'COIN', 'HOOD', 'SQ', 'PYPL', 'MSTR',
+  // Comms / media
+  'NFLX', 'DIS', 'CMCSA', 'T', 'VZ', 'TMUS', 'WBD', 'PARA', 'EA', 'TTWO',
+  // Consumer
+  'WMT', 'COST', 'TGT', 'HD', 'LOW', 'NKE', 'SBUX', 'MCD', 'KO', 'PEP', 'PG', 'CL', 'MDLZ', 'KHC', 'GIS', 'PM', 'MO', 'EL', 'LULU', 'CMG', 'YUM', 'DPZ', 'ULTA', 'DG', 'DLTR', 'KR', 'F', 'GM',
+  // Financials
+  'JPM', 'BAC', 'WFC', 'C', 'GS', 'MS', 'BLK', 'SCHW', 'AXP', 'V', 'MA', 'SPGI', 'CME', 'ICE', 'COF', 'USB', 'PNC', 'TFC', 'BX', 'KKR', 'APO', 'BRK.B',
+  // Healthcare / biotech
+  'UNH', 'JNJ', 'LLY', 'PFE', 'MRK', 'ABBV', 'TMO', 'ABT', 'DHR', 'BMY', 'AMGN', 'GILD', 'VRTX', 'REGN', 'MRNA', 'BIIB', 'ISRG', 'MDT', 'SYK', 'BSX', 'CVS', 'CI', 'HUM', 'ZTS',
+  // Industrials
+  'CAT', 'DE', 'BA', 'GE', 'HON', 'RTX', 'LMT', 'NOC', 'GD', 'MMM', 'UPS', 'FDX', 'UNP', 'CSX', 'EMR', 'ETN', 'PH', 'ITW', 'GEV',
+  // Energy
+  'XOM', 'CVX', 'COP', 'SLB', 'EOG', 'OXY', 'PSX', 'MPC', 'VLO', 'WMB', 'KMI', 'LNG', 'HAL', 'DVN', 'FANG',
+  // Utilities / nuclear / power
+  'CEG', 'VST', 'NEE', 'DUK', 'SO', 'D', 'AEP', 'EXC', 'SRE', 'OKLO', 'SMR', 'CCJ',
+  // Materials / commodities-linked equities
+  'LIN', 'SHW', 'FCX', 'NEM', 'GOLD', 'NUE', 'DOW', 'GLW',
+  // Real estate
+  'PLD', 'AMT', 'EQIX', 'O', 'SPG',
+  // Autos / EV / mobility
+  'TSLA', 'RIVN', 'LCID',
+  // China tech (US-listed ADRs)
+  'BABA', 'PDD', 'JD', 'BIDU', 'NIO',
+  // ETFs / commodity proxies in the demo set
+  'IBIT', 'GLD',
+];
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function finnhubProfile(symbol, key) {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      const resp = await fetch(`${FINNHUB}/stock/profile2?symbol=${encodeURIComponent(symbol)}&token=${key}`);
+      if (resp.status === 429) { await sleep(2000); continue; }
+      if (!resp.ok) return null;
+      const j = await resp.json();
+      if (!j || !j.name) return null;
+      return {
+        name: j.name,
+        industry: j.finnhubIndustry || null,
+        marketCap: j.marketCapitalization ? Math.round(j.marketCapitalization) : null,
+        weburl: j.weburl || null,
+        exchange: j.exchange || null,
+      };
+    } catch (_) { await sleep(1000); }
+  }
+  return null;
+}
+
+const ENRICH_SCHEMA = {
+  type: 'object', additionalProperties: false, required: ['cards'],
+  properties: {
+    cards: {
+      type: 'array',
+      items: {
+        type: 'object', additionalProperties: false, required: ['ticker', 'description', 'products', 'execs'],
+        properties: {
+          ticker: { type: 'string' },
+          description: { type: 'string', description: '1-2 sentence plain-English summary of what the company does' },
+          products: { type: 'array', items: { type: 'string' }, description: '3-6 flagship products / business segments / brands' },
+          execs: { type: 'array', items: { type: 'string' }, description: 'current CEO and at most 1-2 other widely-known executives, full names' },
+        },
+      },
+    },
+  },
+};
+
+async function enrichBatch(openai, batch) {
+  const list = batch.map((b) => `${b.ticker} = ${b.name}${b.industry ? ` [${b.industry}]` : ''}`).join('\n');
+  const system = `You produce concise reference cards for well-known public companies. For each ticker return a 1-2 sentence description of what it does, 3-6 flagship products/segments/brands, and the current CEO (plus at most 1-2 other widely-known executives) by full name.
+CRITICAL: only state facts you are confident are current and correct. If you are unsure of a company's executives or products, return an EMPTY array for that field rather than guessing — a wrong CEO name or product is worse than an empty list. Do not invent.`;
+  const resp = await openai.chat.completions.create({
+    model: LLM_MODEL,
+    messages: [
+      { role: 'system', content: system },
+      { role: 'user', content: `Produce cards for:\n${list}` },
+    ],
+    response_format: { type: 'json_schema', json_schema: { name: 'company_cards', strict: true, schema: ENRICH_SCHEMA } },
+    temperature: 0.1,
+    max_tokens: 4000,
+  });
+  const parsed = JSON.parse(resp.choices[0].message.content || '{"cards":[]}');
+  const byTicker = new Map();
+  for (const c of parsed.cards || []) byTicker.set(String(c.ticker).toUpperCase(), c);
+  return byTicker;
+}
+
+async function main() {
+  const key = process.env.FINNHUB_API_KEY;
+  if (!key) { console.error('FINNHUB_API_KEY not set'); process.exit(2); }
+  const useLlm = !has('--no-llm');
+  const openai = useLlm ? new OpenAI({ apiKey: process.env.OPENAI_API_KEY }) : null;
+  if (useLlm && !process.env.OPENAI_API_KEY) { console.error('OPENAI_API_KEY not set (or pass --no-llm)'); process.exit(2); }
+
+  const existing = fs.existsSync(OUT) ? (yaml.load(fs.readFileSync(OUT, 'utf8')) || {}) : {};
+  const force = has('--force');
+  let universe = [...new Set(UNIVERSE)];
+  const limit = optN('--limit', 0);
+  if (limit > 0) universe = universe.slice(0, limit);
+  const todo = force ? universe : universe.filter((t) => !existing[t]);
+  console.log(`Universe ${universe.length}, building ${todo.length} (skipping ${universe.length - todo.length} existing). LLM: ${useLlm ? LLM_MODEL : 'off'}`);
+
+  // 1) Finnhub backbone (throttled).
+  const backbone = {};
+  let i = 0;
+  for (const t of todo) {
+    i += 1;
+    const p = await finnhubProfile(t, key);
+    if (p) backbone[t] = p;
+    else console.warn(`  ! ${t}: no Finnhub profile`);
+    if (i % 25 === 0) console.log(`  finnhub ${i}/${todo.length}`);
+    await sleep(1100); // ~55/min, under the 60/min free cap
+  }
+
+  // 2) LLM enrichment in batches of 12.
+  const enrich = new Map();
+  if (useLlm) {
+    const have = todo.filter((t) => backbone[t]).map((t) => ({ ticker: t, ...backbone[t] }));
+    for (let b = 0; b < have.length; b += 12) {
+      const batch = have.slice(b, b + 12);
+      try { const m = await enrichBatch(openai, batch); for (const [k, v] of m) enrich.set(k, v); }
+      catch (e) { console.warn(`  ! enrich batch ${b}: ${e.message}`); }
+      console.log(`  enrich ${Math.min(b + 12, have.length)}/${have.length}`);
+    }
+  }
+
+  // 3) Merge → cards.
+  const out = { ...existing };
+  for (const t of todo) {
+    const bb = backbone[t];
+    if (!bb) continue;
+    const e = enrich.get(t) || {};
+    out[t] = {
+      name: bb.name,
+      industry: bb.industry,
+      marketCap: bb.marketCap,
+      weburl: bb.weburl,
+      ...(e.description ? { description: e.description } : {}),
+      ...(Array.isArray(e.products) && e.products.length ? { products: e.products } : {}),
+      ...(Array.isArray(e.execs) && e.execs.length ? { execs: e.execs } : {}),
+      source: useLlm ? 'finnhub+llm' : 'finnhub',
+    };
+  }
+
+  // Stable sort by ticker for a clean diff.
+  const sorted = {};
+  for (const k of Object.keys(out).sort()) sorted[k] = out[k];
+  fs.mkdirSync(path.dirname(OUT), { recursive: true });
+  fs.writeFileSync(OUT, `# Tape company cards — built by scripts/build-company-cards.js\n# Backbone (name/industry/marketCap/weburl) from Finnhub; description/products/execs LLM-drafted (verify before trusting).\n${yaml.dump(sorted, { lineWidth: 120 })}`);
+  console.log(`\nWrote ${Object.keys(sorted).length} cards → ${OUT}`);
+}
+
+main().catch((e) => { console.error('FATAL', e); process.exit(1); });

--- a/scripts/hydrate-stale-cards.js
+++ b/scripts/hydrate-stale-cards.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Hydrate stale company cards — keeps config/tape-company-cards.yaml fresh out of
+ * band so request-time lookups stay zippy (always in-memory, never a live API).
+ *
+ *   node scripts/hydrate-stale-cards.js                 # rebuild cards older than 30d
+ *   node scripts/hydrate-stale-cards.js --max-age-days 14
+ *   node scripts/hydrate-stale-cards.js --dry-run       # just list what's stale
+ *   node scripts/hydrate-stale-cards.js --limit 40      # cap per run (Finnhub rate)
+ *
+ * Staleness = builtAt older than max-age (or missing builtAt). Re-builds the stale
+ * subset by shelling out to build-company-cards.js --only <stale> --force, so all
+ * the Finnhub+LLM logic lives in one place. Intended to be run on a schedule (cron
+ * or node-cron); a single run is rate-limit-friendly via --limit.
+ */
+
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const { spawn } = require('child_process');
+
+const CARDS = path.join(__dirname, '..', 'config', 'tape-company-cards.yaml');
+const BUILDER = path.join(__dirname, 'build-company-cards.js');
+const argv = process.argv.slice(2);
+const optN = (f, d) => { const i = argv.indexOf(f); return i >= 0 && argv[i + 1] ? parseInt(argv[i + 1], 10) : d; };
+const has = (f) => argv.includes(f);
+
+const MAX_AGE_DAYS = optN('--max-age-days', parseInt(process.env.TAPE_CARD_MAX_AGE_DAYS || '30', 10));
+const LIMIT = optN('--limit', parseInt(process.env.TAPE_CARD_HYDRATE_BATCH || '60', 10)); // Finnhub ~60/min
+const DRY = has('--dry-run');
+const DAY_MS = 86_400_000;
+
+function staleTickers(cards, now) {
+  const out = [];
+  for (const [ticker, c] of Object.entries(cards)) {
+    const built = c && c.builtAt ? Date.parse(c.builtAt) : NaN;
+    const ageDays = Number.isFinite(built) ? (now - built) / DAY_MS : Infinity; // missing builtAt = stale
+    if (ageDays > MAX_AGE_DAYS) out.push({ ticker, ageDays });
+  }
+  // Oldest first, so a capped run refreshes the most-stale.
+  return out.sort((a, b) => b.ageDays - a.ageDays);
+}
+
+function main() {
+  if (!fs.existsSync(CARDS)) { console.error('No cards file at', CARDS); process.exit(2); }
+  const now = Date.now();
+  const cards = yaml.load(fs.readFileSync(CARDS, 'utf8')) || {};
+  const total = Object.keys(cards).length;
+  let stale = staleTickers(cards, now);
+  console.log(`${total} cards; ${stale.length} stale (> ${MAX_AGE_DAYS}d).`);
+  if (!stale.length) { console.log('Nothing to hydrate.'); return; }
+
+  if (stale.length > LIMIT) {
+    console.log(`Capping to ${LIMIT} most-stale this run (rerun for the rest).`);
+    stale = stale.slice(0, LIMIT);
+  }
+  const tickers = stale.map((s) => s.ticker);
+  console.log(`${DRY ? '[dry-run] would rebuild' : 'rebuilding'}: ${tickers.join(', ')}`);
+  if (DRY) return;
+
+  const child = spawn('node', [BUILDER, '--only', tickers.join(','), '--force'], { stdio: 'inherit' });
+  child.on('exit', (code) => process.exit(code || 0));
+}
+
+main();

--- a/scripts/tape-eval-scenarios.js
+++ b/scripts/tape-eval-scenarios.js
@@ -91,4 +91,36 @@ const scenarios = [
   { id: 'sp_asym', kind: 'split', body: { personA: 'bulls', personB: 'bears', topic: 'micro-cap space launch startups' }, tags: ['edge', 'asymmetric'], expect: { confidence: THIN } },
 ];
 
+// ---------------------------------------------------------------------------
+// THIN-COVERAGE COHORT (lesser-known small-cap / biotech Read-ins).
+// Corpus coverage (usable clips) was measured before selecting these — the point
+// is NOT "is there a lot of material" but "given what little IS there, do we make
+// an honest, decent read — or degrade gracefully (industry fallback + disclaimer)
+// — WITHOUT fabricating?". Judged under the `thin` rubric (see scripts/tape-eval.js):
+// fabrication / wrong-entity / overconfidence FAIL; a thin/empty label, a missing
+// bull or bear side, and an industry-fallback result all PASS (correct behavior).
+// Run just this cohort with: node scripts/tape-eval.js --tag thin
+const THIN_COHORT = [
+  // limited coverage (~3-6 usable clips) — the core "decent read from little" test
+  { id: 'tc_vktx', ticker: 'VKTX', note: 'Viking Therapeutics ~6' },
+  { id: 'tc_insm', ticker: 'INSM', note: 'Insmed ~5' },
+  { id: 'tc_rxrx', ticker: 'RXRX', note: 'Recursion ~5' },
+  { id: 'tc_ions', ticker: 'IONS', note: 'Ionis ~4' },
+  { id: 'tc_ntla', ticker: 'NTLA', note: 'Intellia ~3' },
+  { id: 'tc_exel', ticker: 'EXEL', note: 'Exelixis ~3' },
+  // moderate-niche (~10-15) — more to work with, still off the beaten path
+  { id: 'tc_srpt', ticker: 'SRPT', note: 'Sarepta ~10' },
+  { id: 'tc_nbix', ticker: 'NBIX', note: 'Neurocrine ~13' },
+  { id: 'tc_alny', ticker: 'ALNY', note: 'Alnylam ~15' },
+  // very thin (~1-2) — stress: honest thin or graceful fallback
+  { id: 'tc_arwr', ticker: 'ARWR', note: 'Arrowhead ~2' },
+  { id: 'tc_cohr', ticker: 'COHR', note: 'Coherent (optics) ~1' },
+  // zero coverage — must use the industry fallback + disclaimer, never fabricate
+  { id: 'tc_tvtx', ticker: 'TVTX', note: 'Travere ~0 (fallback)' },
+];
+THIN_COHORT.forEach((s) => scenarios.push({
+  id: s.id, kind: 'readin', body: { ticker: s.ticker }, tags: ['thin', 'biotech'],
+  expect: { confidence: ANY, noServerError: true }, // thin/empty/partial all acceptable
+}));
+
 module.exports = { scenarios, TODAY, OLD };

--- a/scripts/tape-eval-scenarios.js
+++ b/scripts/tape-eval-scenarios.js
@@ -1,0 +1,94 @@
+/**
+ * Scenario matrix for the Tape eval harness (scripts/tape-eval.js).
+ *
+ * Only the three shipping kinds: readin, brief, split. Each row is EXACTLY the
+ * body the frontend POSTs to /api/tape/<kind>. `expect` drives the deterministic
+ * Layer-1 gate; `judge` notes steer the Sonnet rubric. `stability3x` flags the
+ * ~6 representative rows the harness re-runs 3x for variance.
+ *
+ * Confidence bands are intentionally lenient on the happy path (synthesis is
+ * non-deterministic; `partial` is an acceptable outcome). The bands exist to
+ * catch the WRONG end of the scale — a junk ticker must be `empty`, a niche
+ * topic must not claim `strong`.
+ */
+
+const TODAY = '2026-06-04';
+const OLD = '2026-03-01'; // exercises the Brief 7->30->90 window auto-expand
+
+const HAPPY = ['strong', 'partial'];
+const HAPPY_OR_THIN = ['strong', 'partial', 'thin'];
+const THIN = ['thin', 'partial', 'empty'];
+const ANY = ['strong', 'partial', 'thin', 'empty'];
+const EMPTY = ['empty'];
+
+const scenarios = [
+  // ----------------------------- READ-IN (~20) -----------------------------
+  // Named equities — rich coverage expected.
+  { id: 'ri_tsla', kind: 'readin', body: { ticker: 'TSLA' }, tags: ['happy'], expect: { confidence: HAPPY } },
+  { id: 'ri_nvda', kind: 'readin', body: { ticker: 'NVDA' }, tags: ['happy', 'core'], expect: { confidence: HAPPY }, stability3x: true },
+  { id: 'ri_app', kind: 'readin', body: { ticker: 'APP' }, tags: ['happy'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'ri_jpm', kind: 'readin', body: { ticker: 'JPM' }, tags: ['happy'], expect: { confidence: HAPPY } },
+  { id: 'ri_hood', kind: 'readin', body: { ticker: 'HOOD' }, tags: ['happy'], expect: { confidence: HAPPY } },
+  { id: 'ri_mstr', kind: 'readin', body: { ticker: 'MSTR' }, tags: ['happy', 'bitcoin-proxy'], expect: { confidence: HAPPY } },
+  { id: 'ri_orcl', kind: 'readin', body: { ticker: 'ORCL' }, tags: ['happy'], expect: { confidence: HAPPY } },
+  { id: 'ri_crwv', kind: 'readin', body: { ticker: 'CRWV' }, tags: ['happy', 'ad-read-prone'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'ri_glw', kind: 'readin', body: { ticker: 'GLW' }, tags: ['happy'], expect: { confidence: HAPPY_OR_THIN } },
+  // Nuclear basket.
+  { id: 'ri_ceg', kind: 'readin', body: { ticker: 'CEG' }, tags: ['happy', 'nuclear'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'ri_oklo', kind: 'readin', body: { ticker: 'OKLO' }, tags: ['happy', 'nuclear', 'hype'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'ri_smr', kind: 'readin', body: { ticker: 'SMR' }, tags: ['nuclear'], expect: { confidence: HAPPY_OR_THIN } },
+  // Commodity proxies (per the "Brief + proxy Read-Ins" decision).
+  { id: 'ri_ibit', kind: 'readin', body: { ticker: 'IBIT' }, tags: ['commodity-proxy', 'bitcoin'], expect: { confidence: ANY } },
+  { id: 'ri_gld', kind: 'readin', body: { ticker: 'GLD' }, tags: ['commodity-proxy', 'gold'], expect: { confidence: ANY } },
+  { id: 'ri_xom', kind: 'readin', body: { ticker: 'XOM' }, tags: ['commodity-proxy', 'oil'], expect: { confidence: HAPPY_OR_THIN } },
+  // Boring retailers.
+  { id: 'ri_wmt', kind: 'readin', body: { ticker: 'WMT' }, tags: ['happy', 'retail'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'ri_tgt', kind: 'readin', body: { ticker: 'TGT' }, tags: ['retail'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'ri_cost', kind: 'readin', body: { ticker: 'COST' }, tags: ['retail'], expect: { confidence: HAPPY_OR_THIN } },
+  // Edge cases.
+  { id: 'ri_junk', kind: 'readin', body: { ticker: 'ZXQW9' }, tags: ['edge', 'empty-expected'], expect: { confidence: EMPTY }, stability3x: true },
+  { id: 'ri_ambig', kind: 'readin', body: { ticker: 'GOLD' }, tags: ['edge', 'ambiguous-slug'], expect: { confidence: ANY, noServerError: true } },
+
+  // ------------------------------ BRIEF (~20) ------------------------------
+  { id: 'br_fed', kind: 'brief', body: { topic: 'Fed rate plans', asOfDate: TODAY }, tags: ['happy', 'macro'], expect: { confidence: HAPPY }, stability3x: true },
+  { id: 'br_hormuz', kind: 'brief', body: { topic: 'Strait of Hormuz resolution', asOfDate: TODAY }, tags: ['happy', 'geopolitics'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'br_energy', kind: 'brief', body: { topic: 'Energy sector outlook', asOfDate: TODAY }, tags: ['happy'], expect: { confidence: HAPPY } },
+  { id: 'br_robotics', kind: 'brief', body: { topic: 'Robotics and automation', asOfDate: TODAY }, tags: ['happy', 'theme'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'br_space', kind: 'brief', body: { topic: 'Space technology', asOfDate: TODAY }, tags: ['theme'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'br_sports', kind: 'brief', body: { topic: 'Sports franchise valuations', asOfDate: TODAY }, tags: ['niche'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'br_shipping', kind: 'brief', body: { topic: 'Shipping companies and freight rates', asOfDate: TODAY }, tags: ['niche'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'br_aibuild', kind: 'brief', body: { topic: 'AI buildout and data center companies', asOfDate: TODAY }, tags: ['happy', 'theme'], expect: { confidence: HAPPY } },
+  { id: 'br_chinatech', kind: 'brief', body: { topic: 'Chinese technology stocks', asOfDate: TODAY }, tags: ['happy'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'br_gold', kind: 'brief', body: { topic: 'Gold prices and safe havens', asOfDate: TODAY }, tags: ['happy', 'commodity'], expect: { confidence: HAPPY } },
+  { id: 'br_bitcoin', kind: 'brief', body: { topic: 'Bitcoin', asOfDate: TODAY }, tags: ['happy', 'commodity'], expect: { confidence: HAPPY } },
+  { id: 'br_oil', kind: 'brief', body: { topic: 'Oil prices', asOfDate: TODAY }, tags: ['happy', 'commodity'], expect: { confidence: HAPPY } },
+  { id: 'br_banking', kind: 'brief', body: { topic: 'Banking sector outlook', asOfDate: TODAY }, tags: ['happy'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'br_biotech', kind: 'brief', body: { topic: 'Biotech sector', asOfDate: TODAY }, tags: ['theme'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'br_meddev', kind: 'brief', body: { topic: 'Medical devices industry', asOfDate: TODAY }, tags: ['niche'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'br_retail', kind: 'brief', body: { topic: 'Retailers and consumer spending', asOfDate: TODAY }, tags: ['happy'], expect: { confidence: HAPPY_OR_THIN } },
+  // Window auto-expand (older asOfDate): record windowDays / windowExpanded.
+  { id: 'br_fed_old', kind: 'brief', body: { topic: 'Fed rate plans', asOfDate: OLD }, tags: ['window-expand'], expect: { confidence: HAPPY_OR_THIN, recordWindow: true }, stability3x: true },
+  { id: 'br_btc_old', kind: 'brief', body: { topic: 'Bitcoin', asOfDate: OLD }, tags: ['window-expand'], expect: { confidence: HAPPY_OR_THIN, recordWindow: true } },
+  { id: 'br_hormuz_old', kind: 'brief', body: { topic: 'Strait of Hormuz resolution', asOfDate: OLD }, tags: ['window-expand'], expect: { confidence: ANY, recordWindow: true } },
+  // Deliberately niche -> should NOT claim strong.
+  { id: 'br_niche', kind: 'brief', body: { topic: 'uranium enrichment centrifuge supply chain', asOfDate: TODAY }, tags: ['edge', 'thin-expected'], expect: { confidence: THIN } },
+
+  // ------------------------------ SPLIT (~12) ------------------------------
+  // Camp (bulls/bears) — the topic-quotes groupBy:'bull-bear' code path.
+  { id: 'sp_btc', kind: 'split', body: { personA: 'bulls', personB: 'bears', topic: 'Bitcoin' }, tags: ['camp', 'happy'], expect: { confidence: HAPPY_OR_THIN }, stability3x: true },
+  { id: 'sp_aibubble', kind: 'split', body: { personA: 'bulls', personB: 'bears', topic: 'AI bubble' }, tags: ['camp', 'happy'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'sp_chinatech', kind: 'split', body: { personA: 'bulls', personB: 'bears', topic: 'Chinese technology stocks' }, tags: ['camp'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'sp_tsla', kind: 'split', body: { personA: 'bulls', personB: 'bears', topic: 'Tesla TSLA' }, tags: ['camp'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'sp_nuclear', kind: 'split', body: { personA: 'bulls', personB: 'bears', topic: 'nuclear energy stocks' }, tags: ['camp'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'sp_oil', kind: 'split', body: { personA: 'bulls', personB: 'bears', topic: 'oil prices' }, tags: ['camp'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'sp_gold', kind: 'split', body: { personA: 'bulls', personB: 'bears', topic: 'gold' }, tags: ['camp'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'sp_nvda', kind: 'split', body: { personA: 'bulls', personB: 'bears', topic: 'Nvidia NVDA AI chips' }, tags: ['camp'], expect: { confidence: HAPPY_OR_THIN } },
+  // Named-people — the person-quotes code path (well-known opposers).
+  { id: 'sp_elerian', kind: 'split', body: { personA: 'Mohamed El-Erian', personB: 'Larry Summers', topic: 'recession risk and Fed policy' }, tags: ['named', 'happy'], expect: { confidence: HAPPY_OR_THIN }, stability3x: true },
+  { id: 'sp_saylor', kind: 'split', body: { personA: 'Michael Saylor', personB: 'Peter Schiff', topic: 'Bitcoin' }, tags: ['named'], expect: { confidence: HAPPY_OR_THIN } },
+  { id: 'sp_ai_named', kind: 'split', body: { personA: 'Cathie Wood', personB: 'Jim Chanos', topic: 'AI and tech valuations' }, tags: ['named'], expect: { confidence: HAPPY_OR_THIN } },
+  // Asymmetric edge — one side likely thin.
+  { id: 'sp_asym', kind: 'split', body: { personA: 'bulls', personB: 'bears', topic: 'micro-cap space launch startups' }, tags: ['edge', 'asymmetric'], expect: { confidence: THIN } },
+];
+
+module.exports = { scenarios, TODAY, OLD };

--- a/scripts/tape-eval.js
+++ b/scripts/tape-eval.js
@@ -1,0 +1,500 @@
+#!/usr/bin/env node
+/**
+ * Tape eval harness — exercises the three shipping kinds (readin / brief / split)
+ * exactly as the frontend would, then grades each response in two layers:
+ *
+ *   Layer 1 — deterministic gate (no LLM): HTTP 200, schema/shape, confidence in
+ *             the expected band, every {{clip:id}} resolves to a returned
+ *             citation (no phantom pills), citations carry playable receipts
+ *             (pineconeId + audioUrl + timestamps). Cheap, reliable, runs first;
+ *             a structural failure short-circuits the judge.
+ *   Layer 2 — LLM judge (Claude Sonnet 4.6, independent of the gpt-4o-mini/Haiku
+ *             synthesizer): relevance, grounding, citation quality (ad-read
+ *             detection), confidence honesty, plus kind-specific dimensions
+ *             (Split: are the two sides genuinely opposing; Read-in: is the bear
+ *             slot actually bearish). Returns a structured verdict via forced
+ *             tool-use; the harness computes pass/fail from scores + flags.
+ *
+ * Auth + transport are the real frontend path: a scoped Tape JWT (minted in-proc
+ * via signTapeToken) and POST /api/tape/<kind> over HTTP with refresh:true to
+ * bypass the kind cache so every run measures fresh synthesis.
+ *
+ * Usage:
+ *   node server.js                       # in another terminal (port 4132)
+ *   node scripts/tape-eval.js                       # full suite (~52 + 3x subset)
+ *   node scripts/tape-eval.js --only readin         # one kind
+ *   node scripts/tape-eval.js --limit 3             # first N scenarios (cheap smoke)
+ *   node scripts/tape-eval.js --repeat 3            # force every scenario Nx
+ *   node scripts/tape-eval.js --no-judge            # Layer 1 only (no Anthropic spend)
+ *   node scripts/tape-eval.js --base http://host    # target a different server
+ *
+ * Reports: logs/tape-eval-<utc>.json (full) + .md (summary). Exit 1 if any test fails.
+ */
+
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+const Anthropic = require('@anthropic-ai/sdk');
+const { signTapeToken } = require('../services/tape/tapeAuth');
+const { scenarios } = require('./tape-eval-scenarios');
+
+// ---------------------------------------------------------------- CLI / config
+const argv = process.argv.slice(2);
+const flag = (name) => argv.includes(name);
+const opt = (name, def) => { const i = argv.indexOf(name); return i >= 0 && argv[i + 1] ? argv[i + 1] : def; };
+
+const BASE = opt('--base', `http://localhost:${process.env.PORT || 4132}`);
+const ONLY = opt('--only', null);
+const LIMIT = parseInt(opt('--limit', '0'), 10);
+const FORCE_REPEAT = parseInt(opt('--repeat', '0'), 10);
+const JUDGE_ENABLED = !flag('--no-judge');
+const CONCURRENCY = parseInt(opt('--concurrency', '3'), 10);
+const JUDGE_MODEL = process.env.TAPE_EVAL_JUDGE_MODEL || 'claude-sonnet-4-6';
+// Which synth model each kind ran under (set on the server via env) — used only
+// to price the reported token usage. readin uses its own knob.
+const SYNTH_MODEL = opt('--synth-model', process.env.TAPE_SYNTH_MODEL || 'gpt-4o-mini');
+const READIN_MODEL = opt('--readin-model', process.env.TAPE_READIN_MODEL || 'fast');
+// $/1M tokens [input, output]. 'fast' = Haiku 4.5.
+const PRICE = {
+  'gpt-4o-mini': [0.15, 0.60], 'gpt-4o': [2.50, 10.00], fast: [1.0, 5.0],
+  'claude-haiku-4-5': [1.0, 5.0], quality: [0.14, 0.28],
+};
+const costOf = (model, t) => { const p = PRICE[model] || [0, 0]; return ((t.input || 0) * p[0] + (t.output || 0) * p[1]) / 1e6; };
+const meanScore = (v) => { const s = Object.values((v && v.scores) || {}); return s.length ? s.reduce((a, b) => a + b, 0) / s.length : null; };
+
+const CONF_ENUM = ['strong', 'partial', 'thin', 'empty'];
+
+// --------------------------------------------------------------------- helpers
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const truncate = (s, n) => { const t = String(s || ''); return t.length > n ? `${t.slice(0, n)}…` : t; };
+const clipIdsIn = (text) => [...String(text || '').matchAll(/\{\{clip:([^}]+)\}\}/g)].map((m) => m[1]);
+
+async function postKind(kind, body, token) {
+  const startedAt = Date.now();
+  let resp; let json; let netError = null;
+  try {
+    resp = await fetch(`${BASE}/api/tape/${kind}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+      // refresh:true bypasses the kind cache so we grade fresh synthesis each run.
+      body: JSON.stringify({ ...body, refresh: true }),
+    });
+    json = await resp.json().catch(() => null);
+  } catch (err) {
+    netError = err.message;
+  }
+  return { status: resp ? resp.status : 0, json, netError, elapsedMs: Date.now() - startedAt };
+}
+
+// Collect every citation object across a result, regardless of kind/shape.
+function allCitations(result, kind) {
+  const out = [];
+  const push = (arr) => Array.isArray(arr) && arr.forEach((c) => c && out.push(c));
+  if (kind === 'readin') {
+    push(result.whatTheyDoCitations);
+    push(result.smartMoney?.bulls);
+    push(result.smartMoney?.bears);
+    if (result.pulse?.marqueeCitation) out.push(result.pulse.marqueeCitation);
+  } else if (kind === 'brief') {
+    (result.sections || []).forEach((s) => push(s.citations));
+  } else if (kind === 'split') {
+    push(result.sideA?.citations);
+    push(result.sideB?.citations);
+  }
+  return out;
+}
+
+// Prose fields that may carry inline {{clip:id}} tokens (must resolve to a citation).
+function prosePieces(result, kind) {
+  if (kind === 'readin') return [result.whatTheyDo, result.pulse?.bullLine, result.pulse?.bearLine].filter(Boolean);
+  if (kind === 'brief') return [(result.sections || []).map((s) => s.body || s.summary || '').join('\n')];
+  if (kind === 'split') return [result.sideA?.positionSummary, result.sideB?.positionSummary, result.contrastSummary].filter(Boolean);
+  return [];
+}
+
+// --------------------------------------------------------- Layer 1: assertions
+function assertLayer1(sc, res) {
+  const fails = [];
+  const warns = [];
+  const { status, json, netError } = res;
+
+  if (netError) { fails.push(`network error: ${netError}`); return { fails, warns, infra: true }; }
+  if (status === 429) { return { fails: [], warns: ['rate-limited (429) — restart server to reset in-mem counters'], infra: true }; }
+  if (status !== 200) { fails.push(`HTTP ${status}${json?.detail ? ` — ${truncate(json.detail, 120)}` : ''}`); return { fails, warns, infra: status >= 500 }; }
+  if (!json || typeof json !== 'object') { fails.push('no JSON body'); return { fails, warns }; }
+
+  const conf = json._meta?.confidence;
+  if (!CONF_ENUM.includes(conf)) fails.push(`_meta.confidence missing/invalid: ${JSON.stringify(conf)}`);
+  if (typeof json._meta?.candidateCount !== 'number') warns.push('_meta.candidateCount not a number');
+  if (!Array.isArray(json.tickers)) warns.push('tickers[] missing');
+
+  // Confidence band (only meaningful when defined).
+  const band = sc.expect?.confidence;
+  if (Array.isArray(band) && conf && !band.includes(conf)) {
+    fails.push(`confidence "${conf}" outside expected [${band.join(',')}]`);
+  }
+
+  const isEmpty = conf === 'empty';
+  if (!isEmpty) {
+    // Kind structure must be populated on a non-empty result.
+    if (sc.kind === 'readin') {
+      if (!(json.whatTheyDo && json.whatTheyDo.trim())) fails.push('readin.whatTheyDo empty');
+      if (!json.pulse || typeof json.pulse !== 'object') fails.push('readin.pulse missing');
+      if (!json.smartMoney || !Array.isArray(json.smartMoney.bulls) || !Array.isArray(json.smartMoney.bears)) fails.push('readin.smartMoney malformed');
+      if (!Array.isArray(json.risks)) fails.push('readin.risks missing');
+    } else if (sc.kind === 'brief') {
+      if (!Array.isArray(json.sections) || json.sections.length === 0) fails.push('brief.sections empty');
+      if (typeof json.headline !== 'string') warns.push('brief.headline not a string');
+    } else if (sc.kind === 'split') {
+      if (!json.sideA || !json.sideB) fails.push('split missing sideA/sideB');
+      if (!Array.isArray(json.sideA?.citations) || !Array.isArray(json.sideB?.citations)) fails.push('split sides missing citations[]');
+    }
+
+    // Phantom-pill check: every inline clip token must resolve to a returned citation.
+    const citedIds = new Set(allCitations(json, sc.kind).map((c) => c && c.pineconeId).filter(Boolean));
+    const referenced = prosePieces(json, sc.kind).flatMap(clipIdsIn);
+    const phantom = [...new Set(referenced)].filter((id) => !citedIds.has(id));
+    if (phantom.length) fails.push(`phantom clip token(s) not in citations: ${phantom.slice(0, 3).join(', ')}`);
+
+    // Playable-receipt check on citations.
+    const cites = allCitations(json, sc.kind);
+    if (cites.length === 0) warns.push('no citations attached');
+    const unplayable = cites.filter((c) => !c.pineconeId || !c.audioUrl || c.startTime == null);
+    if (unplayable.length) warns.push(`${unplayable.length}/${cites.length} citation(s) missing audioUrl/startTime`);
+  }
+
+  // Window-expand bookkeeping (Brief older-asOfDate rows).
+  if (sc.expect?.recordWindow && json._meta) {
+    warns.push(`window: ${json._meta.windowDays ?? '?'}d expanded=${json._meta.windowExpanded ?? '?'}`);
+  }
+
+  return { fails, warns };
+}
+
+// ------------------------------------------------------- Layer 2: Sonnet judge
+const JUDGE_DIMS = {
+  readin: ['relevance', 'grounding', 'citation_quality', 'bull_bear_validity', 'confidence_honesty'],
+  brief: ['relevance', 'grounding', 'citation_quality', 'source_diversity', 'confidence_honesty'],
+  split: ['relevance', 'grounding', 'citation_quality', 'opposition', 'confidence_honesty'],
+};
+const FLAG_LIST = ['ad_read_cited', 'unsupported_or_fabricated_claim', 'off_topic_dominant', 'confidence_overstated', 'both_sides_same', 'bear_slot_not_bearish'];
+
+function verdictTool(kind) {
+  const dims = JUDGE_DIMS[kind];
+  const scoreProps = {};
+  dims.forEach((d) => { scoreProps[d] = { type: 'integer', minimum: 1, maximum: 5, description: `1=poor, 5=excellent (${d})` }; });
+  return {
+    name: 'record_verdict',
+    description: 'Record the structured quality verdict for this Tape response.',
+    input_schema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['scores', 'critical_flags', 'rationale'],
+      properties: {
+        scores: { type: 'object', additionalProperties: false, required: dims, properties: scoreProps },
+        critical_flags: { type: 'array', items: { type: 'string', enum: FLAG_LIST }, description: 'Raise only when clearly present.' },
+        rationale: { type: 'string', description: 'One or two sentences justifying the scores and any flags.' },
+      },
+    },
+  };
+}
+
+// Render a compact, judge-readable view of the response (prose + hydrated quotes).
+function renderForJudge(sc, json) {
+  const lines = [`REQUEST: ${sc.kind} ${JSON.stringify(sc.body)}`,
+    `CONFIDENCE (self-reported): ${json._meta?.confidence}${json._meta?.confidenceReason ? ` — ${json._meta.confidenceReason}` : ''}`,
+    `candidateCount=${json._meta?.candidateCount}`, ''];
+  const quote = (c, i) => `   [${i + 1}] (${c.creator || '?'} — ${truncate(c.episodeTitle, 60)}) "${truncate(c.text, 240)}"`;
+  if (sc.kind === 'readin') {
+    lines.push(`WHAT THEY DO: ${truncate(json.whatTheyDo, 500)}`);
+    lines.push(`PULSE bull: ${truncate(json.pulse?.bullLine, 200)}`);
+    lines.push(`PULSE bear: ${truncate(json.pulse?.bearLine, 200)}`);
+    lines.push(`RISKS: ${(json.risks || []).map((r) => truncate(typeof r === 'string' ? r : r.text, 120)).join(' | ')}`);
+    lines.push('SMART MONEY — BULLS:'); (json.smartMoney?.bulls || []).forEach((c, i) => lines.push(quote(c, i)));
+    lines.push('SMART MONEY — BEARS:'); (json.smartMoney?.bears || []).forEach((c, i) => lines.push(quote(c, i)));
+  } else if (sc.kind === 'brief') {
+    lines.push(`HEADLINE: ${json.headline}`);
+    (json.sections || []).forEach((s, si) => {
+      lines.push(`SECTION ${si + 1} (${s.publisher || '?'}): ${truncate(s.body || s.summary || s.text, 300)}`);
+      (s.citations || []).forEach((c, i) => lines.push(quote(c, i)));
+    });
+  } else if (sc.kind === 'split') {
+    lines.push(`SIDE A (${json.sideA?.person}): ${truncate(json.sideA?.positionSummary, 300)}`);
+    (json.sideA?.citations || []).forEach((c, i) => lines.push(quote(c, i)));
+    lines.push(`SIDE B (${json.sideB?.person}): ${truncate(json.sideB?.positionSummary, 300)}`);
+    (json.sideB?.citations || []).forEach((c, i) => lines.push(quote(c, i)));
+    lines.push(`CONTRAST: ${truncate(json.contrastSummary, 300)}`);
+  }
+  return lines.join('\n');
+}
+
+const JUDGE_GUIDANCE = {
+  readin: 'This is a stock "Read-in" primer. Check the BEAR pulse line and SMART MONEY bear quotes are genuinely bearish substance (NOT sponsor/ad reads, promos, or neutral filler) — raise bear_slot_not_bearish or ad_read_cited if so. Grounding = prose claims supported by the quoted clips.',
+  brief: 'This is a topical "Brief". Reward multiple distinct publishers and on-topic, substantive quotes. Penalize ad-reads/promos cited as evidence and claims not supported by the quotes.',
+  split: 'This is a two-sided "Split". The single most important check: are side A and side B genuinely OPPOSING stances on the topic? If both sides argue the same direction, raise both_sides_same and score opposition 1-2. Also flag ad-reads cited as either side.',
+};
+
+async function judge(client, sc, json) {
+  const tool = verdictTool(sc.kind);
+  const system = `You are a rigorous evaluator of an automated financial-podcast summarization API. Score each dimension 1-5 and raise critical flags ONLY when clearly warranted. Be skeptical: a fluent summary built on off-topic or ad-read quotes is a FAILURE, not a pass. ${JUDGE_GUIDANCE[sc.kind]}`;
+  const user = `Evaluate this response and call record_verdict.\n\n${renderForJudge(sc, json)}`;
+  const resp = await client.messages.create({
+    model: JUDGE_MODEL,
+    max_tokens: 1024,
+    temperature: 0,
+    system,
+    tools: [tool],
+    tool_choice: { type: 'tool', name: 'record_verdict' },
+    messages: [{ role: 'user', content: user }],
+  });
+  const block = (resp.content || []).find((b) => b.type === 'tool_use');
+  if (!block) throw new Error('judge returned no tool_use');
+  return { verdict: block.input, usage: resp.usage };
+}
+
+// Pass policy (calibrated): the critical flags are the hard fails (real defects).
+// The numeric bar is "acceptable across the board, not excellent" — a score of 3
+// ("on-topic and supported, if unremarkable") passes; only a 1-2 on a primary
+// dimension fails. This isolates genuine defects from "good-but-not-great", which
+// the original >=4 bar conflated. Tune via TAPE_EVAL_MIN_SCORE.
+const MIN_SCORE = parseInt(process.env.TAPE_EVAL_MIN_SCORE || '3', 10);
+function computePass(layer1, verdict) {
+  if (layer1.fails.length) return { pass: false, why: layer1.fails.join('; ') };
+  if (!verdict) return { pass: true, why: 'layer1-only (empty or no-judge)' };
+  const s = verdict.scores || {};
+  const reasons = [];
+  if ((s.relevance ?? 0) < MIN_SCORE) reasons.push(`relevance ${s.relevance}`);
+  if ((s.grounding ?? 0) < MIN_SCORE) reasons.push(`grounding ${s.grounding}`);
+  if ((s.citation_quality ?? 0) < MIN_SCORE) reasons.push(`citation_quality ${s.citation_quality}`);
+  if (Array.isArray(verdict.critical_flags) && verdict.critical_flags.length) reasons.push(`flags: ${verdict.critical_flags.join(',')}`);
+  return { pass: reasons.length === 0, why: reasons.join('; ') || 'ok' };
+}
+
+// ---------------------------------------------------------------- run one test
+async function runOne(client, sc, token, runIdx) {
+  const res = await postKind(sc.kind, sc.body, token);
+  const layer1 = assertLayer1(sc, res);
+  let verdict = null; let judgeUsage = null;
+  const conf = res.json?._meta?.confidence;
+  const judgeable = JUDGE_ENABLED && client && res.status === 200 && conf && conf !== 'empty' && layer1.fails.length === 0;
+  if (judgeable) {
+    try { const j = await judge(client, sc, res.json); verdict = j.verdict; judgeUsage = j.usage; }
+    catch (err) { layer1.warns.push(`judge error: ${err.message}`); }
+  }
+  const { pass, why } = computePass(layer1, verdict);
+  const tokens = res.json?._meta?.tokens || null;
+  const synthModel = sc.kind === 'readin' ? READIN_MODEL : SYNTH_MODEL;
+  const cost = tokens ? costOf(synthModel, tokens) : 0;
+  const quality = meanScore(verdict); // mean judge dimension (1-5); null if unjudged
+  return {
+    id: sc.id, kind: sc.kind, runIdx, body: sc.body, tags: sc.tags,
+    status: res.status, elapsedMs: res.elapsedMs, infra: !!layer1.infra,
+    confidence: conf ?? null, candidateCount: res.json?._meta?.candidateCount ?? null,
+    layer1Fails: layer1.fails, layer1Warns: layer1.warns,
+    verdict, judgeUsage, pass, why, tokens, synthModel, cost, quality,
+  };
+}
+
+// ------------------------------------------------------- concurrency + repeats
+async function runPool(items, worker, size) {
+  const out = new Array(items.length);
+  let next = 0;
+  async function lane() { while (next < items.length) { const i = next++; out[i] = await worker(items[i], i); } }
+  await Promise.all(Array.from({ length: Math.min(size, items.length) }, lane));
+  return out;
+}
+
+function buildRunList(list) {
+  const jobs = [];
+  for (const sc of list) {
+    const reps = FORCE_REPEAT > 0 ? FORCE_REPEAT : (sc.stability3x ? 3 : 1);
+    for (let r = 0; r < reps; r += 1) jobs.push({ sc, runIdx: r, reps });
+  }
+  return jobs;
+}
+
+// ----------------------------------------------------------------- reporting
+function aggregate(results) {
+  const byId = new Map();
+  for (const r of results) {
+    if (!byId.has(r.id)) byId.set(r.id, []);
+    byId.get(r.id).push(r);
+  }
+  const perScenario = [];
+  for (const [id, runs] of byId) {
+    const passes = runs.filter((r) => r.pass).length;
+    const infra = runs.every((r) => r.infra);
+    const majorityPass = passes * 2 >= runs.length;
+    const qs = runs.map((r) => r.quality).filter((q) => q != null);
+    const quality = qs.length ? qs.reduce((a, b) => a + b, 0) / qs.length : null; // mean dims (1-5)
+    const flagCount = new Set(runs.flatMap((r) => r.verdict?.critical_flags || [])).size;
+    // Tier: PASS (clean) · SOFT (ship-with-caveats: one flag or merely-thin quality)
+    // · HARD (broken: low quality or multiple flags / empty-pool band fail).
+    let tier;
+    if (infra) tier = 'INFRA';
+    else if (majorityPass) tier = 'PASS';
+    else if (quality != null && quality >= 2.5 && flagCount <= 1) tier = 'SOFT';
+    else tier = 'HARD';
+    perScenario.push({
+      id, kind: runs[0].kind, tags: runs[0].tags, body: runs[0].body, runs: runs.length,
+      passes, majorityPass, infra, quality, flagCount, tier,
+      confidences: runs.map((r) => r.confidence),
+      flagged: infra, // surfaced separately
+      detail: runs,
+    });
+  }
+  return perScenario;
+}
+
+function avgDims(results) {
+  const sums = {}; const counts = {};
+  for (const r of results) {
+    if (!r.verdict) continue;
+    for (const [k, v] of Object.entries(r.verdict.scores || {})) { sums[k] = (sums[k] || 0) + v; counts[k] = (counts[k] || 0) + 1; }
+  }
+  const out = {};
+  for (const k of Object.keys(sums)) out[k] = +(sums[k] / counts[k]).toFixed(2);
+  return out;
+}
+
+function mdReport(perScenario, results, meta) {
+  const kinds = ['readin', 'brief', 'split'];
+  const L = [];
+  L.push(`# Tape eval report`, '', `- generated: ${meta.generatedAt}`, `- base: ${meta.base}`, `- judge: ${meta.judgeEnabled ? meta.judgeModel : 'DISABLED'}`, `- scenarios: ${perScenario.length} (${results.length} runs incl. repeats)`, '');
+
+  L.push('## Pass rate by kind', '', '| kind | scenarios | passed | rate |', '|---|---|---|---|');
+  for (const k of kinds) {
+    const rows = perScenario.filter((s) => s.kind === k && !s.infra);
+    const passed = rows.filter((s) => s.majorityPass).length;
+    if (rows.length) L.push(`| ${k} | ${rows.length} | ${passed} | ${Math.round((passed / rows.length) * 100)}% |`);
+  }
+  const gradable = perScenario.filter((s) => !s.infra);
+  const passedAll = gradable.filter((s) => s.majorityPass).length;
+  L.push(`| **all** | **${gradable.length}** | **${passedAll}** | **${gradable.length ? Math.round((passedAll / gradable.length) * 100) : 0}%** |`, '');
+
+  // Overall quality score (0-100) from mean judge dimensions — the gradient view.
+  const qsAll = gradable.map((s) => s.quality).filter((q) => q != null);
+  const meanQ = qsAll.length ? qsAll.reduce((a, b) => a + b, 0) / qsAll.length : 0;
+  L.push('## Quality score & tiers', '', `**Overall quality: ${(meanQ / 5 * 100).toFixed(0)}/100** (mean judge dimension ${meanQ.toFixed(2)}/5)`, '');
+  L.push('| kind | quality /100 | PASS | SOFT | HARD |', '|---|---|---|---|---|');
+  for (const k of kinds) {
+    const rows = gradable.filter((s) => s.kind === k);
+    if (!rows.length) continue;
+    const q = rows.map((s) => s.quality).filter((x) => x != null);
+    const qm = q.length ? Math.round(q.reduce((a, b) => a + b, 0) / q.length / 5 * 100) : 0;
+    const t = (name) => rows.filter((s) => s.tier === name).length;
+    L.push(`| ${k} | ${qm} | ${t('PASS')} | ${t('SOFT')} | ${t('HARD')} |`);
+  }
+  const tAll = (name) => gradable.filter((s) => s.tier === name).length;
+  L.push(`| **all** | **${(meanQ / 5 * 100).toFixed(0)}** | **${tAll('PASS')}** | **${tAll('SOFT')}** | **${tAll('HARD')}** |`, '');
+  L.push('_SOFT = ship-with-caveats (one flag or merely-thin); HARD = broken (low quality / multiple flags / empty pool)._', '');
+
+  // Synthesis cost (token usage × per-model price) + gpt-4o-mini-equivalent differential.
+  const runs = perScenario.flatMap((s) => s.detail);
+  const withTok = runs.filter((r) => r.tokens);
+  if (withTok.length) {
+    const total = withTok.reduce((a, r) => a + (r.cost || 0), 0);
+    const baseline = withTok.reduce((a, r) => a + costOf('gpt-4o-mini', r.tokens), 0);
+    const inTok = withTok.reduce((a, r) => a + (r.tokens.input || 0), 0);
+    const outTok = withTok.reduce((a, r) => a + (r.tokens.output || 0), 0);
+    L.push('## Synthesis cost', '', `- models: non-readin=\`${SYNTH_MODEL}\`, readin=\`${READIN_MODEL}\``,
+      `- tokens: ${inTok.toLocaleString()} in / ${outTok.toLocaleString()} out across ${withTok.length} synths`,
+      `- **total synth cost: $${total.toFixed(4)}** (${(total / withTok.length * 1000).toFixed(2)}¢ per synth × 1000)`,
+      `- same tokens at gpt-4o-mini: $${baseline.toFixed(4)} → **${baseline > 0 ? (total / baseline).toFixed(1) : '∞'}× differential**`, '');
+  }
+
+  const dims = avgDims(results);
+  if (Object.keys(dims).length) {
+    L.push('## Judge dimension averages (1-5)', '', '| dimension | avg |', '|---|---|');
+    for (const [k, v] of Object.entries(dims)) L.push(`| ${k} | ${v} |`);
+    L.push('');
+  }
+
+  const failures = gradable.filter((s) => !s.majorityPass);
+  L.push(`## Failures (${failures.length})`, '');
+  if (failures.length === 0) L.push('_none_', '');
+  else {
+    L.push('| id | kind | conf | why |', '|---|---|---|---|');
+    for (const s of failures) {
+      const r = s.detail.find((x) => !x.pass) || s.detail[0];
+      L.push(`| ${s.id} | ${s.kind} | ${s.confidences.join('/')} | ${truncate((r.why || '') + (r.verdict ? ` — ${r.verdict.rationale}` : ''), 160).replace(/\|/g, '\\|')} |`);
+    }
+    L.push('');
+  }
+
+  const repeated = perScenario.filter((s) => s.runs > 1);
+  if (repeated.length) {
+    L.push('## Stability (repeated scenarios)', '', '| id | runs | passes | confidences |', '|---|---|---|---|');
+    for (const s of repeated) L.push(`| ${s.id} | ${s.runs} | ${s.passes}/${s.runs} | ${s.confidences.join(', ')} |`);
+    L.push('');
+  }
+
+  const infra = perScenario.filter((s) => s.infra);
+  if (infra.length) {
+    L.push(`## Infra / skipped (${infra.length})`, '', '_rate-limit (429) or network/5xx — not quality failures; restart the server to reset in-memory rate counters and re-run._', '');
+    for (const s of infra) L.push(`- ${s.id} (${s.kind}): ${truncate((s.detail[0].layer1Fails.concat(s.detail[0].layer1Warns)).join('; '), 120)}`);
+    L.push('');
+  }
+
+  const lat = results.map((r) => r.elapsedMs).sort((a, b) => a - b);
+  if (lat.length) {
+    const p = (q) => lat[Math.min(lat.length - 1, Math.floor(q * lat.length))];
+    L.push('## Latency (ms)', '', `- p50 ${p(0.5)} · p90 ${p(0.9)} · max ${lat[lat.length - 1]}`, '');
+  }
+  return L.join('\n');
+}
+
+// ----------------------------------------------------------------------- main
+async function main() {
+  let list = scenarios.filter((s) => !ONLY || s.kind === ONLY);
+  if (LIMIT > 0) list = list.slice(0, LIMIT);
+  if (list.length === 0) { console.error('No scenarios match the filter.'); process.exit(2); }
+
+  // Auth exactly as the post-login frontend: a scoped Tape JWT.
+  let token;
+  try { token = signTapeToken().token; }
+  catch (err) { console.error(`Cannot mint Tape JWT: ${err.message}\nIs TAPE_AUTH_SECRET set in .env?`); process.exit(2); }
+
+  // Preflight: confirm the server is up.
+  const ping = await postKind('readin', { ticker: 'AAPL' }, token).catch(() => ({ status: 0 }));
+  if (ping.status === 0) { console.error(`No server at ${BASE}. Start it: node server.js`); process.exit(2); }
+
+  let client = null;
+  if (JUDGE_ENABLED) {
+    if (!process.env.ANTHROPIC_API_KEY) { console.error('ANTHROPIC_API_KEY not set — run with --no-judge for Layer 1 only.'); process.exit(2); }
+    client = new Anthropic();
+  }
+
+  const jobs = buildRunList(list);
+  console.log(`Running ${jobs.length} request(s) across ${list.length} scenario(s) → ${BASE} (judge: ${JUDGE_ENABLED ? JUDGE_MODEL : 'off'}, concurrency ${CONCURRENCY})\n`);
+
+  let done = 0;
+  const results = await runPool(jobs, async (job) => {
+    const r = await runOne(client, job.sc, token, job.runIdx);
+    done += 1;
+    const mark = r.infra ? '∼' : (r.pass ? '✓' : '✗');
+    console.log(`${mark} [${done}/${jobs.length}] ${r.id}#${r.runIdx} ${r.kind} conf=${r.confidence ?? '-'} ${r.elapsedMs}ms ${r.pass ? '' : `(${truncate(r.why, 80)})`}`);
+    return r;
+  }, CONCURRENCY);
+
+  const perScenario = aggregate(results);
+  const meta = { generatedAt: new Date().toISOString(), base: BASE, judgeEnabled: JUDGE_ENABLED, judgeModel: JUDGE_MODEL };
+  const md = mdReport(perScenario, results, meta);
+
+  const stamp = meta.generatedAt.replace(/[:.]/g, '-');
+  const dir = path.join(__dirname, '..', 'logs');
+  fs.mkdirSync(dir, { recursive: true });
+  const jsonPath = path.join(dir, `tape-eval-${stamp}.json`);
+  const mdPath = path.join(dir, `tape-eval-${stamp}.md`);
+  fs.writeFileSync(jsonPath, JSON.stringify({ meta, perScenario, results }, null, 2));
+  fs.writeFileSync(mdPath, md);
+
+  console.log(`\n${md}\n`);
+  console.log(`Reports written:\n  ${jsonPath}\n  ${mdPath}`);
+
+  const gradable = perScenario.filter((s) => !s.infra);
+  const failed = gradable.filter((s) => !s.majorityPass);
+  process.exit(failed.length ? 1 : 0);
+}
+
+main().catch((err) => { console.error('FATAL:', err); process.exit(1); });

--- a/scripts/tape-eval.js
+++ b/scripts/tape-eval.js
@@ -45,6 +45,7 @@ const opt = (name, def) => { const i = argv.indexOf(name); return i >= 0 && argv
 
 const BASE = opt('--base', `http://localhost:${process.env.PORT || 4132}`);
 const ONLY = opt('--only', null);
+const TAG = opt('--tag', null); // e.g. --tag thin (run just the thin-coverage cohort)
 const LIMIT = parseInt(opt('--limit', '0'), 10);
 const FORCE_REPEAT = parseInt(opt('--repeat', '0'), 10);
 const JUDGE_ENABLED = !flag('--no-judge');
@@ -234,9 +235,20 @@ const JUDGE_GUIDANCE = {
   split: 'This is a two-sided "Split". The single most important check: are side A and side B genuinely OPPOSING stances on the topic? If both sides argue the same direction, raise both_sides_same and score opposition 1-2. Also flag ad-reads cited as either side.',
 };
 
+// THIN-COVERAGE addendum: this name has little/no corpus material BY DESIGN. The
+// test is whether the system makes an HONEST, decent read from what little exists
+// — or degrades gracefully — WITHOUT inventing. Reward faithful use of sparse
+// clips and correct graceful degradation; penalize ONLY fabrication, wrong-entity,
+// or overconfidence. A thin/empty confidence label, a missing bull OR bear side,
+// and an industry-fallback result (a disclaimer + related peers/sector clips) are
+// all CORRECT behaviors here — do NOT penalize them or score grounding down for
+// them. Only score grounding low if claims contradict / aren't in the cited clips.
+const THIN_GUIDANCE = 'THIN-COVERAGE MODE: the corpus has little/no material on this name on purpose. Judge whether the read is HONEST and grounded in whatever clips exist (or correctly falls back to industry/peer context with a clear disclaimer). Thinness, a thin/empty label, a missing bull or bear side, and an industry-fallback result are EXPECTED and fine — do not penalize them. Flag ONLY: claims not supported by the cited clips (unsupported_or_fabricated_claim), a different same-named company (off_topic_dominant), or confidence overstated relative to the sparse evidence (confidence_overstated).';
+
 async function judge(client, sc, json) {
   const tool = verdictTool(sc.kind);
-  const system = `You are a rigorous evaluator of an automated financial-podcast summarization API. Score each dimension 1-5 and raise critical flags ONLY when clearly warranted. Be skeptical: a fluent summary built on off-topic or ad-read quotes is a FAILURE, not a pass. ${JUDGE_GUIDANCE[sc.kind]}`;
+  const thin = (sc.tags || []).includes('thin');
+  const system = `You are a rigorous evaluator of an automated financial-podcast summarization API. Score each dimension 1-5 and raise critical flags ONLY when clearly warranted. Be skeptical: a fluent summary built on off-topic or ad-read quotes is a FAILURE, not a pass. ${JUDGE_GUIDANCE[sc.kind]}${thin ? ` ${THIN_GUIDANCE}` : ''}`;
   const user = `Evaluate this response and call record_verdict.\n\n${renderForJudge(sc, json)}`;
   const resp = await client.messages.create({
     model: JUDGE_MODEL,
@@ -258,15 +270,28 @@ async function judge(client, sc, json) {
 // dimension fails. This isolates genuine defects from "good-but-not-great", which
 // the original >=4 bar conflated. Tune via TAPE_EVAL_MIN_SCORE.
 const MIN_SCORE = parseInt(process.env.TAPE_EVAL_MIN_SCORE || '3', 10);
-function computePass(layer1, verdict) {
+// Flags that fail a THIN-coverage scenario — only the "we got it wrong" ones.
+// Thinness/empty/missing-side/fallback are NOT failures in thin mode, so flags
+// like bear_slot_not_bearish / both_sides_same don't count there.
+const THIN_FAIL_FLAGS = new Set(['unsupported_or_fabricated_claim', 'off_topic_dominant', 'confidence_overstated', 'ad_read_cited']);
+function computePass(layer1, verdict, sc) {
   if (layer1.fails.length) return { pass: false, why: layer1.fails.join('; ') };
-  if (!verdict) return { pass: true, why: 'layer1-only (empty or no-judge)' };
+  const thin = sc && (sc.tags || []).includes('thin');
+  // No verdict = empty/no-coverage. For thin that's an HONEST result → pass.
+  if (!verdict) return { pass: true, why: thin ? 'honest empty / no coverage' : 'layer1-only (empty or no-judge)' };
   const s = verdict.scores || {};
+  const flags = Array.isArray(verdict.critical_flags) ? verdict.critical_flags : [];
   const reasons = [];
-  if ((s.relevance ?? 0) < MIN_SCORE) reasons.push(`relevance ${s.relevance}`);
-  if ((s.grounding ?? 0) < MIN_SCORE) reasons.push(`grounding ${s.grounding}`);
-  if ((s.citation_quality ?? 0) < MIN_SCORE) reasons.push(`citation_quality ${s.citation_quality}`);
-  if (Array.isArray(verdict.critical_flags) && verdict.critical_flags.length) reasons.push(`flags: ${verdict.critical_flags.join(',')}`);
+  if ((s.relevance ?? 0) < MIN_SCORE) reasons.push(`relevance ${s.relevance}`); // wrong/off-topic always fails
+  if ((s.grounding ?? 0) < MIN_SCORE) reasons.push(`grounding ${s.grounding}`); // unfaithful to clips always fails
+  if (thin) {
+    // Don't fail thin on citation_quality (sparse material) or non-fatal flags.
+    const fatal = flags.filter((f) => THIN_FAIL_FLAGS.has(f));
+    if (fatal.length) reasons.push(`flags: ${fatal.join(',')}`);
+  } else {
+    if ((s.citation_quality ?? 0) < MIN_SCORE) reasons.push(`citation_quality ${s.citation_quality}`);
+    if (flags.length) reasons.push(`flags: ${flags.join(',')}`);
+  }
   return { pass: reasons.length === 0, why: reasons.join('; ') || 'ok' };
 }
 
@@ -281,7 +306,7 @@ async function runOne(client, sc, token, runIdx) {
     try { const j = await judge(client, sc, res.json); verdict = j.verdict; judgeUsage = j.usage; }
     catch (err) { layer1.warns.push(`judge error: ${err.message}`); }
   }
-  const { pass, why } = computePass(layer1, verdict);
+  const { pass, why } = computePass(layer1, verdict, sc);
   const tokens = res.json?._meta?.tokens || null;
   const synthModel = sc.kind === 'readin' ? READIN_MODEL : SYNTH_MODEL;
   const cost = tokens ? costOf(synthModel, tokens) : 0;
@@ -290,6 +315,7 @@ async function runOne(client, sc, token, runIdx) {
     id: sc.id, kind: sc.kind, runIdx, body: sc.body, tags: sc.tags,
     status: res.status, elapsedMs: res.elapsedMs, infra: !!layer1.infra,
     confidence: conf ?? null, candidateCount: res.json?._meta?.candidateCount ?? null,
+    coverageFallback: res.json?._meta?.coverageFallback || null,
     layer1Fails: layer1.fails, layer1Warns: layer1.warns,
     verdict, judgeUsage, pass, why, tokens, synthModel, cost, quality,
   };
@@ -436,6 +462,23 @@ function mdReport(perScenario, results, meta) {
     L.push('');
   }
 
+  // Thin-coverage cohort — graded on honest handling of limited info, not richness.
+  const thin = perScenario.filter((s) => (s.tags || []).includes('thin'));
+  if (thin.length) {
+    const passed = thin.filter((s) => s.majorityPass).length;
+    L.push(`## Thin-coverage cohort (${passed}/${thin.length} ok — honest-read-or-graceful-fallback, no fabrication)`, '',
+      '| ticker | conf | outcome | ok | note |', '|---|---|---|---|---|');
+    for (const s of thin) {
+      const r = s.detail[0];
+      const outcome = r.coverageFallback === 'industry' ? 'industry-fallback'
+        : r.confidence === 'empty' ? 'honest-empty'
+        : `analyzed (${r.candidateCount} clips)`;
+      const why = s.majorityPass ? '' : truncate((r.why || '') + (r.verdict ? ` — ${r.verdict.rationale}` : ''), 110).replace(/\|/g, '\\|');
+      L.push(`| ${s.body?.ticker || s.id} | ${s.confidences.join('/')} | ${outcome} | ${s.majorityPass ? '✓' : '✗'} | ${why} |`);
+    }
+    L.push('');
+  }
+
   const lat = results.map((r) => r.elapsedMs).sort((a, b) => a - b);
   if (lat.length) {
     const p = (q) => lat[Math.min(lat.length - 1, Math.floor(q * lat.length))];
@@ -446,7 +489,7 @@ function mdReport(perScenario, results, meta) {
 
 // ----------------------------------------------------------------------- main
 async function main() {
-  let list = scenarios.filter((s) => !ONLY || s.kind === ONLY);
+  let list = scenarios.filter((s) => (!ONLY || s.kind === ONLY) && (!TAG || (s.tags || []).includes(TAG)));
   if (LIMIT > 0) list = list.slice(0, LIMIT);
   if (list.length === 0) { console.error('No scenarios match the filter.'); process.exit(2); }
 

--- a/scripts/tape-narrative-evidence.js
+++ b/scripts/tape-narrative-evidence.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * Evidence probe for the new /api/tape/synthesize `kind: 'narrative'`.
+ *
+ * Runs the three queries from the Narrative endpoint spec end-to-end against the
+ * local server (retrieve via topic-quotes/person-quotes with recency weighting
+ * OFF, then synthesize) and dumps the verbatim `synthesize.text` plus a parse of
+ * the bucket/sentiment trajectory so we can validate the marker contract before
+ * wiring narrativeService.ts to the live endpoint.
+ *
+ * Usage:  node scripts/tape-narrative-evidence.js [baseUrl]
+ *         (defaults to http://localhost:<PORT|4132>)
+ */
+
+require('dotenv').config();
+const { signTapeToken } = require('../services/tape/tapeAuth');
+
+const BASE = process.argv[2] || `http://localhost:${process.env.PORT || 4132}`;
+
+// Wide window + recency off + ~60 candidates, per spec §3 (retrieval expectations).
+const NARR_FILTERS = { kind: 'narrative', candidatesLimit: 60, disableRecencyWeighting: true, mainstream: true };
+
+const SCENARIOS = [
+  {
+    label: 'canon-shaped (named person)',
+    route: 'person-quotes',
+    body: {
+      name: 'Luke Gromen',
+      themes: ['the sovereign debt endgame', 'fiscal dominance debt spiral', 'US debt interest expense'],
+      filters: { ...NARR_FILTERS },
+    },
+    input: { topic: 'the sovereign debt endgame', group: 'Luke Gromen' },
+  },
+  {
+    label: 'bull-bear consensus (bears side)',
+    route: 'topic-quotes',
+    body: {
+      query: 'the AI bubble',
+      themes: ['AI bubble overvaluation', 'AI capex bubble burst', 'AI hype unsustainable'],
+      groupBy: 'bull-bear',
+      filters: { ...NARR_FILTERS },
+    },
+    group: 'bear', // keep only the bear side of the classifier
+    input: { topic: 'the AI bubble', group: 'bears' },
+  },
+  {
+    label: 'open consensus (no group)',
+    route: 'topic-quotes',
+    body: {
+      query: 'rate cuts in 2026',
+      themes: ['Fed rate cuts 2026', 'interest rate cut outlook 2026', 'Federal Reserve easing 2026'],
+      filters: { ...NARR_FILTERS },
+    },
+    input: { topic: 'rate cuts in 2026' },
+  },
+];
+
+async function call(path, token, body, method = 'POST') {
+  const resp = await fetch(BASE + path, {
+    method,
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+    body: method === 'POST' ? JSON.stringify(body) : undefined,
+  });
+  const json = await resp.json().catch(() => null);
+  return { status: resp.status, json };
+}
+
+// Pull the bucket lines and parse the chronological sentiment trajectory.
+function parseTrajectory(text) {
+  const lines = text.match(/^##\s*BUCKET\s*\|.*$/gim) || [];
+  return lines.map((line) => {
+    const parts = line.split('|').map((s) => s.trim());
+    return { start: parts[1], end: parts[2], sentiment: parts[3] };
+  });
+}
+
+function dateSpan(candidates) {
+  const dates = candidates.map((c) => c.publishedDate).filter(Boolean).map((d) => String(d).slice(0, 10)).sort();
+  return dates.length ? `${dates[0]} → ${dates[dates.length - 1]}` : 'n/a';
+}
+
+async function main() {
+  const { token } = signTapeToken();
+  console.log(`Base: ${BASE}\n`);
+
+  for (const sc of SCENARIOS) {
+    console.log('═'.repeat(78));
+    console.log(`SCENARIO: ${sc.label}`);
+    console.log(`  topic="${sc.input.topic}"${sc.input.group ? `  group="${sc.input.group}"` : ''}  via /${sc.route}`);
+    console.log('─'.repeat(78));
+
+    // 1) retrieve candidates
+    const r = await call(`/api/tape/${sc.route}`, token, sc.body);
+    if (r.status !== 200 || !r.json) {
+      console.log(`  RETRIEVAL FAILED: status=${r.status} body=${JSON.stringify(r.json)}\n`);
+      continue;
+    }
+    let candidates = r.json.candidates || [];
+    if (sc.group && Array.isArray(r.json.groups)) {
+      const g = r.json.groups.find((x) => String(x.key).toLowerCase().startsWith(sc.group));
+      candidates = (g && g.candidates) || [];
+      console.log(`  groups: ${r.json.groups.map((x) => `${x.key}(${x.candidates.length})`).join(', ')}`);
+    }
+    console.log(`  candidates: ${candidates.length}  | span: ${dateSpan(candidates)}  | weightingDisabled: ${r.json._meta?.weightingDisabled}`);
+    if (!candidates.length) { console.log('  no candidates — skipping synthesize\n'); continue; }
+
+    // 2) synthesize narrative
+    const s = await call('/api/tape/synthesize', token, {
+      kind: 'narrative', input: sc.input, candidates, model: 'fast',
+    });
+    if (s.status !== 200 || !s.json) {
+      console.log(`  SYNTHESIZE FAILED: status=${s.status} body=${JSON.stringify(s.json)}\n`);
+      continue;
+    }
+    const text = s.json.text || '';
+    const traj = parseTrajectory(text);
+    console.log(`  synthesize: status=200  model=${s.json.model}  tokens=${JSON.stringify(s.json.tokens)}  elapsedMs=${s.json.elapsedMs}`);
+    console.log(`  tickers: ${JSON.stringify(s.json.tickers)}`);
+    console.log(`  buckets: ${traj.length}  trajectory: ${traj.map((b) => b.sentiment).join(' → ')}`);
+    if (s.json._meta?.synthesizedEmpty) console.log(`  ⚠ synthesizedEmpty: ${s.json._meta.reason}`);
+    if (s.json._meta?.complianceRecovered) console.log('  ⚠ complianceRecovered (passed on auto-retry)');
+    console.log('\n  ── raw synthesize.text ──────────────────────────────────────────────');
+    console.log(text.split('\n').map((l) => `  ${l}`).join('\n'));
+    console.log('');
+  }
+  console.log('═'.repeat(78));
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/scripts/tape-synth-groundtruth.js
+++ b/scripts/tape-synth-groundtruth.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Ground-truth probe for /api/tape/synthesize.
+ *
+ * Runs real topic-quotes -> synthesize for `brief` and `readin` against the
+ * local server and dumps EXACTLY what the model emits (verbatim text, tokens,
+ * section markers, clip-token integrity) so we can tell whether thin/empty
+ * output is a backend-prompt issue or a client-parser issue.
+ *
+ * Usage:  node scripts/tape-synth-groundtruth.js [baseUrl]
+ *         (defaults to http://localhost:4132)
+ */
+
+require('dotenv').config();
+const { signTapeToken } = require('../services/tape/tapeAuth');
+
+const BASE = process.argv[2] || `http://localhost:${process.env.PORT || 4132}`;
+
+const SCENARIOS = [
+  {
+    kind: 'brief',
+    topicQuotes: { query: 'Federal Reserve interest rates', themes: ['Federal Reserve interest rates inflation', 'Fed rate cut policy outlook'], filters: { mainstream: true, candidatesLimit: 14 } },
+    input: { topic: 'The Fed and interest rates' },
+  },
+  {
+    kind: 'readin',
+    topicQuotes: { query: 'Oracle ORCL', themes: ['Oracle ORCL cloud growth earnings', 'Oracle stock AI datacenter'], filters: { mainstream: true, candidatesLimit: 12 } },
+    input: { topic: 'Oracle (ORCL)', ticker: 'ORCL' },
+  },
+  {
+    kind: 'readin',
+    topicQuotes: { query: 'CRWV', themes: ['CRWV', 'CRWV stock company business'], filters: { mainstream: true, candidatesLimit: 20 } },
+    input: { ticker: 'CRWV', depth: 'quick' },
+  },
+];
+
+async function call(path, token, body, method = 'POST') {
+  const resp = await fetch(BASE + path, {
+    method,
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+    body: method === 'POST' ? JSON.stringify(body) : undefined,
+  });
+  const json = await resp.json().catch(() => null);
+  return { status: resp.status, json };
+}
+
+function analyze(text, candidates) {
+  const markers = (text.match(/^##\s*[^\n]+/gm) || []).map((s) => s.trim());
+  const clipIds = [...text.matchAll(/\{\{clip:([^}]+)\}\}/g)].map((m) => m[1]);
+  const candIds = new Set(candidates.map((c) => c.pineconeId));
+  const validClips = clipIds.filter((id) => candIds.has(id));
+  return {
+    chars: text.length,
+    words: text.trim() ? text.trim().split(/\s+/).length : 0,
+    markers,
+    clipTokens: clipIds.length,
+    clipTokensValid: validClips.length,
+    clipSample: clipIds.slice(0, 3),
+    candIdSample: [...candIds].slice(0, 3),
+  };
+}
+
+(async () => {
+  let token;
+  try { token = signTapeToken().token; }
+  catch (e) { console.error('Cannot mint token — is TAPE_AUTH_SECRET set in .env?', e.message); process.exit(1); }
+
+  for (const sc of SCENARIOS) {
+    console.log('\n' + '='.repeat(78));
+    console.log(`SCENARIO: kind=${sc.kind}  topic="${sc.input.topic}"`);
+    console.log('='.repeat(78));
+
+    const tq = await call('/api/tape/topic-quotes', token, sc.topicQuotes);
+    if (tq.status !== 200) { console.log('topic-quotes FAILED', tq.status, tq.json); continue; }
+    const candidates = (tq.json.candidates || []).slice(0, 10);
+    console.log(`topic-quotes -> ${tq.json.candidates?.length || 0} candidates (using ${candidates.length})`);
+    if (!candidates.length) { console.log('NO CANDIDATES — nothing to synthesize. (retrieval issue, not synthesize)'); continue; }
+    console.log('sample candidate:', JSON.stringify({ pineconeId: candidates[0].pineconeId, creator: candidates[0].creator, text: (candidates[0].text || '').slice(0, 80) + '…' }));
+
+    const syn = await call('/api/tape/synthesize', token, {
+      kind: sc.kind, input: sc.input, candidates, model: 'fast', stream: false, refresh: true,
+    });
+    if (syn.status !== 200) { console.log('synthesize FAILED', syn.status, syn.json); continue; }
+
+    const text = syn.json.text || '';
+    const a = analyze(text, candidates);
+    console.log('\n--- SYNTHESIZE RESULT ---');
+    console.log('model:', syn.json.model, '| tokens:', JSON.stringify(syn.json.tokens), '| elapsedMs:', syn.json.elapsedMs);
+    console.log('analysis:', JSON.stringify(a, null, 2));
+    console.log('\n--- RAW TEXT (verbatim, between markers) ---');
+    console.log('>>>>>>>>>>');
+    console.log(text);
+    console.log('<<<<<<<<<<');
+  }
+  console.log('\nDone.');
+})();

--- a/scripts/warm-readins.js
+++ b/scripts/warm-readins.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * Manual / test runner for the Read-In cache warmer.
+ *
+ *   node scripts/warm-readins.js --dry-run            # list what would be warmed (no DB, no LLM)
+ *   node scripts/warm-readins.js --only NVDA,TSLA     # warm just these (cheap smoke test)
+ *   node scripts/warm-readins.js --limit 5            # warm the top 5 of the generic order
+ *   node scripts/warm-readins.js                      # full run (respects $/ticker caps)
+ *
+ * NOTE: a standalone run warms THIS process's in-memory cache and then exits — only
+ * a server with REDIS_URL set shares that cache. For the in-memory production server
+ * the warm runs IN-PROCESS via the daily cron (server.js); this CLI is for testing
+ * the logic, measuring cost, and Redis deployments.
+ */
+
+require('dotenv').config();
+const mongoose = require('mongoose');
+const OpenAI = require('openai');
+const { warmReadins, effectiveLimit, getWarmTickers } = require('../services/tape/warmReadins');
+
+const argv = process.argv.slice(2);
+const has = (f) => argv.includes(f);
+const optStr = (f) => { const i = argv.indexOf(f); return i >= 0 && argv[i + 1] ? argv[i + 1] : null; };
+const optInt = (f) => { const v = optStr(f); return v != null ? parseInt(v, 10) : undefined; };
+
+(async () => {
+  if (has('--dry-run')) {
+    const all = getWarmTickers();
+    const n = Math.min(effectiveLimit(), all.length);
+    console.log(`[dry-run] generic order has ${all.length} carded tickers; would warm top ${n}:`);
+    console.log('  ' + all.slice(0, n).join(', '));
+    return;
+  }
+
+  if (!process.env.MONGO_URI) { console.error('MONGO_URI not set.'); process.exit(1); }
+  await mongoose.connect(process.env.MONGO_URI, { useNewUrlParser: true, useUnifiedTopology: true });
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+  const only = optStr('--only') ? optStr('--only').split(',').map((s) => s.trim()).filter(Boolean) : undefined;
+  const res = await warmReadins({ openai, log: (m) => console.log(m), limit: optInt('--limit'), only });
+  console.log(JSON.stringify(res, null, 2));
+  await mongoose.disconnect();
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/server.js
+++ b/server.js
@@ -2245,6 +2245,42 @@ const _server = app.listen(PORT, async () => {
       console.log('[TapeCardHydrate] Disabled (TAPE_CARD_HYDRATE_CRON=false)');
     }
 
+    // Tape Read-In cache warmer — pre-computes the most-likely-picked tickers so a
+    // generic user's first Read-In is instant. Runs 15 min AFTER card hydration so
+    // cards are fresh first. Runs IN-PROCESS (the in-memory cache is per-process, so
+    // a spawned child would warm a throwaway Map) and deliberately takes NO
+    // distributed lock — under autoscale every container must warm its own cache.
+    // Budget is bounded by TAPE_WARM_USD_CAP ($2) and TAPE_WARM_MAX_TICKERS (150).
+    if (process.env.TAPE_WARM_READIN_CRON !== 'false') {
+      const cron = require('node-cron');
+      const { warmReadins } = require('./services/tape/warmReadins');
+      // Schedule is env-overridable (5-field cron). Default 08:00 CT — once daily.
+      // Each run costs ~$1.3-2, so keep this a DAILY (or rarer) schedule; never a
+      // high-frequency one (every-10-min would be ~$288/day). Falls back to the
+      // default if the override is invalid. To test that the cron fires without
+      // burning budget, prefer the CLI (`node scripts/warm-readins.js --limit 5`)
+      // or set the schedule to a single near-future minute and revert after.
+      const DEFAULT_WARM_SCHEDULE = '0 8 * * *';
+      let warmSchedule = process.env.TAPE_WARM_READIN_SCHEDULE || DEFAULT_WARM_SCHEDULE;
+      if (!cron.validate(warmSchedule)) {
+        console.warn(`[TapeWarm] invalid TAPE_WARM_READIN_SCHEDULE="${warmSchedule}"; using default "${DEFAULT_WARM_SCHEDULE}"`);
+        warmSchedule = DEFAULT_WARM_SCHEDULE;
+      }
+      const warmTz = process.env.TAPE_WARM_READIN_TZ || 'America/Chicago';
+      cron.schedule(warmSchedule, async () => {
+        try {
+          const now = new Date().toLocaleString('en-US', { timeZone: warmTz });
+          console.log(`[TapeWarm] starting at ${now} (${warmTz})`);
+          await warmReadins({ openai, log: (m) => console.log(m) });
+        } catch (err) {
+          console.error('[TapeWarm] error:', err.message);
+        }
+      }, { timezone: warmTz });
+      console.log(`[TapeWarm] Cron registered: "${warmSchedule}" ${warmTz} (override TAPE_WARM_READIN_SCHEDULE / TAPE_WARM_READIN_TZ; set TAPE_WARM_READIN_CRON=false to disable)`);
+    } else {
+      console.log('[TapeWarm] Disabled (TAPE_WARM_READIN_CRON=false)');
+    }
+
     // Nostr bot — single startup branch handles identity log + all
     // phase crons (mention watcher, zap watcher, reply worker). Each
     // sub-phase is also internally guarded so partial wiring during

--- a/server.js
+++ b/server.js
@@ -68,6 +68,7 @@ const mentionsRoutes = require('./routes/mentions');
 const automationSettingsRoutes = require('./routes/automationSettingsRoutes');
 const analyticsRoutes = require('./routes/analyticsRoutes');
 const corpusRoutes = require('./routes/corpusRoutes');
+const createTapeRoutes = require('./routes/tapeRoutes');
 const agentRoutes = require('./routes/agentRoutes');
 const discoverRoutes = require('./routes/discoverRoutes');
 // const createWorkflowRoutes = require('./routes/workflowRoutes'); // Shelved — replaced by Claude agent
@@ -1726,6 +1727,7 @@ app.use('/api/shared-research-sessions', sharedResearchSessionsRoutes);
 app.use('/api/pulse', analyticsRoutes);      // Primary path (ad-blocker safe)
 app.use('/api/analytics', analyticsRoutes);  // Deprecated — remove after frontend cutover
 app.use('/api/corpus', corpusRoutes); // Corpus navigation for AI agents (feeds, episodes, chapters, topics)
+app.use('/api/tape', createTapeRoutes({ openai })); // Tape finance skin (auth + quote proxy + person/topic-quotes + synthesize)
 app.use('/api/agent', agentRoutes);  // Lightning credit system for agent API access (Issue #63)
 // Nostr bot admin (HMAC-protected). Always mounted (DEBUG_MODE-independent)
 // because ops needs balance/queue lookups in prod. Scope `nostr-bot:admin`

--- a/server.js
+++ b/server.js
@@ -2217,6 +2217,34 @@ const _server = app.listen(PORT, async () => {
       console.log('[BlogIngestion] Disabled — set NOSTR_BLOG_ENABLED=true to activate');
     }
 
+    // Tape company-card hydration — refreshes stale cards (Finnhub backbone + LLM
+    // facts) daily so request-time lookups stay zippy (cards live in-memory; this
+    // updates them out of band, and the loader hot-reloads on file mtime change).
+    // Lock-guarded so only one instance runs it in a multi-container deploy.
+    if (process.env.TAPE_CARD_HYDRATE_CRON !== 'false') {
+      const cron = require('node-cron');
+      const path = require('path');
+      const { spawn } = require('child_process');
+      const { runIfLockHeld } = require('./utils/runIfLockHeld');
+      cron.schedule('0 10 * * *', async () => {
+        try {
+          const result = await runIfLockHeld('tape-card-hydrate', () => new Promise((resolve) => {
+            const now = new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' });
+            console.log(`[TapeCardHydrate] starting at ${now} (CT)`);
+            const child = spawn('node', [path.join(__dirname, 'scripts', 'hydrate-stale-cards.js')], { stdio: 'inherit' });
+            child.on('exit', (code) => { console.log(`[TapeCardHydrate] done (exit ${code})`); resolve(); });
+            child.on('error', (e) => { console.error('[TapeCardHydrate] spawn error:', e.message); resolve(); });
+          }), { bucketResolutionSeconds: 3600, verbose: false });
+          if (!result.ranOnThisInstance) console.log('[TapeCardHydrate] skipped (another instance holds the lock)');
+        } catch (err) {
+          console.error('[TapeCardHydrate] error:', err.message);
+        }
+      }, { timezone: 'America/Chicago' });
+      console.log('[TapeCardHydrate] Cron registered: daily 10:00 America/Chicago (set TAPE_CARD_HYDRATE_CRON=false to disable)');
+    } else {
+      console.log('[TapeCardHydrate] Disabled (TAPE_CARD_HYDRATE_CRON=false)');
+    }
+
     // Nostr bot — single startup branch handles identity log + all
     // phase crons (mention watcher, zap watcher, reply worker). Each
     // sub-phase is also internally guarded so partial wiring during

--- a/services/searchQuotesService.js
+++ b/services/searchQuotesService.js
@@ -272,6 +272,7 @@ async function searchQuotes(params, { openai, recordHelperLlmUsage }) {
         quote,
         episode: metadata.episode || metadata.title || 'Unknown episode',
         creator: metadata.creator || 'Creator not specified',
+        feedId: metadata.feedId != null ? String(metadata.feedId) : null,
         audioUrl: metadata.audioUrl || 'URL unavailable',
         episodeImage: metadata.episodeImage || 'Image unavailable',
         listenLink: metadata.listenLink || '',

--- a/services/tape/README.md
+++ b/services/tape/README.md
@@ -1,0 +1,140 @@
+# Tape backend module (`/api/tape/*`)
+
+Self-contained backend for the **Tape** finance skin (Dossier, Brief, Split, Arc,
+Read-in). Moves the editorial recipes (mainstream allowlist, dedicated-episode
+filter, paragraph-span sort, themed-query fan-out) into a small retrieve-then-write
+pipeline so every client inherits the same DNA and the heavy work is cached
+cross-user. Design doc: `.claude/plans/i-am-making-a-gentle-treehouse.md`.
+
+## Endpoints
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| POST | `/api/tape/auth` | password | Exchange shared password → 30-day scoped JWT |
+| GET  | `/api/tape/quote/:slug` | Bearer | Ticker price + sparkline (Yahoo/Finnhub proxy) |
+| POST | `/api/tape/person-quotes` | Bearer | Best quotes **by a person** on themes (Dossier/Arc/Split) |
+| POST | `/api/tape/topic-quotes` | Bearer | Best quotes **about a topic** (Brief/Split/Read-in) |
+| POST | `/api/tape/synthesize` | Bearer | LLM writer — turns candidates into editorial prose |
+
+Pipeline for any action: **retrieve** (`person-quotes` or `topic-quotes`) → **write**
+(`synthesize`). Retrieval is cached so the fan-out is paid once; `synthesize` is
+content-addressed by candidate set, so synthesis tokens are spent at most once per
+unique set of quotes (a topic with no new episodes never pays twice).
+
+## Reuses (no duplication)
+
+- `services/searchQuotesService.searchQuotes` — semantic search
+- `services/corpusService.{findPeople,getPersonEpisodes}` — person resolution
+- `utils/agent/providers` + `constants/agentModels.resolveModelSelection` — LLM call + model routing
+- `utils/agent/sanitizeOutput` — clip-token (`{{clip:id}}`) cleanup
+
+## Freshness policy (two tiers, finance-tuned)
+
+- **Quantitative** (prices): cache 60s open / 5m closed; never served older than **1 hour**
+  (stale-fallback past the ceiling is flagged `_meta.stale` + `staleReason`).
+- **Qualitative** (quotes + synthesis): cached up to **3 business days** (skips weekends).
+  `synthesize` output is content-addressed with a long (30-day) TTL.
+
+Every response carries a uniform `_meta` "last updated" block:
+`{ cached, revalidated, tier, fetchedAt, cachedAt, ageSec, freshUntil, stale, staleReason }`.
+
+## Stock-quote providers (interchangeable)
+
+`services/tape/quoteProviders/` — a provider chain so Yahoo can be backed up or
+replaced without touching the rest of the stack. Each provider exports
+`{ name, isConfigured(), fetchQuote(slug) }` and returns the normalized shape
+`{ symbol, name, price, currency, dayChangePct, spark[], marketState }`.
+
+- **Yahoo** (default): no key required.
+- **Finnhub**: auto-activates when `FINNHUB_API_KEY` is set; used as fallback under
+  `TAPE_QUOTE_PROVIDER=yahoo` (default) or as primary under `TAPE_QUOTE_PROVIDER=finnhub`.
+
+If Yahoo throttles or 5xxs, the chain transparently tries the next provider; if every
+provider fails, the last cached price is served flagged `stale`. **You do not need a
+Finnhub account today** — the plumbing is in place; just set `FINNHUB_API_KEY` to enable it.
+
+Caveat: index/futures slugs differ across providers (Yahoo `^TNX`, `CL=F`, `DX-Y.NYB`).
+Set `FINNHUB_SYMBOL_MAP` (JSON) to translate per slug, e.g. `{"^TNX":"...","CL=F":"..."}`.
+Finnhub's candle/sparkline endpoint is paid-plan only; on the free tier the sparkline
+degrades to a single point rather than failing.
+
+## Environment variables
+
+```bash
+# --- auth (required to use the module) ---
+TAPE_AUTH_PASSWORD=<shared demo password>
+TAPE_AUTH_SECRET=<32+ random bytes; e.g. `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`>
+TAPE_AUTH_KID=v1                 # bump to revoke ALL outstanding tokens
+TAPE_AUTH_TTL_DAYS=30            # token lifetime (default 30)
+
+# --- cost guards (synthesize) ---
+TAPE_DAILY_OUTPUT_TOKEN_CAP=5000000   # global daily output-token cap (0 = off)
+TAPE_DAILY_USD_CAP=                    # optional global daily $ cap
+TAPE_SYN_HOURLY_LIMIT=30               # per-JWT synthesize calls/hour
+TAPE_SYN_MAX_TOKENS=2048               # max synthesis output tokens
+
+# --- cache backend (optional) ---
+REDIS_URL=                       # unset = in-memory (per-container). Set → Redis (needs `npm i ioredis`)
+TAPE_NOCACHE_ENABLED=false       # allow `_nocache:true` in request bodies (debug)
+
+# --- freshness policy (defaults shown) ---
+TAPE_QUAL_TTL_BUSINESS_DAYS=3
+TAPE_QUANT_MAX_AGE_SEC=3600
+TAPE_QUOTE_TTL_OPEN_SEC=60
+TAPE_QUOTE_TTL_CLOSED_SEC=300
+TAPE_SYN_TTL_DAYS=30
+
+# --- quote providers ---
+TAPE_QUOTE_PROVIDER=yahoo        # yahoo (default) | finnhub
+FINNHUB_API_KEY=                 # enables Finnhub provider when set
+FINNHUB_SYMBOL_MAP={}            # JSON map of Yahoo slug -> Finnhub symbol
+```
+
+Rate limits (per-JWT, per hour): `synthesize` 30, `person-quotes`/`topic-quotes` 120,
+`quote/*` 600. Kill switches: bump `TAPE_AUTH_KID`, or the daily synth cap.
+
+### Force re-synthesize (`refresh: true`)
+
+Send `{"refresh": true}` in a `synthesize` (or `person-quotes`/`topic-quotes`) body to
+bypass the cache **read** and regenerate, while still writing the fresh result back to
+cache. Distinct from `_nocache` (a gated debug flag that bypasses read *and* write).
+
+For `synthesize`, a forced pass spends tokens and counts against the daily cap. **During
+beta it is unlimited and only measured** — see the `TODO(beta)` in
+[synthesize.js](synthesize.js) to add a per-user cap later. Measurement hooks already in place:
+- structured log gets `forced: true` and `_meta.forced: true` on the response;
+- counters `tape:syn:resynth:<jwt_sub>:<utc-date>` (per user) and
+  `tape:syn:resynth:all:<utc-date>` (global) increment on each forced pass, so you can
+  read real usage before picking a limit.
+
+## Token cost (DeepSeek V4 Flash default)
+
+Only `synthesize` spends LLM tokens (~$0.0012–0.0015 per cold query); retrieval
+embeddings are ~$0.0001 and quotes are free. Cached / revalidated repeats are ~$0.
+The 5M daily token cap ≈ 3,300 synth calls ≈ <$3/day at the ceiling.
+
+## Quick verification
+
+```bash
+# 1. auth
+TAPE_JWT=$(curl -s localhost:4132/api/tape/auth -H 'content-type: application/json' \
+  -d '{"password":"<TAPE_AUTH_PASSWORD>"}' | jq -r .token)
+
+# 2. quote (note _meta.source = yahoo|finnhub|cache, _meta.tier = quantitative)
+curl -s localhost:4132/api/tape/quote/APP -H "Authorization: Bearer $TAPE_JWT" | jq
+
+# 3. person-quotes
+curl -s localhost:4132/api/tape/person-quotes -H "Authorization: Bearer $TAPE_JWT" \
+  -H 'content-type: application/json' \
+  -d '{"name":"Mohamed El-Erian","themes":["Federal Reserve interest rates inflation","recession risk Treasury yields"]}' | jq '.candidates[0]'
+
+# 4. topic-quotes (grouped)
+curl -s localhost:4132/api/tape/topic-quotes -H "Authorization: Bearer $TAPE_JWT" \
+  -H 'content-type: application/json' \
+  -d '{"themes":["Strait of Hormuz Iran oil","oil price spike Middle East"],"groupBy":"creator"}' | jq '.groups | length'
+
+# 5. synthesize (feed candidates from step 3)
+curl -s localhost:4132/api/tape/synthesize -H "Authorization: Bearer $TAPE_JWT" \
+  -H 'content-type: application/json' \
+  -d '{"kind":"dossier","input":{"person":"Mohamed El-Erian"},"candidates":[...],"model":"fast"}' | jq '.text, .tokens'
+```

--- a/services/tape/README.md
+++ b/services/tape/README.md
@@ -118,11 +118,28 @@ beta it is unlimited and only measured** — see the `TODO(beta)` in
 - **arc**: `## THESIS:` + `## VERDICT:` + ≥3 `## CALL | …` + optional `## FORWARD:`
 
 Optional sections are **omitted** (no empty headers) when candidates don't support
-them. A server-side guardrail (`hasRequiredMarkers`) verifies the required markers
-are present; if the model can't produce them (or signals the `EMPTY_SYNTHESIS`
-sentinel), the response is `{ text: "", _meta: { synthesizedEmpty: true, reason } }`
-and is **not cached** (so a retry can still succeed). Bump `PROMPT_VERSION` on any
-prompt change — it's part of the cache key.
+them. Bump `PROMPT_VERSION` on any prompt change — it's part of the cache key.
+
+### Kind-compliance validator
+
+Before a synthesis response leaves the handler, `validateKindCompliance(kind, text)`
+([tapePrompts.js](tapePrompts.js)) checks that all REQUIRED markers are present AND no
+FORBIDDEN cross-kind markers leaked (e.g. a `brief` must have `# HEADLINE`/`## PUBLISHER`
+and must NOT contain `## WHAT_THEY_DO`/`## SMART_MONEY`). On a violation, `produce()`
+([synthesize.js](synthesize.js)) does **one auto-retry** with a reflection nudge
+("your previous output used the wrong markers… produce ONLY the markers for `<kind>`").
+If the retry conforms, it's served with `_meta.complianceRecovered: true`; if it still
+violates, the handler returns **502** `{ type: ".../tape/kind-compliance" }` rather than
+serving malformed text. Neither violation nor empty results are cached.
+
+A genuinely empty result (the `EMPTY_SYNTHESIS` sentinel / sparse candidates) is distinct
+from a violation — it returns `{ text: "", _meta: { synthesizedEmpty: true, reason } }`
+with a 200 (a valid "no results" render state, not an error).
+
+Every compliance failure (even one the retry then fixes) is logged as a structured
+`kind-compliance-fail` line (kind, reason, leaked/missing, the input, and the offending
+text) for prompt hardening; set `TAPE_COMPLIANCE_LOG_FILE` to also append them as JSONL
+for an eval fixture set.
 
 ## Relevant tickers (`tickers: string[]`)
 

--- a/services/tape/README.md
+++ b/services/tape/README.md
@@ -116,6 +116,7 @@ beta it is unlimited and only measured** — see the `TODO(beta)` in
 - **dossier**: one or more `## TOPIC:` + optional `## APPEARANCES`
 - **split**: two `## PERSON:` blocks + optional `## CONTRAST`
 - **arc**: `## THESIS:` + `## VERDICT:` + ≥3 `## CALL | …` + optional `## FORWARD:`
+- **narrative**: `## THESIS:` + ≥3 `## BUCKET | <ISO start> | <ISO end> | <signed sentiment -5..+5>` (chronological, oldest→newest) + optional `## INFLECTION` / `## FORWARD:`. Sentiment is the **third pipe field**, a required integer in `-5..+5` on every bucket (drives the client trajectory chart); a missing/malformed value is a compliance failure. A sign-flip across zero between adjacent buckets is a reversal — the client renders a marker at the crossing.
 
 Optional sections are **omitted** (no empty headers) when candidates don't support
 them. Bump `PROMPT_VERSION` on any prompt change — it's part of the cache key.
@@ -150,8 +151,9 @@ Every successful `synthesize` response carries a top-level `tickers` array (the
 the body; stripped from `text` and gated out of the stream so it never renders).
 Per-kind meaning lives in [tapePrompts.js](tapePrompts.js) `TICKER_GUIDANCE`
 (dossier = names the person covers; brief/split = what's exposed to the topic;
-arc = names in the tracked thesis; **readin = the queried company's PEERS, not
-itself**). Parsing/validation (incl. `^TNX`, `DX-Y.NYB`, `CL=F`, `BRK-B`,
+arc = names in the tracked thesis; **narrative = names exposed to the TOPIC, not
+the group filter** — same tickers whether the lens is bulls, bears, or a person;
+**readin = the queried company's PEERS, not itself**). Parsing/validation (incl. `^TNX`, `DX-Y.NYB`, `CL=F`, `BRK-B`,
 `BTC-USD`) is in [tickerExtract.js](tickerExtract.js). Empty/`synthesizedEmpty`
 responses return `tickers: []`.
 
@@ -188,6 +190,19 @@ retrieval cache key carries a version (`tape:tq:v2:…`) — bump it when retrie
 changes to evict stale entries. Empty *live* responses still carry `_meta` (so the
 client can show a Refresh affordance and the correct date window — prefer the live empty
 response over any canned/mock empty fallback).
+
+**Recency weighting.** Candidates are ranked by `span × exp(-age_months / half_life)`
+before truncation ([recency.js](recency.js)), so a quote from a company's prior era
+(ORCL 2021, NVDA pre-2023) loses to current ones — soft decay, not a cutoff, so a strong
+old quote survives if nothing newer competes. Half-life is per **kind** (passed by the
+client on the retrieval call): `brief` ~1wk, `readin`/`split` 6mo, `dossier` 18mo, `arc`
+and `narrative` **disabled** (the time dimension is the point — full multi-year spread
+preserved; `narrative` drift analysis needs the whole window unweighted).
+Override via `filters.halfLifeMonths` / `filters.disableRecencyWeighting`. Undated
+candidates (corpus lacks `publishedDate`) get a fixed 0.5 penalty (`TAPE_UNDATED_DECAY_FACTOR`)
+— unknown age shouldn't outrank fresh dated quotes. `_meta.halfLifeApplied` /
+`_meta.weightingDisabled` report what was used. Lives only in the Tape recipe layer —
+`searchQuotes` / `/api/pull` ranking is untouched.
 
 **Query-layer ticker resolution.** A ticker-shaped query is resolved to its company
 and the **company name** is what's searched — critical for tickers that collide with

--- a/services/tape/README.md
+++ b/services/tape/README.md
@@ -107,11 +107,48 @@ beta it is unlimited and only measured** — see the `TODO(beta)` in
   `tape:syn:resynth:all:<utc-date>` (global) increment on each forced pass, so you can
   read real usage before picking a limit.
 
-## Token cost (DeepSeek V4 Flash default)
+## Synthesis output contract
 
-Only `synthesize` spends LLM tokens (~$0.0012–0.0015 per cold query); retrieval
-embeddings are ~$0.0001 and quotes are free. Cached / revalidated repeats are ~$0.
-The 5M daily token cap ≈ 3,300 synth calls ≈ <$3/day at the ceiling.
+`synthesize` emits a strict per-kind marker contract the client parser splits on
+(see [tapePrompts.js](tapePrompts.js) `CONTRACTS`):
+- **readin**: `## WHAT_THEY_DO` (required) + optional `## PULSE | BULL:… | BEAR:…`, `## SMART_MONEY: BULL`, `## SMART_MONEY: BEAR`, `## RISKS`
+- **brief**: `# HEADLINE:` (required) + one `## PUBLISHER: <show>` per creator
+- **dossier**: one or more `## TOPIC:` + optional `## APPEARANCES`
+- **split**: two `## PERSON:` blocks + optional `## CONTRAST`
+- **arc**: `## THESIS:` + `## VERDICT:` + ≥3 `## CALL | …` + optional `## FORWARD:`
+
+Optional sections are **omitted** (no empty headers) when candidates don't support
+them. A server-side guardrail (`hasRequiredMarkers`) verifies the required markers
+are present; if the model can't produce them (or signals the `EMPTY_SYNTHESIS`
+sentinel), the response is `{ text: "", _meta: { synthesizedEmpty: true, reason } }`
+and is **not cached** (so a retry can still succeed). Bump `PROMPT_VERSION` on any
+prompt change — it's part of the cache key.
+
+## Model & token cost
+
+`model: "fast"` → **Haiku 4.5** (`claude-haiku-4-5`, $1/$5 per 1M) ≈ **~$0.005 per
+synth** (measured: Oracle readin 2125 in / 471 out). `model: "quality"` → **DeepSeek
+V4 Flash** ($0.14/$0.28 per 1M) ≈ **~$0.0004 per synth** (~10× cheaper). The
+server's own default is `quality`; the Tape client currently sends `fast`, so it's
+on Haiku. The marker contract is a prompt property — it holds on either model.
+
+Only `synthesize` spends LLM tokens; retrieval embeddings are ~$0.0001 and quotes
+are free. Cached / revalidated repeats are ~$0. The 5M daily token cap ≈ <$3–15/day
+at the ceiling depending on model.
+
+## Ticker-query retrieval guard
+
+For ticker-shaped `topic-quotes` queries (`^[A-Z]{1,5}$`), candidates are post-filtered
+to those whose text mentions the ticker or any resolved **name/alias** of the company,
+dropping vector-noise (e.g. `CRWV` no longer returns Crimson Wine / leveraged ETFs).
+Never reduces a non-empty set to zero. Disable with `TAPE_TICKER_FILTER=false`.
+
+Aliases come from [tickerResolver.js](tickerResolver.js), which merges: a curated map
+(nicknames / former names / pronunciations — e.g. `CRWV` → "core weave", "atlantic
+crypto"), the live quote-proxy `name`, and auto-derived variants (camelCase split,
+significant tokens). Add a ticker to `CURATED` only when its nicknames can't be derived
+from the formal name; everything else (spacing, tokenization) falls out automatically.
+The resolver is reusable for query/theme expansion too.
 
 ## Quick verification
 

--- a/services/tape/README.md
+++ b/services/tape/README.md
@@ -121,6 +121,33 @@ beta it is unlimited and only measured** — see the `TODO(beta)` in
 Optional sections are **omitted** (no empty headers) when candidates don't support
 them. Bump `PROMPT_VERSION` on any prompt change — it's part of the cache key.
 
+### Confidence tiers
+
+Every `synthesize` response carries `_meta.confidence` (`strong`/`partial`/`thin`/`empty`),
+`_meta.confidenceReason` (≤100-char sentence, `null` when `strong`), and
+`_meta.candidateCount`. The tier is **deterministic** ([confidence.js](confidence.js)) —
+computed from candidate count, rendered section/marker presence, publisher/side
+distribution, and date spread — not model self-grading (LLMs miscalibrate). `synthesizedEmpty`
+→ `empty`. The client renders a yellow (`partial`) / red (`thin`) pill with the reason, or the
+empty state for `empty`.
+
+### Narrative adaptive cadence
+
+Narrative buckets follow **data density**, not a fixed monthly/quarterly/yearly rule: the model
+picks 3–8 variable-width boundaries (narrow where dense, wide where sparse), ≥2 candidates each.
+The validator floor is **≥1 bucket** (was 3) so a thin topic still renders. Signed-sentiment
+validation per bucket is unchanged.
+
+### Brief auto-expanding window
+
+When `kind: "brief"` and no explicit `minDate`, retrieval starts at a 7-day lookback from
+`asOfDate` and **widens 7 → 30 → 90 days** until ≥3 dated candidates clear (one fan-out at the
+widest step, narrowed in-memory). Reports `_meta.windowDays` + `_meta.windowExpanded`. Crucially,
+when the window expands the recency **half-life is coupled to the effective window** (`~windowDays/30`
+months) — otherwise the 1-week half-life would decay the widened candidates right back out. Solves
+"empty this week when there's a month-old story." The client forwards `windowDays`/`windowExpanded`
+into `synthesize` so the confidence reason can say "Widened to 30 days."
+
 ### Kind-compliance validator
 
 Before a synthesis response leaves the handler, `validateKindCompliance(kind, text)`

--- a/services/tape/README.md
+++ b/services/tape/README.md
@@ -124,6 +124,20 @@ sentinel), the response is `{ text: "", _meta: { synthesizedEmpty: true, reason 
 and is **not cached** (so a retry can still succeed). Bump `PROMPT_VERSION` on any
 prompt change — it's part of the cache key.
 
+## Relevant tickers (`tickers: string[]`)
+
+Every successful `synthesize` response carries a top-level `tickers` array (the
+"On the tape" strip) — real Yahoo-typed symbols in relevance order, 4–8 typical,
+`[]` when the topic isn't about specific names. Implemented as a parsed-off
+`## TICKERS` marker the model appends (option 1 — no extra LLM call; cached with
+the body; stripped from `text` and gated out of the stream so it never renders).
+Per-kind meaning lives in [tapePrompts.js](tapePrompts.js) `TICKER_GUIDANCE`
+(dossier = names the person covers; brief/split = what's exposed to the topic;
+arc = names in the tracked thesis; **readin = the queried company's PEERS, not
+itself**). Parsing/validation (incl. `^TNX`, `DX-Y.NYB`, `CL=F`, `BRK-B`,
+`BTC-USD`) is in [tickerExtract.js](tickerExtract.js). Empty/`synthesizedEmpty`
+responses return `tickers: []`.
+
 ## Model & token cost
 
 `model: "fast"` → **Haiku 4.5** (`claude-haiku-4-5`, $1/$5 per 1M) ≈ **~$0.005 per
@@ -142,6 +156,29 @@ For ticker-shaped `topic-quotes` queries (`^[A-Z]{1,5}$`), candidates are post-f
 to those whose text mentions the ticker or any resolved **name/alias** of the company,
 dropping vector-noise (e.g. `CRWV` no longer returns Crimson Wine / leveraged ETFs).
 Never reduces a non-empty set to zero. Disable with `TAPE_TICKER_FILTER=false`.
+
+**Theme expansion (non-ticker topics).** A user phrasing nobody says ("gold prognosis")
+is expanded server-side into podcast-realistic phrasings ("gold outlook", "gold safe
+haven", …) before fanning out — [themeExpander.js](themeExpander.js), gpt-4o-mini with a
+deterministic template fallback. Caller-provided `themes` are kept verbatim and ranked
+first. Disable per request with `{"expandThemes": false}` or globally with
+`TAPE_THEME_EXPANSION=false`. Since this lives in the backend, the client does not need
+its own expansion.
+
+**Empty results are never cached.** `person-quotes`/`topic-quotes` only cache when
+`candidates.length > 0`, so a zero-result phrasing isn't pinned for the TTL. The
+retrieval cache key carries a version (`tape:tq:v2:…`) — bump it when retrieval logic
+changes to evict stale entries. Empty *live* responses still carry `_meta` (so the
+client can show a Refresh affordance and the correct date window — prefer the live empty
+response over any canned/mock empty fallback).
+
+**Query-layer ticker resolution.** A ticker-shaped query is resolved to its company
+and the **company name** is what's searched — critical for tickers that collide with
+English words (`APP`→AppLovin, `U`→Unity): searching the literal "app" retrieves noise
+("happen", "apple") or nothing. The noise filter then matches the bare ticker only as a
+real symbol (case-sensitive, word-bounded — `$APP`/`NASDAQ: APP`, never "happen") plus
+company-name aliases. `synthesize` also gets the resolved identity (`COMPANY: APP =
+AppLovin`) so it picks sector-correct peers (adtech `TTD/U/RBLX`, not default mega-cap).
 
 Aliases come from [tickerResolver.js](tickerResolver.js), which merges: a curated map
 (nicknames / former names / pronunciations — e.g. `CRWV` → "core weave", "atlantic

--- a/services/tape/companyCards.js
+++ b/services/tape/companyCards.js
@@ -76,4 +76,17 @@ function cardAnchors(ticker) {
   return { products: lc(c.products), execs: lc(c.execs), industry: c.industry ? String(c.industry).toLowerCase() : null };
 }
 
-module.exports = { getCard, cardContext, cardAnchors, load, CONFIG_PATH };
+/**
+ * Ultra-condensed identity for the reranker — just enough to recognize and DROP
+ * a wrong-same-named entity (CEG = Constellation Energy, not Software). Kept tiny
+ * to protect the reranker's token budget. Returns '' when no card.
+ */
+function cardRerankHint(ticker) {
+  const c = getCard(ticker);
+  if (!c) return '';
+  const desc = c.description ? String(c.description).slice(0, 140) : '';
+  const execs = Array.isArray(c.execs) && c.execs.length ? ` Execs: ${c.execs.slice(0, 2).join(', ')}.` : '';
+  return `${c.name || ticker}${c.industry ? ` — ${c.industry}.` : '.'} ${desc}${execs}`.trim();
+}
+
+module.exports = { getCard, cardContext, cardAnchors, cardRerankHint, load, CONFIG_PATH };

--- a/services/tape/companyCards.js
+++ b/services/tape/companyCards.js
@@ -89,4 +89,21 @@ function cardRerankHint(ticker) {
   return `${c.name || ticker}${c.industry ? ` — ${c.industry}.` : '.'} ${desc}${execs}`.trim();
 }
 
-module.exports = { getCard, cardContext, cardAnchors, cardRerankHint, load, CONFIG_PATH };
+/**
+ * Same-industry peers for a ticker, biggest first (more likely to have corpus
+ * coverage) — powers the Read-in industry fallback ("no coverage of X, here's
+ * related <industry> / competitors"). Returns [{ ticker, name, marketCap }].
+ */
+function peersByIndustry(ticker, limit = 5) {
+  const cards = load();
+  const key = String(ticker || '').toUpperCase();
+  const me = cards[key];
+  if (!me || !me.industry) return [];
+  return Object.entries(cards)
+    .filter(([tk, c]) => tk !== key && c && c.industry === me.industry && c.name)
+    .map(([tk, c]) => ({ ticker: tk, name: c.name, marketCap: c.marketCap || 0 }))
+    .sort((a, b) => b.marketCap - a.marketCap)
+    .slice(0, limit);
+}
+
+module.exports = { getCard, cardContext, cardAnchors, cardRerankHint, peersByIndustry, load, CONFIG_PATH };

--- a/services/tape/companyCards.js
+++ b/services/tape/companyCards.js
@@ -1,0 +1,79 @@
+/**
+ * Company-card loader — per-ticker reference facts that ground Read-in synthesis,
+ * disambiguate retrieval (the CEG = Constellation Energy vs Software problem), and
+ * seed search with real products / executive names.
+ *
+ * Backbone fields (name, industry, marketCap, weburl) come from Finnhub profile2
+ * (reliable); description / products / execs are LLM-drafted (best-effort — well-
+ * known for large caps, may be stale for the long tail). Built by
+ * scripts/build-company-cards.js → config/tape-company-cards.yaml.
+ *
+ * Loaded once, lazily reloaded on file mtime change (same pattern as tapeTaste).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const { printLog } = require('../../constants');
+
+const CONFIG_PATH = path.join(__dirname, '..', '..', 'config', 'tape-company-cards.yaml');
+
+let cached = null;
+let cachedMtimeMs = -1;
+
+function load() {
+  let mtimeMs = 0;
+  try { mtimeMs = fs.statSync(CONFIG_PATH).mtimeMs; } catch (_) { /* missing file → empty */ }
+  if (cached && mtimeMs === cachedMtimeMs) return cached;
+  try {
+    const parsed = yaml.load(fs.readFileSync(CONFIG_PATH, 'utf8')) || {};
+    // Normalize keys to uppercase tickers.
+    const byTicker = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      if (v && typeof v === 'object') byTicker[String(k).toUpperCase()] = v;
+    }
+    cached = byTicker;
+    cachedMtimeMs = mtimeMs;
+    printLog(`[companyCards] loaded ${Object.keys(cached).length} cards`);
+  } catch (err) {
+    if (!cached) { cached = {}; printLog(`[companyCards] no cards loaded: ${err.message}`); }
+  }
+  return cached;
+}
+
+/** Card for a ticker, or null. */
+function getCard(ticker) {
+  if (!ticker) return null;
+  return load()[String(ticker).trim().toUpperCase()] || null;
+}
+
+/**
+ * Compact grounding block for the synthesis prompt — authoritative facts the
+ * writer should lean on instead of inferring from sparse clips. Returns '' when
+ * no card. Kept short (the clips are the evidence; this is just identity).
+ */
+function cardContext(ticker) {
+  const c = getCard(ticker);
+  if (!c) return '';
+  const bits = [];
+  if (c.name) bits.push(`${c.name}${c.industry ? ` (${c.industry})` : ''}`);
+  if (c.description) bits.push(c.description);
+  if (Array.isArray(c.products) && c.products.length) bits.push(`Key products/segments: ${c.products.join(', ')}.`);
+  if (Array.isArray(c.execs) && c.execs.length) bits.push(`Key people: ${c.execs.join(', ')}.`);
+  return bits.join(' ');
+}
+
+/**
+ * Extra retrieval anchors from the card — products + execs + industry — as lower-
+ * cased match phrases. Used to (a) seed search and (b) disambiguate the ticker
+ * filter (a clip mentioning the company name token but NONE of these is more
+ * likely the wrong same-named entity).
+ */
+function cardAnchors(ticker) {
+  const c = getCard(ticker);
+  if (!c) return { products: [], execs: [], industry: null };
+  const lc = (a) => (Array.isArray(a) ? a.map((s) => String(s).toLowerCase()).filter(Boolean) : []);
+  return { products: lc(c.products), execs: lc(c.execs), industry: c.industry ? String(c.industry).toLowerCase() : null };
+}
+
+module.exports = { getCard, cardContext, cardAnchors, load, CONFIG_PATH };

--- a/services/tape/confidence.js
+++ b/services/tape/confidence.js
@@ -1,0 +1,116 @@
+/**
+ * Confidence tiers for synthesize responses (memo: confidence tiers).
+ *
+ * The tier is the backend's editorial judgment, computed DETERMINISTICALLY from
+ * signals available post-synthesis — candidate count, rendered section/marker
+ * presence, publisher/side distribution, date spread — NOT model self-grading
+ * (LLMs are poorly calibrated). `confidenceReason` is a short templated sentence
+ * (≤100 chars) the client renders verbatim.
+ *
+ * Unified enum across kinds: strong | partial | thin | empty.
+ *   strong  → full result, no pill
+ *   partial → result + yellow pill (reason)
+ *   thin    → result + red pill (reason)
+ *   empty   → empty state, reason shown verbatim
+ */
+
+const CLIP_RE = /\{\{clip:[^}]+\}\}/g;
+
+function markerCount(text, re) { return (text.match(re) || []).length; }
+function clipCount(s) { return (s.match(CLIP_RE) || []).length; }
+function trim100(s) { const t = String(s || '').trim(); return t.length > 100 ? `${t.slice(0, 97)}…` : t; }
+
+function fmtMonth(ms) {
+  const d = new Date(ms);
+  return `${d.toLocaleString('en-US', { month: 'short', timeZone: 'UTC' })} ${d.getUTCFullYear()}`;
+}
+function dateRange(candidates) {
+  const ds = candidates
+    .map((c) => (c.publishedDate ? new Date(c.publishedDate).getTime() : NaN))
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+  if (ds.length < 2) return null;
+  return `${fmtMonth(ds[0])}–${fmtMonth(ds[ds.length - 1])}`;
+}
+
+/**
+ * @returns {{ confidence:'strong'|'partial'|'thin'|'empty', confidenceReason:string|null, candidateCount:number }}
+ */
+function assessConfidence({
+  kind, candidates = [], finalText = '',
+  synthesizedEmpty = false, emptyReason = null,
+  windowDays = null, windowExpanded = false,
+}) {
+  const candidateCount = candidates.length;
+  if (synthesizedEmpty) {
+    return {
+      confidence: 'empty',
+      confidenceReason: trim100(emptyReason || 'Not enough on-topic material to synthesize.'),
+      candidateCount,
+    };
+  }
+
+  let tier = 'strong';
+  let reason = '';
+
+  switch (kind) {
+    case 'brief': {
+      const publishers = markerCount(finalText, /^##\s*PUBLISHER\s*:/gim);
+      if (publishers >= 3) { tier = 'strong'; } else if (publishers >= 1) { tier = 'partial'; reason = `Only ${publishers} publisher${publishers > 1 ? 's' : ''} in the window.`; } else { tier = 'thin'; reason = 'Single source; little corroboration.'; }
+      // Widening past the default week caps it at partial and is called out.
+      if (windowExpanded) {
+        if (tier === 'strong') tier = 'partial';
+        reason = `Widened to ${windowDays} days; ${candidateCount} mentions.`;
+      }
+      break;
+    }
+    case 'readin': {
+      const wtd = /##\s*WHAT_THEY_DO/i.test(finalText);
+      const pulse = /##\s*PULSE/i.test(finalText);
+      const bull = /##\s*SMART_MONEY\s*:\s*BULL/i.test(finalText);
+      const bear = /##\s*SMART_MONEY\s*:\s*BEAR/i.test(finalText);
+      const risks = /##\s*RISKS/i.test(finalText);
+      if (wtd && pulse && bull && bear && risks) { tier = 'strong'; } else if (wtd && (pulse || bull || bear)) {
+        tier = 'partial';
+        const miss = [!bull && 'bull', !bear && 'bear', !risks && 'risks'].filter(Boolean).join('/');
+        reason = `Incomplete: ${miss || 'some sections'} not synthesized.`;
+      } else { tier = 'thin'; reason = 'Only a primer; no bull/bear structure available.'; }
+      break;
+    }
+    case 'split': {
+      const blocks = finalText.split(/^##\s*PERSON\s*:/im).slice(1);
+      const a = clipCount(blocks[0] || '');
+      const b = clipCount(blocks[1] || '');
+      const total = a + b;
+      if (a >= 4 && b >= 4) { tier = 'strong'; } else if (total >= 4) {
+        tier = 'partial';
+        reason = (Math.min(a, b) <= 2) ? 'One side thinly represented; contrast weak.' : 'Asymmetric coverage across the two sides.';
+      } else { tier = 'thin'; reason = 'Few quotes across both sides combined.'; }
+      break;
+    }
+    case 'dossier': {
+      const topics = markerCount(finalText, /^##\s*TOPIC\s*:/gim);
+      if (candidateCount >= 5 && topics >= 3) { tier = 'strong'; } else if (candidateCount >= 3) { tier = 'partial'; reason = `${candidateCount} appearances — narrow sample.`; } else { tier = 'thin'; reason = `Only ${candidateCount} appearance${candidateCount === 1 ? '' : 's'}.`; }
+      break;
+    }
+    case 'narrative': {
+      const buckets = markerCount(finalText, /^##\s*BUCKET\s*\|/gim);
+      const range = dateRange(candidates);
+      if (candidateCount >= 20 && buckets >= 4) { tier = 'strong'; } else if (candidateCount >= 10 || buckets >= 2) {
+        tier = 'partial';
+        reason = range ? `Coverage clusters in ${range}; earlier history sparse.` : `${candidateCount} candidates across ${buckets} windows.`;
+      } else { tier = 'thin'; reason = `Only ${candidateCount} candidates / ${buckets} window${buckets === 1 ? '' : 's'}.`; }
+      break;
+    }
+    default:
+      tier = 'strong';
+  }
+
+  return {
+    confidence: tier,
+    confidenceReason: tier === 'strong' ? null : trim100(reason),
+    candidateCount,
+  };
+}
+
+module.exports = { assessConfidence };

--- a/services/tape/contextExpander.js
+++ b/services/tape/contextExpander.js
@@ -1,0 +1,84 @@
+/**
+ * Adjacent-paragraph context stitching for Tape synthesis (eval items: truncated
+ * quotes, thin grounding). Same Mongo adjacency pattern /pull uses
+ * (agent-tools/pineconeTools.js getAdjacentParagraphs — episode-scoped, ordered by
+ * start_time), but: (a) it returns the neighbor TEXT (that function strips it),
+ * and (b) it's BATCHED — the whole candidate set costs ~2 queries, not one
+ * full-episode scan per clip.
+ *
+ * Only truncated/short candidates are expanded (a clip cut mid-sentence — the
+ * "limited prof…" failures — or under ~25 words). The expanded passage replaces
+ * the clip's `text` ONLY in the copy handed to the synthesizer, so it grounds on
+ * the fuller context; the citation pill still resolves against the ORIGINAL
+ * candidate (original text + timestamps), so nothing wider leaks to the client.
+ */
+
+const JamieVectorMetadata = require('../../models/JamieVectorMetadata');
+const { printLog } = require('../../constants');
+
+const DEFAULT_WINDOW = parseInt(process.env.TAPE_CONTEXT_WINDOW || '1', 10);
+const MAX_EXPANDED_CHARS = parseInt(process.env.TAPE_CONTEXT_MAX_CHARS || '700', 10);
+const SHORT_WORDS = parseInt(process.env.TAPE_CONTEXT_SHORT_WORDS || '12', 10);
+
+/** A clip worth expanding: ends mid-sentence (no terminal punctuation) or short. */
+function looksTruncated(text) {
+  const t = String(text || '').trim();
+  if (!t) return true;
+  if (t.split(/\s+/).length < SHORT_WORDS) return true;
+  return !/[.!?"'’”)\]]$/.test(t);
+}
+
+/**
+ * @param {Array} candidates  Tape candidates (need .pineconeId, .text)
+ * @param {object} [opts]      { window }
+ * @returns {Promise<Array>}   copies with .text expanded for truncated clips (others unchanged)
+ */
+async function expandPassages(candidates, { window = DEFAULT_WINDOW } = {}) {
+  try {
+    if (!Array.isArray(candidates) || !candidates.length) return candidates;
+    const targets = candidates.filter((c) => c && c.pineconeId && looksTruncated(c.text));
+    if (!targets.length) return candidates;
+
+    // 1) seed lookup: clip id -> { guid, start_time } (cheap, unique-indexed)
+    const seeds = await JamieVectorMetadata.find(
+      { pineconeId: { $in: targets.map((c) => c.pineconeId) }, type: 'paragraph' },
+      { pineconeId: 1, guid: 1, start_time: 1 },
+    ).lean();
+    if (!seeds.length) return candidates;
+    const seedById = new Map(seeds.map((s) => [s.pineconeId, s]));
+    const guids = [...new Set(seeds.map((s) => s.guid).filter(Boolean))];
+
+    // 2) one query for every involved episode's paragraphs, time-ordered, w/ text
+    const all = await JamieVectorMetadata.find(
+      { type: 'paragraph', guid: { $in: guids } },
+      { pineconeId: 1, guid: 1, start_time: 1, 'metadataRaw.text': 1 },
+    ).sort({ guid: 1, start_time: 1 }).lean();
+    const byGuid = new Map();
+    for (const d of all) {
+      if (!byGuid.has(d.guid)) byGuid.set(d.guid, []);
+      byGuid.get(d.guid).push(d);
+    }
+
+    const textOf = (d) => (d && d.metadataRaw && d.metadataRaw.text) || '';
+    const expandedById = new Map();
+    for (const c of targets) {
+      const seed = seedById.get(c.pineconeId);
+      const arr = seed ? byGuid.get(seed.guid) : null;
+      if (!arr) continue;
+      const idx = arr.findIndex((d) => d.pineconeId === c.pineconeId);
+      if (idx === -1) continue;
+      const slice = arr.slice(Math.max(0, idx - window), Math.min(arr.length, idx + 1 + window));
+      let text = slice.map(textOf).filter(Boolean).join(' ').replace(/\s+/g, ' ').trim();
+      if (text.length > MAX_EXPANDED_CHARS) text = `${text.slice(0, MAX_EXPANDED_CHARS).replace(/\s+\S*$/, '')}…`;
+      if (text && text.length > String(c.text || '').length) expandedById.set(c.pineconeId, text);
+    }
+    if (!expandedById.size) return candidates;
+    printLog(`[contextExpander] expanded ${expandedById.size}/${candidates.length} truncated clips (window ${window})`);
+    return candidates.map((c) => (expandedById.has(c.pineconeId) ? { ...c, text: expandedById.get(c.pineconeId) } : c));
+  } catch (err) {
+    printLog(`[contextExpander] error: ${err.message} — using un-expanded candidates`);
+    return candidates;
+  }
+}
+
+module.exports = { expandPassages, looksTruncated };

--- a/services/tape/dateHydration.js
+++ b/services/tape/dateHydration.js
@@ -1,0 +1,61 @@
+/**
+ * Backfill missing candidate dates from the parent episode (Tape-only).
+ *
+ * Some paragraphs' Pinecone metadata lacks `publishedDate` — not because the
+ * date is unknown, but because older episodes were ingested before the derived
+ * date fields (metadataRaw.publishedTimestamp/Year/Month) were populated, so the
+ * downstream metadata the search returns reads "undated". The canonical
+ * top-level `publishedDate` string on the episode doc in Mongo IS intact.
+ *
+ * Since a paragraph and its episode necessarily share a publish date, we look up
+ * the episode by the GUID embedded in the candidate's pineconeId (`<guid>_p<n>`)
+ * and fill in the missing date. One batched query per call; only runs when there
+ * are undated candidates. Disable with TAPE_DATE_HYDRATION=false.
+ */
+
+const JamieVectorMetadata = require('../../models/JamieVectorMetadata');
+const { printLog } = require('../../constants');
+
+const ENABLED = process.env.TAPE_DATE_HYDRATION !== 'false';
+
+/** Episode GUID from a paragraph pineconeId: strip a trailing `_p<digits>`. */
+function guidOf(pineconeId) {
+  return String(pineconeId || '').replace(/_p\d+$/, '');
+}
+
+/**
+ * Mutates `candidates` in place: fills `publishedDate` (and flags `_dateHydrated`)
+ * on any undated candidate whose parent episode has a canonical date.
+ * @returns {Promise<{ hydrated:number, missing:number, total:number }>}
+ */
+async function hydrateCandidateDates(candidates) {
+  const total = Array.isArray(candidates) ? candidates.length : 0;
+  if (!ENABLED || !total) return { hydrated: 0, missing: 0, total };
+
+  const missing = candidates.filter((c) => !c.publishedDate && c.pineconeId);
+  if (!missing.length) return { hydrated: 0, missing: 0, total };
+
+  const guids = [...new Set(missing.map((c) => guidOf(c.pineconeId)).filter(Boolean))];
+  if (!guids.length) return { hydrated: 0, missing: missing.length, total };
+
+  let byGuid = new Map();
+  try {
+    const docs = await JamieVectorMetadata.find({ type: 'episode', guid: { $in: guids } })
+      .select('guid publishedDate')
+      .lean();
+    byGuid = new Map(docs.filter((d) => d.publishedDate).map((d) => [d.guid, d.publishedDate]));
+  } catch (err) {
+    printLog(`[dateHydration] lookup failed (${err.message}) — leaving dates as-is`);
+    return { hydrated: 0, missing: missing.length, total };
+  }
+
+  let hydrated = 0;
+  for (const c of missing) {
+    const d = byGuid.get(guidOf(c.pineconeId));
+    if (d) { c.publishedDate = d; c._dateHydrated = true; hydrated += 1; }
+  }
+  if (hydrated) printLog(`[dateHydration] filled ${hydrated}/${missing.length} missing candidate dates from episode records`);
+  return { hydrated, missing: missing.length, total };
+}
+
+module.exports = { hydrateCandidateDates, guidOf };

--- a/services/tape/kindOrchestrator.js
+++ b/services/tape/kindOrchestrator.js
@@ -476,7 +476,18 @@ async function runReadin(body, { jwtSub, openai, auditId }) {
   const synthCands = await expandPassages(cands);
   const r = await synth('readin', { ticker }, synthCands, body.model || TAPE_READIN_MODEL, jwtSub, auditId);
   const parsed = parseReadin(r.finalText, cands);
-  const peers = r.synthesizedEmpty ? [] : r.tickers;
+
+  // Honest-empty: synthesis produced nothing (clips too thin/off-topic). Do NOT
+  // floor citations onto an empty read-in — that surfaced off-topic quotes (e.g.
+  // 23andMe / COVID clips on a TVTX read-in). Return a clean empty state.
+  if (r.synthesizedEmpty || !parsed.whatTheyDo) {
+    return {
+      result: { ticker, name: resolved.name || ticker, sectorTag: '', yahoo: ticker, whatTheyDo: '', whatTheyDoCitations: [], pulse: { bullLine: '', bearLine: '', priceAction: '', marqueeCitation: null }, smartMoney: { bulls: [], bears: [] }, catalysts: [], risks: [], peers: [], generatedAt: isoNow(), tickers: [], _meta: emptyMeta(r.reason || `${ticker} has no meaningful mentions in the corpus.`) },
+      usage: r.usage,
+      synthesizedEmpty: true,
+    };
+  }
+  const peers = r.tickers;
 
   // Citation floor. The bear slot draws ONLY from genuinely-bearish quotes (when
   // the gate is active): keep stance-correct model picks, then backfill from the

--- a/services/tape/kindOrchestrator.js
+++ b/services/tape/kindOrchestrator.js
@@ -19,6 +19,42 @@ const { TapeHttpError } = require('./tapeErrors');
 const { resolveTicker } = require('./tickerResolver');
 const { classifyStance } = require('./stanceClassifier');
 const { expandPassages } = require('./contextExpander');
+const { getCard, peersByIndustry } = require('./companyCards');
+
+// When a Read-in ticker has no real corpus coverage, zoom out to its industry:
+// surface related peer/sector discussion with a loud disclaimer, instead of a dead
+// empty state. Uses the company card (industry + peers + description). Default on.
+const INDUSTRY_FALLBACK_ENABLED = process.env.TAPE_INDUSTRY_FALLBACK !== 'false';
+
+async function industryReadinFallback(ticker, openai) {
+  if (!INDUSTRY_FALLBACK_ENABLED) return null;
+  const card = getCard(ticker);
+  if (!card || !card.industry) return null;
+  const peers = peersByIndustry(ticker, 5);
+  const themes = [card.industry, ...peers.map((p) => p.name).filter(Boolean)].slice(0, 7);
+  let cites = [];
+  try {
+    const { body: tq } = await topicQuotes(
+      { query: card.industry, themes, kind: 'readin', expandThemes: false, noLiteralAnchor: true, filters: { mainstream: false, candidatesLimit: 6 } },
+      { openai },
+    );
+    cites = (tq.candidates || []).slice(0, 5);
+  } catch (_) { /* fall through to null */ }
+  if (!cites.length) return null;
+  const disclaimer = `⚠️ No podcast coverage of ${card.name} (${ticker}) was found. ${card.name} is a ${card.industry} company${card.description ? ` — ${card.description}` : '.'} The clips below are related ${card.industry} / peer discussion, NOT about ${card.name} specifically.`;
+  return {
+    result: {
+      ticker, name: card.name || ticker, sectorTag: card.industry, yahoo: ticker,
+      whatTheyDo: disclaimer, whatTheyDoCitations: cites,
+      pulse: { bullLine: '', bearLine: '', priceAction: '', marqueeCitation: cites[0] || null },
+      smartMoney: { bulls: [], bears: [] }, catalysts: [], risks: [],
+      peers: peers.map((p) => p.ticker),
+      generatedAt: isoNow(), tickers: peers.map((p) => p.ticker),
+      _meta: { confidence: 'thin', confidenceReason: `No direct coverage of ${ticker}; showing ${card.industry} peers/context.`, candidateCount: cites.length, coverageFallback: 'industry' },
+    },
+    usage: null, synthesizedEmpty: false,
+  };
+}
 const { audit, slimCandidate } = require('./tapeAudit');
 
 // Stance gate (precision half of the polarity work): verify a quote is GENUINELY
@@ -455,6 +491,8 @@ async function runReadin(body, { jwtSub, openai, auditId }) {
     if (candidates.length >= READIN_CAND_CAP) break;
   }
   if (!candidates.length) {
+    const fb = await industryReadinFallback(ticker, openai);
+    if (fb) return fb;
     return { result: { ticker, name: resolved.name || ticker, sectorTag: '', yahoo: ticker, whatTheyDo: '', whatTheyDoCitations: [], pulse: { bullLine: '', bearLine: '', priceAction: '', marqueeCitation: null }, smartMoney: { bulls: [], bears: [] }, catalysts: [], risks: [], peers: [], generatedAt: isoNow(), tickers: [], _meta: emptyMeta(`${ticker} has no meaningful mentions in the corpus.`) }, usage: null, synthesizedEmpty: true };
   }
 
@@ -481,6 +519,8 @@ async function runReadin(body, { jwtSub, openai, auditId }) {
   // floor citations onto an empty read-in — that surfaced off-topic quotes (e.g.
   // 23andMe / COVID clips on a TVTX read-in). Return a clean empty state.
   if (r.synthesizedEmpty || !parsed.whatTheyDo) {
+    const fb = await industryReadinFallback(ticker, openai);
+    if (fb) { fb.usage = r.usage; return fb; } // keep token accounting from the attempt
     return {
       result: { ticker, name: resolved.name || ticker, sectorTag: '', yahoo: ticker, whatTheyDo: '', whatTheyDoCitations: [], pulse: { bullLine: '', bearLine: '', priceAction: '', marqueeCitation: null }, smartMoney: { bulls: [], bears: [] }, catalysts: [], risks: [], peers: [], generatedAt: isoNow(), tickers: [], _meta: emptyMeta(r.reason || `${ticker} has no meaningful mentions in the corpus.`) },
       usage: r.usage,

--- a/services/tape/kindOrchestrator.js
+++ b/services/tape/kindOrchestrator.js
@@ -17,7 +17,15 @@ const { parseDossier, parseBrief, parseSplit, parseNarrative, parseReadin } = re
 const { assessConfidence } = require('./confidence');
 const { TapeHttpError } = require('./tapeErrors');
 const { resolveTicker } = require('./tickerResolver');
+const { classifyStance } = require('./stanceClassifier');
+const { expandPassages } = require('./contextExpander');
 const { audit, slimCandidate } = require('./tapeAudit');
+
+// Stance gate (precision half of the polarity work): verify a quote is GENUINELY
+// bullish/bearish before it fills a bear slot (Read-in) or a camp side (Split),
+// so seeding's recall doesn't drag non-polarized quotes into a directional slot.
+// Fail-open (classifier errors → un-gated pool). Disable with TAPE_STANCE_GATE=false.
+const STANCE_GATE_ENABLED = process.env.TAPE_STANCE_GATE !== 'false';
 
 const CAMPS = new Set(['bulls', 'bears', 'hawks', 'doves']);
 const DAY_MS = 86_400_000;
@@ -44,6 +52,16 @@ function campSide(name) {
   return null;
 }
 
+// Strip the internal `_stance` hint off citation objects so it never leaks into
+// the API response (it's an orchestration-only annotation for the stance gate).
+function stripStance(arr) {
+  return (arr || []).map((c) => {
+    if (!c || c._stance === undefined) return c;
+    const { _stance, ...rest } = c;
+    return rest;
+  });
+}
+
 const DEFAULT_DOSSIER_THEMES = [
   'Federal Reserve interest rates inflation policy',
   'recession risk economy',
@@ -65,15 +83,70 @@ const DOSSIER_FILTER_TIERS = [
   { dedicatedOnly: false, mainstream: false },
 ];
 
-// Tape synthesis is a no-tools prose pass. The global `quality` alias (DeepSeek
-// V4) is a REASONING model that's flaky here (burns budget thinking → empty /
-// truncated output that drops the trailing ## TICKERS block). So Tape uses a
-// clean prose model — gpt-4o-mini, which is exactly what /api/pull routes its
-// own final prose to (AGENT_SYNTHESIS_MODEL). Cheap (~$0.001/synth), reliable.
-// `fast` (Haiku) honored if explicitly requested; TAPE_SYNTH_MODEL overrides.
-const TAPE_SYNTH_MODEL = process.env.TAPE_SYNTH_MODEL || 'gpt-4o-mini';
+// Per-kind synthesis routing — LOCKED from the eval model sweep (2026-06-05):
+// - Brief / Split / dossier / narrative → DeepSeek V4-Flash ('quality'): the
+//   cheapest synth in the stack AND the highest quality on these kinds (eval v6:
+//   Brief 9→15/20, confidence_overstated 7→0). The old "DeepSeek is flaky" issue
+//   was a too-low token cap (now 8000), NOT the model — 0 compliance failures at
+//   the proper cap. Trade-off is latency (~30s/synth), which Tape's content-
+//   addressed caching absorbs on repeats.
+// - Read-in → Haiku ('fast', see TAPE_READIN_MODEL): the citation-heavy primer;
+//   DeepSeek under-produced it (eval v6: 6/20, several empty). Haiku cites reliably.
+// Both overridable per env for future A/Bs.
+const TAPE_SYNTH_MODEL = process.env.TAPE_SYNTH_MODEL || 'quality';
+const TAPE_READIN_MODEL = process.env.TAPE_READIN_MODEL || 'fast';
+// Map a requested model to a resolveModelSelection key. 'fast' → Haiku; an
+// explicit model id (gpt-4o, gpt-4o-mini, …) passes through so model can be swept
+// per env; anything empty/'quality'/'default' falls back to the Tape synth model.
 function tapeModelKey(requested) {
-  return requested === 'fast' ? 'fast' : TAPE_SYNTH_MODEL;
+  if (requested === 'fast') return 'fast';
+  if (typeof requested === 'string' && requested && requested !== 'quality' && requested !== 'default') return requested;
+  return TAPE_SYNTH_MODEL;
+}
+
+// Read-in bear-seeded retrieval. Podcasts skew bullish/promotional, so a neutral
+// "{ticker}" vector query lands in a bull-heavy neighborhood and the synth has no
+// genuine bearish material for the SMART_MONEY:BEAR slot (eval flagged
+// bear_slot_not_bearish across ~11 tickers). A second retrieval seeded with
+// bearish framing pulls the short/overvalued/downside neighborhood; results merge
+// into the pool so real bear quotes EXIST for the synth to cite and the bear
+// citation-floor to draw from. Disable with TAPE_READIN_BEAR_SEED=false.
+const BEAR_SEED_ENABLED = process.env.TAPE_READIN_BEAR_SEED !== 'false';
+const READIN_CAND_CAP = parseInt(process.env.TAPE_READIN_CAND_CAP || '24', 10);
+function bearThemes(name) {
+  return [
+    `${name} overvalued bubble`,
+    `${name} bear case short thesis`,
+    `${name} downside risk concerns headwinds`,
+    `${name} expensive valuation priced for perfection`,
+    `why ${name} could fall decline`,
+  ];
+}
+function bullThemes(topic) {
+  return [
+    `${topic} bullish upside`,
+    `${topic} buy opportunity growth`,
+    `${topic} undervalued long thesis`,
+    `why ${topic} will rise positive outlook`,
+  ];
+}
+
+// Split camp side: polarity-seeded retrieval so each side comes from its OWN
+// sentiment neighborhood, not one neutral pool sorted by a keyword classifier
+// (eval: both_sides_same). expandThemes off so the neutral expander doesn't
+// dilute the polarity; query=topic keeps the literal-anchor/topic filter.
+function splitCampPool(topic, themes, openai) {
+  return topicQuotes({ query: topic, themes, kind: 'split', expandThemes: false, filters: { mainstream: true, candidatesLimit: 12 } }, { openai })
+    .then((r) => r.body.candidates || [])
+    .catch(() => []);
+}
+
+// Named Split side: bias toward first-person quotes (a proxy for the person
+// actually SPEAKING vs being discussed by a host — the Saylor "about-them"
+// fabrication). Soft re-rank; never drops, so a thinly-covered person isn't
+// emptied by the heuristic alone.
+function preferFirstPerson(cands) {
+  return [...(cands || [])].sort((a, b) => (b._signals?.firstPerson ? 1 : 0) - (a._signals?.firstPerson ? 1 : 0));
 }
 
 /** One internal synthesis pass via the shared agentic core. */
@@ -198,48 +271,99 @@ async function runSplit(body, { jwtSub, openai, auditId }) {
   if (!personA || !personB || !topic) throw new TapeHttpError(400, 'bad-request', 'Bad request', 'personA, personB and topic are required');
 
   const isCamp = CAMPS.has(personA.toLowerCase()) || CAMPS.has(personB.toLowerCase());
-  let candidates = [];
   let subA = []; // per-side pools for the citation floor
   let subB = [];
+  let stanceMap = new Map();
   if (isCamp) {
-    const { body: tq } = await topicQuotes({ query: topic, themes: [topic], kind: 'split', groupBy: 'bull-bear', filters: { mainstream: true } }, { openai });
-    candidates = tq.candidates || [];
-    const sa = campSide(personA);
+    // Polarity-seeded dual retrieval (recall) → stance gate (precision): each
+    // side keeps only quotes whose classified stance matches its camp, so the two
+    // sides genuinely oppose instead of sharing topically-adjacent neutrals.
+    const [bullPool, bearPool] = await Promise.all([
+      splitCampPool(topic, bullThemes(topic), openai),
+      splitCampPool(topic, bearThemes(topic), openai),
+    ]);
+    const union = [];
+    const seenU = new Set();
+    for (const c of [...bullPool, ...bearPool]) { if (c?.pineconeId && !seenU.has(c.pineconeId)) { seenU.add(c.pineconeId); union.push(c); } }
+    if (STANCE_GATE_ENABLED) {
+      try { ({ stances: stanceMap } = await classifyStance({ subject: topic, clips: union, openai })); } catch (_) { /* fail-open */ }
+    }
+    const sa = campSide(personA); // 'bull' | 'bear' | null
     const sb = campSide(personB);
-    const half = Math.ceil(candidates.length / 2);
-    subA = sa ? candidates.filter((c) => c.side === sa) : candidates.slice(0, half);
-    subB = sb ? candidates.filter((c) => c.side === sb) : candidates.slice(half);
+    if (stanceMap.size > 0) {
+      const ofStance = (st) => union.filter((c) => stanceMap.get(c.pineconeId) === st);
+      subA = sa ? ofStance(sa) : union;   // stance-correct quotes for camp A
+      subB = sb ? ofStance(sb) : union;   // stance-correct quotes for camp B
+    } else {
+      subA = sa === 'bear' ? bearPool : bullPool;   // fail-open: seeded pools
+      subB = sb === 'bull' ? bullPool : bearPool;
+    }
   } else {
+    // Named: quotes BY each person, first-person-preferred (proxy for speaking).
     const grab = (name) => personQuotes({ name, themes: [topic], kind: 'split', filters: { dedicatedOnly: false, mainstream: false } }, { openai })
-      .then((r) => r.body.candidates || []).catch(() => []);
+      .then((r) => preferFirstPerson(r.body.candidates || [])).catch(() => []);
     [subA, subB] = await Promise.all([grab(personA), grab(personB)]);
-    const seen = new Set();
-    candidates = [...subA, ...subB].filter((c) => c.pineconeId && !seen.has(c.pineconeId) && seen.add(c.pineconeId));
+  }
+  // Merge dedup for the synth pool (side pools stay separate for the floor);
+  // annotate with stance so the writer slots quotes onto the correct side.
+  const seenC = new Set();
+  const candidates = [];
+  for (const c of [...subA, ...subB]) {
+    if (!c || !c.pineconeId || seenC.has(c.pineconeId)) continue;
+    seenC.add(c.pineconeId);
+    candidates.push({ ...c, _stance: stanceMap.get(c.pineconeId) });
   }
   if (!candidates.length) {
     return { result: { topic, sideA: { person: personA, positionSummary: '', citations: [] }, sideB: { person: personB, positionSummary: '', citations: [] }, generatedAt: isoNow(), tickers: [], _meta: emptyMeta('No quotes found for either side of this debate.') }, usage: null, synthesizedEmpty: true };
   }
 
+  // Note: NO context expansion on Split — it dilutes the stance-gated quotes
+  // (v5: both_sides_same regressed 3→9). Expansion stays Read-In-only.
   const r = await synth('split', { person: personA, personB, topic }, candidates, body.model, jwtSub, auditId);
   const parsed = parseSplit(r.finalText, candidates);
   const conf = assessConfidence({ kind: 'split', candidates, finalText: r.finalText, synthesizedEmpty: r.synthesizedEmpty, emptyReason: r.reason });
   const used = new Set();
   const sideA = { ...parsed.sideA, person: parsed.sideA.person || personA };
   const sideB = { ...parsed.sideB, person: parsed.sideB.person || personB };
-  sideA.citations = floorEmpty(sideA.citations, subA, used, 3);
-  sideB.citations = floorEmpty(sideB.citations, subB, used, 3);
+  // Citations must be side-correct (stance/person-matched) and never shared across
+  // sides: keep only the model picks belonging to this side's pool, then backfill
+  // from it; the shared `used` set guarantees a clip can't appear on both sides.
+  const aIds = new Set(subA.map((c) => c.pineconeId));
+  const bIds = new Set(subB.map((c) => c.pineconeId));
+  const aModel = (sideA.citations || []).filter((c) => aIds.has(c.pineconeId));
+  const bModel = (sideB.citations || []).filter((c) => bIds.has(c.pineconeId));
+  sideA.citations = stripStance(floorEmpty(aModel, subA, used, 3));
+  sideB.citations = stripStance(floorEmpty(bModel, subB, used, 3));
+
+  // Honest-empty gate: a side with no genuine quotes must not present a
+  // fabricated stance (the El-Erian/Summers + Saylor failures). Blank the prose
+  // and citations for the starved side and report it in the confidence, instead
+  // of letting the writer mirror the other side or invent a position.
+  let { confidence, confidenceReason, candidateCount } = conf;
+  const starved = [];
+  if (!subA.length) { sideA.positionSummary = ''; sideA.citations = []; starved.push(sideA.person); }
+  if (!subB.length) { sideB.positionSummary = ''; sideB.citations = []; starved.push(sideB.person); }
+  if (starved.length === 2) {
+    confidence = 'empty';
+    confidenceReason = `No quotes found for ${sideA.person} or ${sideB.person}.`;
+  } else if (starved.length === 1) {
+    confidence = 'thin';
+    confidenceReason = `No quotes found for ${starved[0]}; one-sided.`;
+  }
+  const oneSided = starved.length > 0;
+
   return {
     result: {
       topic,
       sideA,
       sideB,
-      contrastSummary: parsed.contrastSummary,
+      contrastSummary: oneSided ? '' : parsed.contrastSummary,
       generatedAt: isoNow(),
       tickers: r.synthesizedEmpty ? [] : r.tickers,
-      _meta: { confidence: conf.confidence, confidenceReason: conf.confidenceReason, candidateCount: conf.candidateCount, ...(r.recovered ? { complianceRecovered: true } : {}) },
+      _meta: { confidence, confidenceReason, candidateCount, ...(r.recovered ? { complianceRecovered: true } : {}) },
     },
     usage: r.usage,
-    synthesizedEmpty: r.synthesizedEmpty,
+    synthesizedEmpty: r.synthesizedEmpty || starved.length === 2,
   };
 }
 
@@ -302,24 +426,70 @@ async function runReadin(body, { jwtSub, openai, auditId }) {
   if (!ticker) throw new TapeHttpError(400, 'bad-request', 'Bad request', 'ticker is required');
   const resolved = await resolveTicker(ticker);
 
-  const { body: tq } = await topicQuotes({ query: ticker, themes: [ticker], kind: 'readin', filters: { mainstream: false, candidatesLimit: 20 } }, { openai });
-  const candidates = tq.candidates || [];
+  // Two retrievals: a neutral pool (bull/primer material) + a bear-seeded pool so
+  // genuinely bearish quotes are present. Bear call skips theme expansion so the
+  // neutral expander doesn't dilute the bearish framing, and uses query=ticker so
+  // the resolver + ticker-noise filter still anchor results on the company.
+  const bearName = resolved.name || ticker;
+  const [bullRes, bearRes] = await Promise.all([
+    topicQuotes({ query: ticker, themes: [ticker], kind: 'readin', filters: { mainstream: false, candidatesLimit: 18 } }, { openai }),
+    BEAR_SEED_ENABLED
+      ? topicQuotes({ query: ticker, themes: bearThemes(bearName), kind: 'readin', expandThemes: false, filters: { mainstream: false, candidatesLimit: 12 } }, { openai }).catch(() => ({ body: { candidates: [] } }))
+      : Promise.resolve({ body: { candidates: [] } }),
+  ]);
+  const bullCands = bullRes.body.candidates || [];
+  const bearCands = bearRes.body.candidates || [];
+  // Track which ids came from the bear-seeded retrieval (no flag mutation on the
+  // candidate, so nothing leaks into the API response). Merge bull-first, dedup.
+  const bearIds = new Set(bearCands.map((c) => c.pineconeId).filter(Boolean));
+  const seenIds = new Set();
+  const candidates = [];
+  for (const c of [...bullCands, ...bearCands]) {
+    if (!c || !c.pineconeId || seenIds.has(c.pineconeId)) continue;
+    seenIds.add(c.pineconeId);
+    candidates.push(c);
+    if (candidates.length >= READIN_CAND_CAP) break;
+  }
   if (!candidates.length) {
     return { result: { ticker, name: resolved.name || ticker, sectorTag: '', yahoo: ticker, whatTheyDo: '', whatTheyDoCitations: [], pulse: { bullLine: '', bearLine: '', priceAction: '', marqueeCitation: null }, smartMoney: { bulls: [], bears: [] }, catalysts: [], risks: [], peers: [], generatedAt: isoNow(), tickers: [], _meta: emptyMeta(`${ticker} has no meaningful mentions in the corpus.`) }, usage: null, synthesizedEmpty: true };
   }
 
+  // Stance gate: classify each candidate's stance toward the company so the bear
+  // slot is filled only by genuinely BEARISH quotes (seeding surfaces the bearish
+  // neighborhood; this verifies polarity). Fail-open → un-gated bear-seeded pool.
+  let stanceMap = new Map();
+  if (STANCE_GATE_ENABLED) {
+    try { ({ stances: stanceMap } = await classifyStance({ subject: bearName, clips: candidates, openai })); } catch (_) { /* fail-open */ }
+  }
+  const gateActive = stanceMap.size > 0;
+  const cands = candidates.map((c) => ({ ...c, _stance: stanceMap.get(c.pineconeId) }));
+
   // Read-in is citation-critical (inline WHAT_THEY_DO pills + SMART_MONEY quotes);
   // gpt-4o-mini under-cites the primer, so this one kind defaults to Haiku, which
   // cites reliably. Other kinds stay on cheap gpt-4o-mini. Explicit body.model wins.
-  const r = await synth('readin', { ticker }, candidates, body.model || 'fast', jwtSub, auditId);
-  const parsed = parseReadin(r.finalText, candidates);
+  // Stitch adjacent paragraphs onto truncated clips for the synthesis pass only;
+  // citations still hydrate against the original `cands` (original text + times).
+  const synthCands = await expandPassages(cands);
+  const r = await synth('readin', { ticker }, synthCands, body.model || TAPE_READIN_MODEL, jwtSub, auditId);
+  const parsed = parseReadin(r.finalText, cands);
   const peers = r.synthesizedEmpty ? [] : r.tickers;
-  // Citation floor (insurance — readin is on Haiku and usually cites well).
+
+  // Citation floor. The bear slot draws ONLY from genuinely-bearish quotes (when
+  // the gate is active): keep stance-correct model picks, then backfill from the
+  // bear-stance pool. If nothing is genuinely bearish, the bear slot stays empty
+  // and the bear pulse line is blanked — honest over a fabricated bear case.
   const usedR = new Set();
-  const whatTheyDoCitations = floorEmpty(parsed.whatTheyDoCitations, candidates, usedR, 3);
-  const bulls = floorEmpty(parsed.smartMoney.bulls, candidates, usedR, 2);
-  const bears = floorEmpty(parsed.smartMoney.bears, candidates, usedR, 2);
-  const pulse = { ...parsed.pulse, marqueeCitation: parsed.pulse.marqueeCitation || whatTheyDoCitations[0] || candidates[0] || null };
+  const bearStancePool = gateActive ? cands.filter((c) => c._stance === 'bear') : cands.filter((c) => bearIds.has(c.pineconeId));
+  const bearStanceIds = new Set(bearStancePool.map((c) => c.pineconeId));
+  const nonBearPool = gateActive ? cands.filter((c) => c._stance !== 'bear') : cands.filter((c) => !bearIds.has(c.pineconeId));
+  const modelBears = gateActive ? (parsed.smartMoney.bears || []).filter((c) => bearStanceIds.has(c.pineconeId)) : (parsed.smartMoney.bears || []);
+  const bears = stripStance(floorEmpty(modelBears, bearStancePool.length ? bearStancePool : (gateActive ? [] : cands), usedR, 2));
+  const whatTheyDoCitations = stripStance(floorEmpty(parsed.whatTheyDoCitations, cands, usedR, 3));
+  const bulls = stripStance(floorEmpty(parsed.smartMoney.bulls, nonBearPool.length ? nonBearPool : cands, usedR, 2));
+  // Blank an unsupported bear pulse line: no genuine bear quote ⇒ nothing backs it.
+  const bearLine = (gateActive && bears.length === 0) ? '' : parsed.pulse.bearLine;
+  const marquee = parsed.pulse.marqueeCitation || whatTheyDoCitations[0] || cands[0] || null;
+  const pulse = { ...parsed.pulse, bearLine, marqueeCitation: marquee ? stripStance([marquee])[0] : null };
 
   // Confidence scored on the ASSEMBLED result (post-floor): a Read-in that
   // renders the full structure — primer + bull & bear pulse lines + both
@@ -329,7 +499,7 @@ async function runReadin(body, { jwtSub, openai, auditId }) {
   // the floor only backfills citations, not those.
   const hasWtd = !!(parsed.whatTheyDo && parsed.whatTheyDo.trim());
   const hasBullLine = !!(parsed.pulse.bullLine && parsed.pulse.bullLine.trim());
-  const hasBearLine = !!(parsed.pulse.bearLine && parsed.pulse.bearLine.trim());
+  const hasBearLine = !!(bearLine && bearLine.trim());
   const hasRisks = parsed.risks.length > 0;
   let confidence;
   let confidenceReason = null;

--- a/services/tape/kindOrchestrator.js
+++ b/services/tape/kindOrchestrator.js
@@ -431,6 +431,10 @@ async function runReadin(body, { jwtSub, openai, auditId }) {
   // neutral expander doesn't dilute the bearish framing, and uses query=ticker so
   // the resolver + ticker-noise filter still anchor results on the company.
   const bearName = resolved.name || ticker;
+  // NOTE: exec/product search-seeding was tried (v9) and reverted — adding those
+  // themes to the BULL pool crowded out the bear-seeded clips at the merge cap and
+  // worsened bear_slot_not_bearish. Recall on sparse tickers needs a bear-protected
+  // approach, not bull-pool seeding.
   const [bullRes, bearRes] = await Promise.all([
     topicQuotes({ query: ticker, themes: [ticker], kind: 'readin', filters: { mainstream: false, candidatesLimit: 18 } }, { openai }),
     BEAR_SEED_ENABLED

--- a/services/tape/kindOrchestrator.js
+++ b/services/tape/kindOrchestrator.js
@@ -148,6 +148,12 @@ function tapeModelKey(requested) {
 // into the pool so real bear quotes EXIST for the synth to cite and the bear
 // citation-floor to draw from. Disable with TAPE_READIN_BEAR_SEED=false.
 const BEAR_SEED_ENABLED = process.env.TAPE_READIN_BEAR_SEED !== 'false';
+// Read-in does NOT hard-gate by source (default false): hard-gating starved its
+// bear side (eval v11: bear_slot_not_bearish 4→8). Instead the SOURCE_BOOST in
+// topicQuotes SOFT-demotes non-allowlisted feeds (quality sources rank first,
+// but off-topic noise is still rejected by the ticker filter + reranker). Set
+// TAPE_READIN_MAINSTREAM=true to hard-gate again.
+const READIN_MAINSTREAM = process.env.TAPE_READIN_MAINSTREAM === 'true';
 const READIN_CAND_CAP = parseInt(process.env.TAPE_READIN_CAND_CAP || '24', 10);
 function bearThemes(name) {
   return [
@@ -472,9 +478,9 @@ async function runReadin(body, { jwtSub, openai, auditId }) {
   // worsened bear_slot_not_bearish. Recall on sparse tickers needs a bear-protected
   // approach, not bull-pool seeding.
   const [bullRes, bearRes] = await Promise.all([
-    topicQuotes({ query: ticker, themes: [ticker], kind: 'readin', filters: { mainstream: false, candidatesLimit: 18 } }, { openai }),
+    topicQuotes({ query: ticker, themes: [ticker], kind: 'readin', filters: { mainstream: READIN_MAINSTREAM, candidatesLimit: 18 } }, { openai }),
     BEAR_SEED_ENABLED
-      ? topicQuotes({ query: ticker, themes: bearThemes(bearName), kind: 'readin', expandThemes: false, filters: { mainstream: false, candidatesLimit: 12 } }, { openai }).catch(() => ({ body: { candidates: [] } }))
+      ? topicQuotes({ query: ticker, themes: bearThemes(bearName), kind: 'readin', expandThemes: false, filters: { mainstream: READIN_MAINSTREAM, candidatesLimit: 12 } }, { openai }).catch(() => ({ body: { candidates: [] } }))
       : Promise.resolve({ body: { candidates: [] } }),
   ]);
   const bullCands = bullRes.body.candidates || [];

--- a/services/tape/kindOrchestrator.js
+++ b/services/tape/kindOrchestrator.js
@@ -1,0 +1,371 @@
+/**
+ * Kind-level orchestration: the full retrieve → synthesize → parse → hydrate →
+ * assemble pipeline for each Tape action, behind one call. Composes the existing
+ * internal primitives (personQuotes / topicQuotes / produce) + markerParse +
+ * confidence. Returns { result, usage, synthesizedEmpty }; throws TapeHttpError
+ * on hard failure (caught by withKindEndpoint).
+ *
+ * This is the only place the retrieve↔synthesize seam lives now — the client
+ * just calls /api/tape/<kind> and renders the typed Result.
+ */
+
+const { resolveModelSelection } = require('../../constants/agentModels');
+const { personQuotes } = require('./personQuotes');
+const { topicQuotes } = require('./topicQuotes');
+const { produce } = require('./synthesize');
+const { parseDossier, parseBrief, parseSplit, parseNarrative, parseReadin } = require('./markerParse');
+const { assessConfidence } = require('./confidence');
+const { TapeHttpError } = require('./tapeErrors');
+const { resolveTicker } = require('./tickerResolver');
+const { audit, slimCandidate } = require('./tapeAudit');
+
+const CAMPS = new Set(['bulls', 'bears', 'hawks', 'doves']);
+const DAY_MS = 86_400_000;
+const isoDay = (ms) => new Date(ms).toISOString().slice(0, 10);
+
+// Citation floor (per the citation-hydration memo): when the synth leaves a
+// section's citations empty, backfill from the candidate pool so the UI always
+// shows real, playable receipts — model-independent. Preserves the synth's own
+// picks where present; `used` dedups across sections so the same clip isn't
+// repeated everywhere.
+function floorEmpty(citations, subpool, used, k) {
+  if (citations && citations.length) { citations.forEach((c) => used.add(c.pineconeId)); return citations; }
+  const picks = [];
+  for (const c of (subpool || [])) {
+    if (picks.length >= k) break;
+    if (c && c.pineconeId && !used.has(c.pineconeId)) { picks.push(c); used.add(c.pineconeId); }
+  }
+  return picks;
+}
+function campSide(name) {
+  const n = String(name || '').toLowerCase();
+  if (n === 'bulls') return 'bull';
+  if (n === 'bears') return 'bear';
+  return null;
+}
+
+const DEFAULT_DOSSIER_THEMES = [
+  'Federal Reserve interest rates inflation policy',
+  'recession risk economy',
+  'stock market valuations',
+  'oil commodities energy',
+  'the US dollar and Treasury yields',
+  'gold and safe havens',
+];
+
+const isoNow = () => new Date().toISOString();
+
+// Dossier retrieval ladder: prefer dedicated + mainstream, but a person who only
+// ever guests (titles don't contain their name) or appears on shows outside the
+// allowlist would yield nothing. Broaden in steps until candidates surface —
+// same resilience shape as Brief's window auto-expand.
+const DOSSIER_FILTER_TIERS = [
+  { dedicatedOnly: true, mainstream: true },
+  { dedicatedOnly: false, mainstream: true },
+  { dedicatedOnly: false, mainstream: false },
+];
+
+// Tape synthesis is a no-tools prose pass. The global `quality` alias (DeepSeek
+// V4) is a REASONING model that's flaky here (burns budget thinking → empty /
+// truncated output that drops the trailing ## TICKERS block). So Tape uses a
+// clean prose model — gpt-4o-mini, which is exactly what /api/pull routes its
+// own final prose to (AGENT_SYNTHESIS_MODEL). Cheap (~$0.001/synth), reliable.
+// `fast` (Haiku) honored if explicitly requested; TAPE_SYNTH_MODEL overrides.
+const TAPE_SYNTH_MODEL = process.env.TAPE_SYNTH_MODEL || 'gpt-4o-mini';
+function tapeModelKey(requested) {
+  return requested === 'fast' ? 'fast' : TAPE_SYNTH_MODEL;
+}
+
+/** One internal synthesis pass via the shared agentic core. */
+async function synth(kind, input, candidates, model, jwtSub, auditId) {
+  audit('retrieval', auditId, { kind, input, candidateCount: candidates.length, candidates: candidates.map(slimCandidate) });
+  const { modelConfig } = resolveModelSelection({ model: tapeModelKey(model) });
+  const validIds = new Set(candidates.map((c) => c.pineconeId).filter(Boolean));
+  const r = await produce({ kind, input, candidates, modelConfig, validIds, ctx: { sub: jwtSub, model: modelConfig.id } });
+  audit('synthesis', auditId, { kind, model: modelConfig.id, tokens: r.usage, synthesizedEmpty: r.synthesizedEmpty, attempts: r.attempts, rawText: r.finalText });
+  return r;
+}
+
+function emptyMeta(reason) {
+  return { confidence: 'empty', confidenceReason: reason, candidateCount: 0 };
+}
+
+// ---- Dossier ----
+async function runDossier(body, { jwtSub, openai, auditId }) {
+  const person = String(body.person || '').trim();
+  if (!person) throw new TapeHttpError(400, 'bad-request', 'Bad request', 'person is required');
+
+  let pq = null;
+  let tierUsed = -1;
+  for (let i = 0; i < DOSSIER_FILTER_TIERS.length; i += 1) {
+    const res = await personQuotes(
+      { name: person, themes: DEFAULT_DOSSIER_THEMES, kind: 'dossier', filters: DOSSIER_FILTER_TIERS[i] },
+      { openai },
+    );
+    pq = res.body;
+    if ((pq.candidates || []).length) { tierUsed = i; break; }
+  }
+  const candidates = pq?.candidates || [];
+  if (!candidates.length) {
+    return {
+      result: { person, topics: [], appearances: [], generatedAt: isoNow(), tickers: [], _meta: emptyMeta(`${person} has no mainstream appearances surfaced in the corpus.`) },
+      usage: null, synthesizedEmpty: true,
+    };
+  }
+
+  const r = await synth('dossier', { person }, candidates, body.model, jwtSub, auditId);
+  const parsed = parseDossier(r.finalText, candidates);
+  // Backfill appearances from person-quotes if the synthesis omitted the block.
+  const appearances = parsed.appearances.length
+    ? parsed.appearances
+    : (pq.appearances || []).map((a) => ({ show: a.feedTitle || null, episodeTitle: a.title || null, publishedDate: a.publishedDate || null, citationCount: 0 }));
+  const conf = assessConfidence({ kind: 'dossier', candidates, finalText: r.finalText, synthesizedEmpty: r.synthesizedEmpty, emptyReason: r.reason });
+  // Broadening past the mainstream allowlist caps confidence at partial and is noted.
+  let { confidence, confidenceReason } = conf;
+  if (tierUsed >= 2 && confidence === 'strong') {
+    confidence = 'partial';
+    confidenceReason = 'Broadened beyond mainstream sources — limited dedicated coverage.';
+  }
+
+  const usedD = new Set();
+  const topics = parsed.topics.map((t) => ({ ...t, citations: floorEmpty(t.citations, candidates, usedD, 3) }));
+  return {
+    result: {
+      person,
+      topics,
+      appearances,
+      generatedAt: isoNow(),
+      tickers: r.synthesizedEmpty ? [] : r.tickers,
+      _meta: { confidence, confidenceReason, candidateCount: conf.candidateCount, ...(r.recovered ? { complianceRecovered: true } : {}) },
+    },
+    usage: r.usage,
+    synthesizedEmpty: r.synthesizedEmpty || parsed.topics.length === 0,
+  };
+}
+
+// ---- Brief ----
+async function runBrief(body, { jwtSub, openai, auditId }) {
+  const topic = String(body.topic || '').trim();
+  const asOfDate = body.asOfDate;
+  if (!topic) throw new TapeHttpError(400, 'bad-request', 'Bad request', 'topic is required');
+  if (!asOfDate || !/^\d{4}-\d{2}-\d{2}/.test(asOfDate)) throw new TapeHttpError(400, 'bad-request', 'Bad request', 'asOfDate (yyyy-mm-dd) is required');
+
+  // Backend owns the window: kind=brief + asOfDate drives the 7→30→90 auto-expand.
+  const { body: tq } = await topicQuotes(
+    { query: topic, kind: 'brief', asOfDate, filters: { mainstream: true } },
+    { openai },
+  );
+  const candidates = tq.candidates || [];
+  const windowDays = tq._meta?.windowDays ?? null;
+  const windowExpanded = tq._meta?.windowExpanded ?? false;
+
+  if (!candidates.length) {
+    return {
+      result: { topic, asOfDate, headline: '', sections: [], generatedAt: isoNow(), tickers: [], _meta: { ...emptyMeta('No mainstream coverage of this topic in the last 90 days.'), ...(windowDays != null ? { windowDays, windowExpanded } : {}) } },
+      usage: null, synthesizedEmpty: true,
+    };
+  }
+
+  const r = await synth('brief', { topic }, candidates, body.model, jwtSub, auditId);
+  const parsed = parseBrief(r.finalText, candidates);
+  const conf = assessConfidence({ kind: 'brief', candidates, finalText: r.finalText, synthesizedEmpty: r.synthesizedEmpty, emptyReason: r.reason, windowDays, windowExpanded });
+  const usedB = new Set();
+  const sections = parsed.sections.map((s) => {
+    const byCreator = candidates.filter((c) => c.creator && s.publisher && c.creator.toLowerCase() === s.publisher.toLowerCase());
+    return { ...s, citations: floorEmpty(s.citations, byCreator.length ? byCreator : candidates, usedB, 2) };
+  });
+
+  return {
+    result: {
+      topic,
+      asOfDate,
+      headline: parsed.headline,
+      sections,
+      generatedAt: isoNow(),
+      tickers: r.synthesizedEmpty ? [] : r.tickers,
+      _meta: { confidence: conf.confidence, confidenceReason: conf.confidenceReason, candidateCount: conf.candidateCount, ...(windowDays != null ? { windowDays, windowExpanded } : {}), ...(r.recovered ? { complianceRecovered: true } : {}) },
+    },
+    usage: r.usage,
+    synthesizedEmpty: r.synthesizedEmpty || parsed.sections.length === 0,
+  };
+}
+
+// ---- Split ----
+async function runSplit(body, { jwtSub, openai, auditId }) {
+  const personA = String(body.personA || '').trim();
+  const personB = String(body.personB || '').trim();
+  const topic = String(body.topic || '').trim();
+  if (!personA || !personB || !topic) throw new TapeHttpError(400, 'bad-request', 'Bad request', 'personA, personB and topic are required');
+
+  const isCamp = CAMPS.has(personA.toLowerCase()) || CAMPS.has(personB.toLowerCase());
+  let candidates = [];
+  let subA = []; // per-side pools for the citation floor
+  let subB = [];
+  if (isCamp) {
+    const { body: tq } = await topicQuotes({ query: topic, themes: [topic], kind: 'split', groupBy: 'bull-bear', filters: { mainstream: true } }, { openai });
+    candidates = tq.candidates || [];
+    const sa = campSide(personA);
+    const sb = campSide(personB);
+    const half = Math.ceil(candidates.length / 2);
+    subA = sa ? candidates.filter((c) => c.side === sa) : candidates.slice(0, half);
+    subB = sb ? candidates.filter((c) => c.side === sb) : candidates.slice(half);
+  } else {
+    const grab = (name) => personQuotes({ name, themes: [topic], kind: 'split', filters: { dedicatedOnly: false, mainstream: false } }, { openai })
+      .then((r) => r.body.candidates || []).catch(() => []);
+    [subA, subB] = await Promise.all([grab(personA), grab(personB)]);
+    const seen = new Set();
+    candidates = [...subA, ...subB].filter((c) => c.pineconeId && !seen.has(c.pineconeId) && seen.add(c.pineconeId));
+  }
+  if (!candidates.length) {
+    return { result: { topic, sideA: { person: personA, positionSummary: '', citations: [] }, sideB: { person: personB, positionSummary: '', citations: [] }, generatedAt: isoNow(), tickers: [], _meta: emptyMeta('No quotes found for either side of this debate.') }, usage: null, synthesizedEmpty: true };
+  }
+
+  const r = await synth('split', { person: personA, personB, topic }, candidates, body.model, jwtSub, auditId);
+  const parsed = parseSplit(r.finalText, candidates);
+  const conf = assessConfidence({ kind: 'split', candidates, finalText: r.finalText, synthesizedEmpty: r.synthesizedEmpty, emptyReason: r.reason });
+  const used = new Set();
+  const sideA = { ...parsed.sideA, person: parsed.sideA.person || personA };
+  const sideB = { ...parsed.sideB, person: parsed.sideB.person || personB };
+  sideA.citations = floorEmpty(sideA.citations, subA, used, 3);
+  sideB.citations = floorEmpty(sideB.citations, subB, used, 3);
+  return {
+    result: {
+      topic,
+      sideA,
+      sideB,
+      contrastSummary: parsed.contrastSummary,
+      generatedAt: isoNow(),
+      tickers: r.synthesizedEmpty ? [] : r.tickers,
+      _meta: { confidence: conf.confidence, confidenceReason: conf.confidenceReason, candidateCount: conf.candidateCount, ...(r.recovered ? { complianceRecovered: true } : {}) },
+    },
+    usage: r.usage,
+    synthesizedEmpty: r.synthesizedEmpty,
+  };
+}
+
+// ---- Narrative ----
+async function runNarrative(body, { jwtSub, openai, auditId }) {
+  const topic = String(body.topic || '').trim();
+  if (!topic) throw new TapeHttpError(400, 'bad-request', 'Bad request', 'topic is required');
+  const group = body.group ? String(body.group).trim() : null;
+  const minDate = isoDay(Date.now() - 36 * 30.44 * DAY_MS); // ~36-month spread
+
+  let candidates = [];
+  if (group && /^(bulls|bears)$/i.test(group)) {
+    const { body: tq } = await topicQuotes({ query: topic, themes: [topic], kind: 'narrative', groupBy: 'bull-bear', filters: { mainstream: true, minDate, candidatesLimit: 40 } }, { openai });
+    const side = group.toLowerCase() === 'bulls' ? 'bull' : 'bear';
+    candidates = (tq.candidates || []).filter((c) => c.side === side);
+  } else if (group && group.toLowerCase() !== 'all') {
+    const { body: pq } = await personQuotes({ name: group, themes: [topic], kind: 'narrative', filters: { dedicatedOnly: false, mainstream: false } }, { openai }).catch(() => ({ body: { candidates: [] } }));
+    candidates = pq.candidates || [];
+  } else {
+    const { body: tq } = await topicQuotes({ query: topic, themes: [topic], kind: 'narrative', filters: { mainstream: true, minDate, candidatesLimit: 40 } }, { openai });
+    candidates = tq.candidates || [];
+  }
+  if (!candidates.length) {
+    return { result: { topic, group: group || undefined, thesis: '', buckets: [], inflections: [], generatedAt: isoNow(), tickers: [], _meta: emptyMeta('Not enough coverage to trace a narrative over time.') }, usage: null, synthesizedEmpty: true };
+  }
+
+  const r = await synth('narrative', { topic, group }, candidates, body.model, jwtSub, auditId);
+  const parsed = parseNarrative(r.finalText, candidates);
+  const conf = assessConfidence({ kind: 'narrative', candidates, finalText: r.finalText, synthesizedEmpty: r.synthesizedEmpty, emptyReason: r.reason });
+  const usedN = new Set();
+  const buckets = parsed.buckets.map((b) => {
+    const s = new Date(b.start).getTime();
+    const e = new Date(b.end).getTime();
+    const inWin = candidates.filter((c) => {
+      const t = c.publishedDate ? new Date(c.publishedDate).getTime() : NaN;
+      return Number.isFinite(t) && Number.isFinite(s) && Number.isFinite(e) && t >= s && t <= e;
+    });
+    return { ...b, citations: floorEmpty(b.citations, inWin.length ? inWin : candidates, usedN, 2) };
+  });
+  return {
+    result: {
+      topic,
+      group: group || undefined,
+      thesis: parsed.thesis,
+      buckets,
+      inflections: parsed.inflections,
+      forwardCall: parsed.forwardCall,
+      generatedAt: isoNow(),
+      tickers: r.synthesizedEmpty ? [] : r.tickers,
+      _meta: { confidence: conf.confidence, confidenceReason: conf.confidenceReason, candidateCount: conf.candidateCount, ...(r.recovered ? { complianceRecovered: true } : {}) },
+    },
+    usage: r.usage,
+    synthesizedEmpty: r.synthesizedEmpty || parsed.buckets.length === 0,
+  };
+}
+
+// ---- Read-in ----
+async function runReadin(body, { jwtSub, openai, auditId }) {
+  const ticker = String(body.ticker || '').trim();
+  if (!ticker) throw new TapeHttpError(400, 'bad-request', 'Bad request', 'ticker is required');
+  const resolved = await resolveTicker(ticker);
+
+  const { body: tq } = await topicQuotes({ query: ticker, themes: [ticker], kind: 'readin', filters: { mainstream: false, candidatesLimit: 20 } }, { openai });
+  const candidates = tq.candidates || [];
+  if (!candidates.length) {
+    return { result: { ticker, name: resolved.name || ticker, sectorTag: '', yahoo: ticker, whatTheyDo: '', whatTheyDoCitations: [], pulse: { bullLine: '', bearLine: '', priceAction: '', marqueeCitation: null }, smartMoney: { bulls: [], bears: [] }, catalysts: [], risks: [], peers: [], generatedAt: isoNow(), tickers: [], _meta: emptyMeta(`${ticker} has no meaningful mentions in the corpus.`) }, usage: null, synthesizedEmpty: true };
+  }
+
+  // Read-in is citation-critical (inline WHAT_THEY_DO pills + SMART_MONEY quotes);
+  // gpt-4o-mini under-cites the primer, so this one kind defaults to Haiku, which
+  // cites reliably. Other kinds stay on cheap gpt-4o-mini. Explicit body.model wins.
+  const r = await synth('readin', { ticker }, candidates, body.model || 'fast', jwtSub, auditId);
+  const parsed = parseReadin(r.finalText, candidates);
+  const peers = r.synthesizedEmpty ? [] : r.tickers;
+  // Citation floor (insurance — readin is on Haiku and usually cites well).
+  const usedR = new Set();
+  const whatTheyDoCitations = floorEmpty(parsed.whatTheyDoCitations, candidates, usedR, 3);
+  const bulls = floorEmpty(parsed.smartMoney.bulls, candidates, usedR, 2);
+  const bears = floorEmpty(parsed.smartMoney.bears, candidates, usedR, 2);
+  const pulse = { ...parsed.pulse, marqueeCitation: parsed.pulse.marqueeCitation || whatTheyDoCitations[0] || candidates[0] || null };
+
+  // Confidence scored on the ASSEMBLED result (post-floor): a Read-in that
+  // renders the full structure — primer + bull & bear pulse lines + both
+  // smart-money sides populated + risks — is `strong`, even if the synth's raw
+  // clip tokens were malformed (the floor still attaches real, playable quotes).
+  // The synth-authored prose (pulse lines, risks) is the differentiator since
+  // the floor only backfills citations, not those.
+  const hasWtd = !!(parsed.whatTheyDo && parsed.whatTheyDo.trim());
+  const hasBullLine = !!(parsed.pulse.bullLine && parsed.pulse.bullLine.trim());
+  const hasBearLine = !!(parsed.pulse.bearLine && parsed.pulse.bearLine.trim());
+  const hasRisks = parsed.risks.length > 0;
+  let confidence;
+  let confidenceReason = null;
+  if (r.synthesizedEmpty || !hasWtd) {
+    confidence = 'empty';
+    confidenceReason = r.reason || `${ticker} has no meaningful mentions in the corpus.`;
+  } else if (hasBullLine && hasBearLine && bulls.length >= 1 && bears.length >= 1 && hasRisks) {
+    confidence = 'strong';
+  } else if (hasBullLine || hasBearLine || hasRisks || bulls.length || bears.length) {
+    const missing = [!hasBullLine && 'bull', !hasBearLine && 'bear', !hasRisks && 'risks'].filter(Boolean).join('/');
+    confidence = 'partial';
+    confidenceReason = missing ? `Incomplete: ${missing} not synthesized.` : 'Some sections thin.';
+  } else {
+    confidence = 'thin';
+    confidenceReason = 'Only a primer; no bull/bear structure available.';
+  }
+  return {
+    result: {
+      ticker,
+      name: resolved.name || ticker,
+      sectorTag: '', // not in the current readin marker contract; left blank
+      yahoo: ticker,
+      whatTheyDo: parsed.whatTheyDo, // keeps {{clip:id}} tokens for inline pills
+      whatTheyDoCitations,
+      pulse,
+      smartMoney: { bulls, bears },
+      catalysts: [],
+      risks: parsed.risks,
+      peers,
+      generatedAt: isoNow(),
+      tickers: peers,
+      _meta: { confidence, confidenceReason, candidateCount: candidates.length, ...(r.recovered ? { complianceRecovered: true } : {}) },
+    },
+    usage: r.usage,
+    synthesizedEmpty: r.synthesizedEmpty || !parsed.whatTheyDo,
+  };
+}
+
+module.exports = { runDossier, runBrief, runSplit, runNarrative, runReadin, DEFAULT_DOSSIER_THEMES };

--- a/services/tape/kindOrchestrator.js
+++ b/services/tape/kindOrchestrator.js
@@ -478,9 +478,9 @@ async function runReadin(body, { jwtSub, openai, auditId }) {
   // worsened bear_slot_not_bearish. Recall on sparse tickers needs a bear-protected
   // approach, not bull-pool seeding.
   const [bullRes, bearRes] = await Promise.all([
-    topicQuotes({ query: ticker, themes: [ticker], kind: 'readin', filters: { mainstream: READIN_MAINSTREAM, candidatesLimit: 18 } }, { openai }),
+    topicQuotes({ query: ticker, themes: [ticker], kind: 'readin', strictTicker: true, filters: { mainstream: READIN_MAINSTREAM, candidatesLimit: 18 } }, { openai }),
     BEAR_SEED_ENABLED
-      ? topicQuotes({ query: ticker, themes: bearThemes(bearName), kind: 'readin', expandThemes: false, filters: { mainstream: READIN_MAINSTREAM, candidatesLimit: 12 } }, { openai }).catch(() => ({ body: { candidates: [] } }))
+      ? topicQuotes({ query: ticker, themes: bearThemes(bearName), kind: 'readin', expandThemes: false, strictTicker: true, filters: { mainstream: READIN_MAINSTREAM, candidatesLimit: 12 } }, { openai }).catch(() => ({ body: { candidates: [] } }))
       : Promise.resolve({ body: { candidates: [] } }),
   ]);
   const bullCands = bullRes.body.candidates || [];

--- a/services/tape/mainstreamFeeds.js
+++ b/services/tape/mainstreamFeeds.js
@@ -1,0 +1,54 @@
+/**
+ * Resolve the allowlisted ("mainstream") shows to their feedIds, so retrieval
+ * can be CONSTRAINED to them at the Pinecone level.
+ *
+ * Why: for crowded topics (bitcoin, AI), the densest-talking shows are often the
+ * crypto/niche ones — which are on the DENY list. They dominate vector relevance
+ * and crowd mainstream shows out of the retrieved top-N *before* the post-filter
+ * runs, so a `mainstream:true` query can come back near-empty even though the
+ * mainstream coverage is plentiful (just lower-ranked). Passing the allowlist
+ * feedIds into searchQuotes filters at the source, so the retrieval budget is
+ * spent only on shows that survive.
+ *
+ * Result is cached process-wide (1h) — the feed roster changes slowly.
+ */
+
+const JamieVectorMetadata = require('../../models/JamieVectorMetadata');
+const taste = require('./tapeTaste');
+const { printLog } = require('../../constants');
+
+const TTL_MS = parseInt(process.env.TAPE_MAINSTREAM_FEEDS_TTL_MS || '3600000', 10);
+let cache = null;
+let cachedAt = 0;
+let lastRun = { totalFeeds: 0, matched: 0, sampleTitles: [], error: null }; // debug
+
+function getResolverStats() { return lastRun; }
+
+/**
+ * @returns {Promise<string[]>} feedIds of allowlisted (and not denied) shows.
+ * Empty array on failure → callers should treat empty as "don't constrain".
+ */
+async function getMainstreamFeedIds() {
+  if (cache && Date.now() - cachedAt < TTL_MS) return cache;
+  try {
+    // Show name lives in metadataRaw.creator (the same field isMainstream matches
+    // in the post-filter) — NOT feedTitle, which is null on these docs.
+    const feeds = await JamieVectorMetadata.aggregate([
+      { $match: { type: 'episode', 'metadataRaw.creator': { $exists: true, $ne: null } } },
+      { $group: { _id: '$feedId', title: { $first: '$metadataRaw.creator' } } },
+    ]);
+    const matched = feeds.filter((f) => f._id != null && taste.isMainstream(f.title));
+    const ids = matched.map((f) => String(f._id));
+    cache = [...new Set(ids)];
+    cachedAt = Date.now();
+    lastRun = { totalFeeds: feeds.length, matched: matched.length, sampleTitles: feeds.slice(0, 6).map((f) => f.title), error: null };
+    printLog(`[mainstreamFeeds] resolved ${cache.length} allowlisted feedIds from ${feeds.length} feeds`);
+    return cache;
+  } catch (err) {
+    lastRun = { totalFeeds: 0, matched: 0, sampleTitles: [], error: err.message };
+    printLog(`[mainstreamFeeds] resolve failed (${err.message}); leaving retrieval unconstrained`);
+    return cache || [];
+  }
+}
+
+module.exports = { getMainstreamFeedIds, getResolverStats };

--- a/services/tape/markerParse.js
+++ b/services/tape/markerParse.js
@@ -1,0 +1,182 @@
+/**
+ * Server-side marker parsing + citation hydration for the kind-level endpoints.
+ *
+ * Turns the raw `synthesize` marker text (## TOPIC / ## PUBLISHER / ## BUCKET /
+ * etc. with {{clip:id}} tokens) into the typed Result sub-shapes the client
+ * renders directly — so the per-kind marker parsers move OFF the client.
+ *
+ * A "citation" is the already-hydrated candidate object (pineconeId, text,
+ * episodeTitle, creator, episodeImage, audioUrl, startTime, endTime,
+ * publishedDate) — resolved by looking the clip id up in the candidate pool, so
+ * no get-hierarchy round trip is needed.
+ */
+
+const CLIP_RE = /\{\{clip:([^}]+)\}\}/g;
+
+/** Ordered list of marker blocks: { marker, payload, body }. */
+function splitBlocks(text) {
+  const headRe = /^(#{1,3})[ \t]*([A-Za-z_]+)([^\n]*)$/gm;
+  const heads = [];
+  let m;
+  while ((m = headRe.exec(text || ''))) {
+    heads.push({ idx: m.index, end: m.index + m[0].length, marker: m[2].toUpperCase(), payload: m[3].trim() });
+  }
+  return heads.map((h, i) => ({
+    marker: h.marker,
+    payload: h.payload.replace(/^[:|]\s*/, ''), // drop a leading ":" / "|"
+    rawPayload: h.payload,
+    body: (text.slice(h.end, i + 1 < heads.length ? heads[i + 1].idx : text.length)).trim(),
+  }));
+}
+
+function clipIdsIn(text) {
+  return [...String(text || '').matchAll(CLIP_RE)].map((mm) => mm[1].trim()).filter(Boolean);
+}
+
+/** clip ids → ordered, deduped citation objects present in the pool. */
+function hydrate(text, poolMap) {
+  const seen = new Set();
+  const out = [];
+  for (const id of clipIdsIn(text)) {
+    if (seen.has(id)) continue;
+    const cand = poolMap.get(id);
+    if (cand) { seen.add(id); out.push(cand); }
+  }
+  return out;
+}
+
+/** Strip clip tokens + tidy whitespace — for prose fields that don't render pills. */
+function stripClips(text) {
+  return String(text || '')
+    .replace(CLIP_RE, '')
+    .replace(/ {2,}/g, ' ')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function poolMapOf(candidates) {
+  return new Map((candidates || []).filter((c) => c && c.pineconeId).map((c) => [c.pineconeId, c]));
+}
+
+// Body text with any trailing clip-token lines removed → the prose summary.
+function summaryOf(body) { return stripClips(body); }
+
+// "- a\n- b" → ['a','b']
+function bulletLines(body) {
+  return String(body || '')
+    .split('\n')
+    .map((l) => l.replace(/^[\s\-*•\d.)]+/, '').trim())
+    .filter(Boolean);
+}
+
+// ---- per-kind shapers ----
+
+function parseDossier(text, candidates) {
+  const pool = poolMapOf(candidates);
+  const blocks = splitBlocks(text);
+  const topics = blocks
+    .filter((b) => b.marker === 'TOPIC')
+    .map((b) => ({ topic: b.payload, positionSummary: summaryOf(b.body), citations: hydrate(b.body, pool) }));
+  const appBlock = blocks.find((b) => b.marker === 'APPEARANCES');
+  const appearances = appBlock
+    ? bulletLines(appBlock.body).map((line) => {
+      const [show, episodeTitle, publishedDate] = line.split('|').map((s) => s.trim());
+      return { show: show || null, episodeTitle: episodeTitle || null, publishedDate: publishedDate || null, citationCount: 0 };
+    })
+    : [];
+  return { topics, appearances };
+}
+
+function parseBrief(text, candidates) {
+  const pool = poolMapOf(candidates);
+  const blocks = splitBlocks(text);
+  const headline = (blocks.find((b) => b.marker === 'HEADLINE')?.payload) || '';
+  const sections = blocks
+    .filter((b) => b.marker === 'PUBLISHER')
+    .map((b) => ({ publisher: b.payload, summary: summaryOf(b.body), citations: hydrate(b.body, pool) }));
+  return { headline, sections };
+}
+
+function parseSplit(text, candidates) {
+  const pool = poolMapOf(candidates);
+  const blocks = splitBlocks(text);
+  const persons = blocks.filter((b) => b.marker === 'PERSON');
+  const side = (b) => (b ? { person: b.payload, positionSummary: summaryOf(b.body), citations: hydrate(b.body, pool) } : { person: '', positionSummary: '', citations: [] });
+  const contrast = blocks.find((b) => b.marker === 'CONTRAST');
+  return { sideA: side(persons[0]), sideB: side(persons[1]), contrastSummary: contrast ? summaryOf(contrast.body) : undefined };
+}
+
+function parseNarrative(text, candidates) {
+  const pool = poolMapOf(candidates);
+  const blocks = splitBlocks(text);
+  const thesis = (blocks.find((b) => b.marker === 'THESIS')?.payload) || '';
+  const buckets = blocks.filter((b) => b.marker === 'BUCKET').map((b) => {
+    // rawPayload looks like "| <start> | <end> | <sentiment>"
+    const parts = b.rawPayload.split('|').map((s) => s.trim());
+    const p = parts[0] === '' ? parts.slice(1) : parts; // drop leading empty from the leading "|"
+    const sentiment = parseInt(p[2], 10);
+    return {
+      start: p[0] || null,
+      end: p[1] || null,
+      sentiment: Number.isFinite(sentiment) ? sentiment : 0,
+      stance: summaryOf(b.body),
+      citations: hydrate(b.body, pool),
+    };
+  });
+  const inflBlock = blocks.find((b) => b.marker === 'INFLECTION');
+  const inflections = inflBlock
+    ? bulletLines(inflBlock.body).map((line) => {
+      const i = line.indexOf(':');
+      return i > 0
+        ? { date: line.slice(0, i).trim(), description: line.slice(i + 1).trim() }
+        : { date: null, description: line };
+    })
+    : [];
+  const forwardCall = blocks.find((b) => b.marker === 'FORWARD')?.payload || undefined;
+  return { thesis, buckets, inflections, forwardCall };
+}
+
+function parseReadin(text, candidates) {
+  const pool = poolMapOf(candidates);
+  const blocks = splitBlocks(text);
+  const find = (marker, predicate) => blocks.find((b) => b.marker === marker && (!predicate || predicate(b)));
+
+  const wtd = find('WHAT_THEY_DO');
+  const pulse = find('PULSE');
+  const smBull = find('SMART_MONEY', (b) => /bull/i.test(b.rawPayload));
+  const smBear = find('SMART_MONEY', (b) => /bear/i.test(b.rawPayload));
+  const risks = find('RISKS');
+
+  let bullLine = '';
+  let bearLine = '';
+  if (pulse) {
+    const mBull = pulse.rawPayload.match(/BULL:\s*([^|]*)/i);
+    const mBear = pulse.rawPayload.match(/BEAR:\s*([^|]*)/i);
+    bullLine = mBull ? mBull[1].trim() : '';
+    bearLine = mBear ? mBear[1].trim() : '';
+  }
+  const pulseCites = pulse ? hydrate(pulse.body, pool) : [];
+
+  return {
+    // whatTheyDo KEEPS clip tokens (client renders inline pills); others strip.
+    whatTheyDo: wtd ? wtd.body : '',
+    whatTheyDoCitations: wtd ? hydrate(wtd.body, pool) : [],
+    pulse: {
+      bullLine,
+      bearLine,
+      priceAction: '',
+      marqueeCitation: pulseCites[0] || null,
+    },
+    smartMoney: {
+      bulls: smBull ? hydrate(smBull.body, pool) : [],
+      bears: smBear ? hydrate(smBear.body, pool) : [],
+    },
+    risks: risks ? bulletLines(risks.body) : [],
+  };
+}
+
+module.exports = {
+  splitBlocks, clipIdsIn, hydrate, stripClips, poolMapOf,
+  parseDossier, parseBrief, parseSplit, parseNarrative, parseReadin,
+};

--- a/services/tape/personQuotes.js
+++ b/services/tape/personQuotes.js
@@ -13,6 +13,10 @@ const { TapeHttpError } = require('./tapeErrors');
 const { candidateFromResult, validateDate } = require('./tapeShared');
 const { resolveHalfLife, rankByRecency, recencyMeta } = require('./recency');
 const { hydrateCandidateDates } = require('./dateHydration');
+const { rerankClips } = require('../../utils/clipReranker'); // shared quality reranker
+
+const RERANK_ENABLED = process.env.TAPE_RERANK !== 'false';
+const RERANK_MAX = parseInt(process.env.TAPE_RERANK_MAX || '25', 10);
 
 const DEFAULTS = {
   guestsOnly: true,
@@ -110,6 +114,21 @@ async function personQuotes(input = {}, { openai } = {}) {
     if (Number.isFinite(f.maxSpan) && c.spanSec > f.maxSpan) return false;
     return true;
   });
+
+  // Quality gate (shared with the pull path): drop ad reads / intros / shallow
+  // clips and keep substantively on-topic quotes. Self-skips when <=2 candidates.
+  if (RERANK_ENABLED && openai && candidates.length > 2) {
+    try {
+      const rel = (c) => (Number.isFinite(c.similarity) ? c.similarity : 0.5);
+      const pool = candidates.length > RERANK_MAX
+        ? [...candidates].sort((a, b) => rel(b) - rel(a)).slice(0, RERANK_MAX)
+        : candidates;
+      const rr = await rerankClips({ query: `${resolvedName} ${themes[0] || ''}`.trim(), clips: pool, openai });
+      if (rr.usage) recordHelperLlmUsage(rr.usage.model, rr.usage.input_tokens, rr.usage.output_tokens);
+      candidates = rr.clips;
+    } catch (e) { /* keep unranked on error */ }
+  }
+
   // Lazy-fill missing dates from the parent episode before recency ranking.
   const dates = await hydrateCandidateDates(candidates);
 

--- a/services/tape/personQuotes.js
+++ b/services/tape/personQuotes.js
@@ -1,0 +1,143 @@
+/**
+ * person-quotes recipe (spec §2) — "best quotes BY this person on these topics".
+ *
+ * Powers Dossier, Arc, and the person side of Split. Composes corpus + search:
+ *   resolve person -> appearances -> dedicated/mainstream filter ->
+ *   search-quotes fan-out (guids × themes) -> dedup/span-sort -> confidence tag.
+ */
+
+const { searchQuotes } = require('../searchQuotesService');
+const { findPeople, getPersonEpisodes } = require('../corpusService');
+const taste = require('./tapeTaste');
+const { TapeHttpError } = require('./tapeErrors');
+const { candidateFromResult, validateDate } = require('./tapeShared');
+
+const DEFAULTS = {
+  guestsOnly: true,
+  dedicatedOnly: true,
+  mainstream: true,
+  minSpan: 15,
+  maxSpan: 120,
+  episodesLimit: 6,
+  quotesPerEpisode: 3,
+  candidatesLimit: 25,
+};
+
+function firstPersonHeuristic(text) {
+  const head = String(text || '').slice(0, 120).toLowerCase();
+  return /\b(i|i'm|i've|my|we|we're|our)\b/.test(head);
+}
+
+/**
+ * @param {object} input
+ * @param {object} deps  { openai }
+ * @returns {Promise<{body:object, underlying:object}>}
+ */
+async function personQuotes(input = {}, { openai } = {}) {
+  const name = typeof input.name === 'string' ? input.name.trim() : '';
+  if (!name) throw new TapeHttpError(400, 'bad-request', 'Bad request', 'name is required');
+
+  const f = { ...DEFAULTS, ...(input.filters || {}) };
+  const minDate = validateDate(f.minDate, 'minDate');
+  const maxDate = validateDate(f.maxDate, 'maxDate');
+  const themes = Array.isArray(input.themes) && input.themes.length
+    ? input.themes.filter((t) => typeof t === 'string' && t.trim())
+    : [name];
+
+  // Per-call usage accumulator for cost logging.
+  const underlying = { peopleEpisodes: 0, searchQuotes: 0, helperTokens: 0 };
+  const recordHelperLlmUsage = (_model, inTok = 0, outTok = 0) => {
+    underlying.helperTokens += (inTok || 0) + (outTok || 0);
+  };
+
+  // 1. Resolve the person.
+  const people = await findPeople({ search: name, guestsOnly: f.guestsOnly });
+  const match = (people.data || [])[0];
+  if (!match) {
+    throw new TapeHttpError(404, 'person-not-found', 'Person not found',
+      `No corpus match for "${name}"`);
+  }
+  const resolvedName = match.name;
+
+  // 2. Appearances (fetch generously so filters have room).
+  const epResp = await getPersonEpisodes({
+    name: resolvedName,
+    guestsOnly: f.guestsOnly,
+    limit: Math.min(200, f.episodesLimit * 4),
+  });
+  if (epResp.error) throw new TapeHttpError(502, 'upstream-failure', 'Upstream failure', epResp.error);
+  underlying.peopleEpisodes = (epResp.data || []).length;
+
+  // 3 + 4. Dedicated + mainstream filters (default on).
+  let episodes = epResp.data || [];
+  if (f.dedicatedOnly) episodes = episodes.filter((e) => taste.isDedicated(e.title, resolvedName));
+  if (f.mainstream) episodes = episodes.filter((e) => taste.isMainstream(e.feedTitle));
+  episodes = episodes.slice(0, f.episodesLimit);
+
+  const dedicatedGuids = new Set(episodes.filter((e) => taste.isDedicated(e.title, resolvedName)).map((e) => e.guid));
+
+  // 5. Fan out search-quotes across guids × themes.
+  const tasks = [];
+  for (const ep of episodes) {
+    for (const theme of themes) {
+      tasks.push(
+        searchQuotes(
+          { query: theme, guids: [ep.guid], minDate, maxDate, limit: f.quotesPerEpisode },
+          { openai, recordHelperLlmUsage },
+        ).then((r) => ({ ep, results: r.results || [] })),
+      );
+    }
+  }
+  const settled = await Promise.all(tasks);
+  underlying.searchQuotes = tasks.length;
+
+  // 6. Dedup by pineconeId, compute span, filter, sort.
+  const byId = new Map();
+  for (const { ep, results } of settled) {
+    for (const r of results) {
+      const cand = candidateFromResult(r);
+      if (!cand || !cand.pineconeId) continue;
+      if (byId.has(cand.pineconeId)) continue;
+      cand._ep = ep;
+      byId.set(cand.pineconeId, cand);
+    }
+  }
+  let candidates = [...byId.values()].filter((c) => {
+    if (c.spanSec == null) return true;
+    if (Number.isFinite(f.minSpan) && c.spanSec < f.minSpan) return false;
+    if (Number.isFinite(f.maxSpan) && c.spanSec > f.maxSpan) return false;
+    return true;
+  });
+  candidates.sort((a, b) => (b.spanSec || 0) - (a.spanSec || 0));
+  candidates = candidates.slice(0, f.candidatesLimit);
+
+  // 7. Confidence tagging.
+  const maxSpan = candidates.reduce((m, c) => Math.max(m, c.spanSec || 0), 0) || 1;
+  candidates = candidates.map((c) => {
+    const dedicated = dedicatedGuids.has(c._ep?.guid);
+    const mainstream = taste.isMainstream(c.creator);
+    const spanRank = (c.spanSec || 0) / maxSpan;
+    const firstPerson = firstPersonHeuristic(c.text);
+    const { score, tier } = taste.scoreConfidence({ dedicated, mainstream, spanRank, firstPerson });
+    const { _ep, ...clean } = c;
+    return {
+      ...clean,
+      confidenceTier: tier,
+      _signals: { dedicated, mainstream, spanRank: parseFloat(spanRank.toFixed(2)), firstPerson, score },
+    };
+  });
+
+  const appearances = episodes.map((e) => ({
+    guid: e.guid,
+    title: e.title,
+    feedTitle: e.feedTitle,
+    publishedDate: e.publishedDate,
+    role: e.role,
+    imageUrl: e.imageUrl,
+  }));
+
+  const body = { person: resolvedName, appearances, candidates, _meta: { underlying } };
+  return { body, underlying };
+}
+
+module.exports = { personQuotes, DEFAULTS };

--- a/services/tape/personQuotes.js
+++ b/services/tape/personQuotes.js
@@ -11,6 +11,8 @@ const { findPeople, getPersonEpisodes } = require('../corpusService');
 const taste = require('./tapeTaste');
 const { TapeHttpError } = require('./tapeErrors');
 const { candidateFromResult, validateDate } = require('./tapeShared');
+const { resolveHalfLife, rankByRecency, recencyMeta } = require('./recency');
+const { hydrateCandidateDates } = require('./dateHydration');
 
 const DEFAULTS = {
   guestsOnly: true,
@@ -108,8 +110,18 @@ async function personQuotes(input = {}, { openai } = {}) {
     if (Number.isFinite(f.maxSpan) && c.spanSec > f.maxSpan) return false;
     return true;
   });
-  candidates.sort((a, b) => (b.spanSec || 0) - (a.spanSec || 0));
-  candidates = candidates.slice(0, f.candidatesLimit);
+  // Lazy-fill missing dates from the parent episode before recency ranking.
+  const dates = await hydrateCandidateDates(candidates);
+
+  // Soft recency weighting before truncation. Default half-life from the kind
+  // (dossier 18mo); Arc passes kind:'arc' / disableRecencyWeighting to keep the
+  // full multi-year spread that the time dimension depends on.
+  const recency = resolveHalfLife({
+    kind: input.kind,
+    halfLifeMonths: f.halfLifeMonths,
+    disableRecencyWeighting: f.disableRecencyWeighting,
+  });
+  candidates = rankByRecency(candidates, recency).slice(0, f.candidatesLimit);
 
   // 7. Confidence tagging.
   const maxSpan = candidates.reduce((m, c) => Math.max(m, c.spanSec || 0), 0) || 1;
@@ -136,7 +148,7 @@ async function personQuotes(input = {}, { openai } = {}) {
     imageUrl: e.imageUrl,
   }));
 
-  const body = { person: resolvedName, appearances, candidates, _meta: { underlying } };
+  const body = { person: resolvedName, appearances, candidates, _meta: { underlying, ...recencyMeta(recency), datesHydrated: dates.hydrated } };
   return { body, underlying };
 }
 

--- a/services/tape/quoteProviders/finnhub.js
+++ b/services/tape/quoteProviders/finnhub.js
@@ -11,10 +11,20 @@
  *   would need a mapping table to resolve on Finnhub. `FINNHUB_SYMBOL_MAP`
  *   (JSON env) lets you translate per slug, e.g. {"^TNX":"...","CL=F":"..."}.
  * - The candle (sparkline) endpoint requires a paid Finnhub plan; on free tier
- *   it 403s. We degrade gracefully to a single-point spark rather than failing.
+ *   it 403s. When it does, we DON'T degrade to a single point (which renders a
+ *   blank sparkline on the client) — we synthesize a >= 2-point series from the
+ *   /quote payload (prev close -> open -> current) so the shape matches Yahoo.
  */
 
 const API = 'https://finnhub.io/api/v1';
+
+// Company names don't change — cache resolved names by symbol for the process
+// lifetime so we hit /stock/profile2 at most once per symbol, not once per cold
+// quote-cache miss. Only positive hits are cached, so a transient profile2
+// failure doesn't permanently pin name === symbol.
+const nameCache = new Map();
+
+const { isUsMarketOpen } = require('../tapeFreshness');
 
 function apiKey() { return process.env.FINNHUB_API_KEY || ''; }
 function isConfigured() { return !!apiKey(); }
@@ -37,24 +47,52 @@ async function getJson(url) {
   }
 }
 
-async function fetchSpark(symbol, key, fallbackPrice) {
-  // Daily candles for the last ~2 weeks → up to 10 closes. Paid-plan endpoint;
-  // degrade to a single point on any failure.
+/**
+ * Build a >= 2-point spark from the /quote payload alone (no extra request).
+ * Finnhub's free-tier /quote returns pc (previous close), o (today's open) and
+ * c (current). That's a chronologically ordered mini-series that reflects the
+ * day's direction — enough for the sparkline to render and stay consistent with
+ * dayChangePct. Guarantees length >= 2 whenever a price exists.
+ */
+function syntheticSpark(quote, price) {
+  const raw = [quote && quote.pc, quote && quote.o, price].filter((v) => Number.isFinite(v));
+  // Collapse consecutive duplicates so a flat day doesn't produce repeats,
+  // but never drop below the two endpoints we need to draw a line.
+  const series = raw.filter((v, i) => i === 0 || v !== raw[i - 1]);
+  if (series.length >= 2) return series;
+  if (Number.isFinite(price)) {
+    if (Number.isFinite(quote && quote.pc) && quote.pc !== price) return [quote.pc, price];
+    return [price, price]; // flat 2-point line — still renders, unlike a single point
+  }
+  return [];
+}
+
+async function fetchSpark(symbol, key, quote, price) {
+  // Primary: daily candles for the last ~3 weeks → up to ~9 historical closes
+  // with the live price appended as the final element (matches Yahoo, whose
+  // last spark point is the live regularMarketPrice). Paid-plan endpoint.
   try {
     const to = Math.floor(Date.now() / 1000);
     const from = to - 21 * 86400;
     const data = await getJson(`${API}/stock/candle?symbol=${encodeURIComponent(symbol)}&resolution=D&from=${from}&to=${to}&token=${key}`);
     if (data && data.s === 'ok' && Array.isArray(data.c) && data.c.length) {
-      return data.c.filter((v) => v != null && Number.isFinite(v)).slice(-10);
+      const closes = data.c.filter((v) => v != null && Number.isFinite(v));
+      const series = Number.isFinite(price) ? [...closes.slice(-9), price] : closes.slice(-10);
+      if (series.length >= 2) return series;
     }
-  } catch (_) { /* free-tier 403 / throttle — fall through */ }
-  return Number.isFinite(fallbackPrice) ? [fallbackPrice] : [];
+  } catch (_) { /* free-tier 403 / throttle — fall through to synthetic */ }
+  // Fallback (free tier / candle unavailable): synthesize from the /quote
+  // payload so spark always has >= 2 points and the sparkline never blanks.
+  return syntheticSpark(quote, price);
 }
 
 async function fetchName(symbol, key) {
+  if (nameCache.has(symbol)) return nameCache.get(symbol);
   try {
     const p = await getJson(`${API}/stock/profile2?symbol=${encodeURIComponent(symbol)}&token=${key}`);
-    return p && p.name ? p.name : null;
+    const name = p && p.name ? p.name : null;
+    if (name) nameCache.set(symbol, name); // cache positive hits only
+    return name;
   } catch (_) { return null; }
 }
 
@@ -72,7 +110,7 @@ async function fetchQuote(slug) {
   const price = Number.isFinite(q.c) ? q.c : null;
   const dayChangePct = Number.isFinite(q.dp) ? parseFloat(q.dp.toFixed(2)) : null;
   const [spark, name] = await Promise.all([
-    fetchSpark(symbol, key, price),
+    fetchSpark(symbol, key, q, price),
     fetchName(symbol, key),
   ]);
 
@@ -83,7 +121,10 @@ async function fetchQuote(slug) {
     currency: 'USD', // /quote does not return currency; assume USD
     dayChangePct,
     spark,
-    marketState: null,
+    // Finnhub /quote has no market-state field; fill best-effort from US market
+    // hours so the type matches Yahoo's enum ('REGULAR' | 'CLOSED') instead of
+    // null. Pre/post-market aren't distinguishable here, so we map to CLOSED.
+    marketState: isUsMarketOpen() ? 'REGULAR' : 'CLOSED',
   };
 }
 

--- a/services/tape/quoteProviders/finnhub.js
+++ b/services/tape/quoteProviders/finnhub.js
@@ -1,0 +1,90 @@
+/**
+ * Finnhub quote provider — drop-in alternative / fallback to Yahoo.
+ *
+ * Activates only when FINNHUB_API_KEY is set. Emits the SAME normalized quote
+ * shape as the Yahoo provider so the rest of the Tape stack is provider-blind:
+ *   { symbol, name, price, currency, dayChangePct, spark[], marketState }
+ *
+ * Notes / caveats:
+ * - Symbol formats differ from Yahoo. Equity tickers (AAPL, APP) match across
+ *   both; indices/futures (^TNX, CL=F, DX-Y.NYB) use Yahoo-specific slugs and
+ *   would need a mapping table to resolve on Finnhub. `FINNHUB_SYMBOL_MAP`
+ *   (JSON env) lets you translate per slug, e.g. {"^TNX":"...","CL=F":"..."}.
+ * - The candle (sparkline) endpoint requires a paid Finnhub plan; on free tier
+ *   it 403s. We degrade gracefully to a single-point spark rather than failing.
+ */
+
+const API = 'https://finnhub.io/api/v1';
+
+function apiKey() { return process.env.FINNHUB_API_KEY || ''; }
+function isConfigured() { return !!apiKey(); }
+
+function symbolMap() {
+  try { return JSON.parse(process.env.FINNHUB_SYMBOL_MAP || '{}'); } catch (_) { return {}; }
+}
+
+async function getJson(url) {
+  if (typeof fetch !== 'function') throw new Error('global fetch unavailable (Node 18+ required)');
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 8000);
+  try {
+    const resp = await fetch(url, { headers: { Accept: 'application/json' }, signal: controller.signal });
+    if (resp.status === 429) { const e = new Error('finnhub rate limited'); e.code = 429; throw e; }
+    if (!resp.ok) { const e = new Error(`finnhub ${resp.status}`); e.code = resp.status; throw e; }
+    return await resp.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchSpark(symbol, key, fallbackPrice) {
+  // Daily candles for the last ~2 weeks → up to 10 closes. Paid-plan endpoint;
+  // degrade to a single point on any failure.
+  try {
+    const to = Math.floor(Date.now() / 1000);
+    const from = to - 21 * 86400;
+    const data = await getJson(`${API}/stock/candle?symbol=${encodeURIComponent(symbol)}&resolution=D&from=${from}&to=${to}&token=${key}`);
+    if (data && data.s === 'ok' && Array.isArray(data.c) && data.c.length) {
+      return data.c.filter((v) => v != null && Number.isFinite(v)).slice(-10);
+    }
+  } catch (_) { /* free-tier 403 / throttle — fall through */ }
+  return Number.isFinite(fallbackPrice) ? [fallbackPrice] : [];
+}
+
+async function fetchName(symbol, key) {
+  try {
+    const p = await getJson(`${API}/stock/profile2?symbol=${encodeURIComponent(symbol)}&token=${key}`);
+    return p && p.name ? p.name : null;
+  } catch (_) { return null; }
+}
+
+async function fetchQuote(slug) {
+  const key = apiKey();
+  if (!key) { const e = new Error('finnhub not configured'); e.code = 401; throw e; }
+  const symbol = symbolMap()[slug] || slug;
+
+  const q = await getJson(`${API}/quote?symbol=${encodeURIComponent(symbol)}&token=${key}`);
+  // Finnhub returns all-zeros for unknown symbols.
+  if (!q || (q.c === 0 && q.pc === 0 && q.h === 0 && q.l === 0)) {
+    const e = new Error('no result'); e.code = 404; throw e;
+  }
+
+  const price = Number.isFinite(q.c) ? q.c : null;
+  const dayChangePct = Number.isFinite(q.dp) ? parseFloat(q.dp.toFixed(2)) : null;
+  const [spark, name] = await Promise.all([
+    fetchSpark(symbol, key, price),
+    fetchName(symbol, key),
+  ]);
+
+  return {
+    symbol,
+    name: name || symbol,
+    price,
+    currency: 'USD', // /quote does not return currency; assume USD
+    dayChangePct,
+    spark,
+    marketState: null,
+  };
+}
+
+module.exports = { name: 'finnhub', isConfigured, fetchQuote };

--- a/services/tape/quoteProviders/index.js
+++ b/services/tape/quoteProviders/index.js
@@ -1,0 +1,57 @@
+/**
+ * Quote provider registry + fallback chain.
+ *
+ * Selection via TAPE_QUOTE_PROVIDER:
+ *   'yahoo'   (default) -> Yahoo primary; Finnhub fallback if configured
+ *   'finnhub'           -> Finnhub primary (if configured); Yahoo fallback
+ *   'auto'              -> same as 'yahoo'
+ *
+ * A provider that throws is skipped and the next is tried. Only when *every*
+ * provider reports "no result" (404) do we surface 404; otherwise the last
+ * transport error (e.g. 429) propagates so the caller can serve a stale price.
+ *
+ * Adding another provider later = drop a module exporting
+ * { name, isConfigured(), fetchQuote(slug) } and register it here.
+ */
+
+const yahoo = require('./yahoo');
+const finnhub = require('./finnhub');
+const { printLog } = require('../../../constants');
+
+function orderedProviders() {
+  const pref = (process.env.TAPE_QUOTE_PROVIDER || 'yahoo').toLowerCase();
+  const chain = [];
+  if (pref === 'finnhub') {
+    if (finnhub.isConfigured()) chain.push(finnhub);
+    chain.push(yahoo);
+  } else {
+    chain.push(yahoo);
+    if (finnhub.isConfigured()) chain.push(finnhub);
+  }
+  return chain;
+}
+
+/**
+ * Try each active provider in order. Returns { quote, source }.
+ * Throws an Error with `.code` (404 only if all providers agree there's no
+ * result; otherwise the last transport error).
+ */
+async function fetchQuoteWithFallback(slug) {
+  const chain = orderedProviders();
+  let lastErr = null;
+  let notFound = 0;
+  for (const p of chain) {
+    try {
+      const quote = await p.fetchQuote(slug);
+      return { quote, source: p.name };
+    } catch (err) {
+      if (err.code === 404) notFound += 1;
+      else printLog(`[quoteProviders] ${p.name} failed for ${slug}: ${err.message} (code=${err.code || '?'})`);
+      lastErr = err;
+    }
+  }
+  if (notFound === chain.length) { const e = new Error('no result'); e.code = 404; throw e; }
+  throw lastErr || new Error('all quote providers failed');
+}
+
+module.exports = { fetchQuoteWithFallback, orderedProviders };

--- a/services/tape/quoteProviders/yahoo.js
+++ b/services/tape/quoteProviders/yahoo.js
@@ -1,0 +1,64 @@
+/**
+ * Yahoo Finance quote provider.
+ *
+ * Implements the provider interface:
+ *   name           -> 'yahoo'
+ *   isConfigured() -> boolean (always true; no key needed)
+ *   fetchQuote(slug) -> normalized quote | throws Error with `.code`
+ *
+ * Normalized quote shape (provider-agnostic):
+ *   { symbol, name, price, currency, dayChangePct, spark[], marketState }
+ *
+ * dayChangePct is computed from the last two valid daily closes — NOT
+ * meta.chartPreviousClose, which is the close *before* the requested range.
+ */
+
+const DESKTOP_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+  '(KHTML, like Gecko) Chrome/124.0 Safari/537.36';
+
+async function fetchQuote(slug) {
+  if (typeof fetch !== 'function') throw new Error('global fetch unavailable (Node 18+ required)');
+  const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(slug)}?range=1mo&interval=1d`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 8000);
+  let json;
+  try {
+    const resp = await fetch(url, {
+      headers: { 'User-Agent': DESKTOP_UA, Accept: 'application/json' },
+      signal: controller.signal,
+    });
+    if (resp.status === 429) { const e = new Error('yahoo rate limited'); e.code = 429; throw e; }
+    if (!resp.ok) { const e = new Error(`yahoo ${resp.status}`); e.code = resp.status; throw e; }
+    json = await resp.json();
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const result = json?.chart?.result?.[0];
+  if (!result) { const e = new Error('no result'); e.code = 404; throw e; }
+  const meta = result.meta || {};
+  const closes = (result.indicators?.quote?.[0]?.close || []).filter((v) => v != null && Number.isFinite(v));
+  const price = Number.isFinite(meta.regularMarketPrice)
+    ? meta.regularMarketPrice
+    : (closes.length ? closes[closes.length - 1] : null);
+
+  let dayChangePct = null;
+  if (closes.length >= 2 && closes[closes.length - 2]) {
+    const last = closes[closes.length - 1];
+    const prev = closes[closes.length - 2];
+    dayChangePct = parseFloat((((last - prev) / prev) * 100).toFixed(2));
+  }
+
+  return {
+    symbol: meta.symbol || slug,
+    name: meta.shortName || meta.longName || meta.symbol || slug,
+    price,
+    currency: meta.currency || 'USD',
+    dayChangePct,
+    spark: closes.slice(-10),
+    marketState: meta.marketState || null,
+  };
+}
+
+module.exports = { name: 'yahoo', isConfigured: () => true, fetchQuote };

--- a/services/tape/recency.js
+++ b/services/tape/recency.js
@@ -72,18 +72,26 @@ function decayFactor(publishedDate, halfLifeMonths, now = Date.now()) {
   return Math.exp(-ageMonths / halfLifeMonths);
 }
 
+// Default base score = vector RELEVANCE (0..1), not clip length. Selection used
+// to rank by span, which discarded the relevance signal and let long, adjacent
+// clips beat short on-topic ones. Lexical-only / literal hits have null
+// similarity → treated as mid-relevance (0.5); they're inherently on-topic and a
+// literal-term boost (in topicQuotes) lifts them further. Span is the tiebreaker.
+const NO_SIM_RELEVANCE = parseFloat(process.env.TAPE_NO_SIM_RELEVANCE || '0.5');
+function defaultRelevance(c) {
+  return Number.isFinite(c.similarity) ? c.similarity : NO_SIM_RELEVANCE;
+}
+
 /**
- * Re-rank candidates by base_score × recency decay (descending) without
- * mutating or leaking internal fields. `baseScoreFn(candidate)` defaults to the
- * existing span-based key so non-recency ordering is otherwise preserved.
+ * Re-rank candidates by base_score × recency decay (descending), span as the
+ * tiebreaker. `baseScoreFn` defaults to vector relevance. Does not mutate or
+ * leak internal fields.
  */
-function rankByRecency(candidates, { halfLifeMonths, disabled }, baseScoreFn = (c) => c.spanSec || 0, now = Date.now()) {
-  if (disabled) {
-    return [...candidates].sort((a, b) => baseScoreFn(b) - baseScoreFn(a));
-  }
+function rankByRecency(candidates, { halfLifeMonths, disabled }, baseScoreFn = defaultRelevance, now = Date.now()) {
+  const span = (c) => c.spanSec || 0;
   return candidates
-    .map((c) => ({ c, w: baseScoreFn(c) * decayFactor(c.publishedDate, halfLifeMonths, now) }))
-    .sort((a, b) => b.w - a.w)
+    .map((c) => ({ c, w: baseScoreFn(c) * (disabled ? 1 : decayFactor(c.publishedDate, halfLifeMonths, now)) }))
+    .sort((a, b) => (b.w - a.w) || (span(b.c) - span(a.c)))
     .map((x) => x.c);
 }
 
@@ -97,5 +105,5 @@ function recencyMeta({ halfLifeMonths, disabled }) {
 
 module.exports = {
   HALF_LIFE_MONTHS, DEFAULT_HALF_LIFE_MONTHS,
-  resolveHalfLife, decayFactor, rankByRecency, recencyMeta,
+  resolveHalfLife, decayFactor, rankByRecency, recencyMeta, defaultRelevance,
 };

--- a/services/tape/recency.js
+++ b/services/tape/recency.js
@@ -1,0 +1,101 @@
+/**
+ * Soft recency weighting for Tape candidate retrieval.
+ *
+ * Applied as a multiplicative decay against the existing relevance/ranking
+ * score (span) during candidate ranking, before truncation to candidatesLimit:
+ *
+ *   weighted_score = base_score * exp(-age_months / half_life_months)
+ *
+ * A quote at 1 half-life keeps 50% of its score, 2 → 25%, 3 → 12.5%. Soft, not
+ * a cutoff: an old quote survives if its base score is strong enough and no
+ * newer candidate outranks it.
+ *
+ * Per-kind half-lives (the action's framing drives the strength of decay):
+ *   brief   ~1 week   — "this week"; older is the wrong window
+ *   readin  6 months  — business velocity; old quotes can be wrong about the co.
+ *   split   6 months  — current debate
+ *   dossier   18 months — positions evolve; older is biography
+ *   arc       disabled  — the time dimension IS the point; full spread preserved
+ *   narrative disabled  — drift-over-time analysis; needs the full window unweighted
+ *
+ * SCOPE: Tape recipe layer only. `searchQuotesService` / the /api/pull agent are
+ * never touched — this weights candidates *after* the shared search returns.
+ */
+
+const MS_PER_MONTH = 30.44 * 24 * 3600 * 1000;
+
+const HALF_LIFE_MONTHS = {
+  brief: 7 / 30.44, // ~1 week
+  readin: 6,
+  split: 6,
+  dossier: 18,
+  arc: null, // disabled
+  narrative: null, // disabled — Narrative analyses drift over the full window (spec §3.2)
+};
+
+const DEFAULT_HALF_LIFE_MONTHS = parseFloat(process.env.TAPE_DEFAULT_HALF_LIFE_MONTHS || '12');
+
+// Undated candidates (corpus metadata lacks publishedDate) are unknown-age, so
+// unknown-risk. Giving them a full factor of 1 lets them outrank fresh DATED
+// quotes — worse than surfacing an old quote, since we can't even see the age.
+// Treat them as ~one half-life old: below fresh dated, above stale dated.
+const UNDATED_DECAY = parseFloat(process.env.TAPE_UNDATED_DECAY_FACTOR || '0.5');
+
+/**
+ * Resolve the half-life to apply. Precedence:
+ *   disableRecencyWeighting → explicit halfLifeMonths → per-kind default → global default.
+ * @returns {{ halfLifeMonths: number|null, disabled: boolean }}
+ */
+function resolveHalfLife({ kind, halfLifeMonths, disableRecencyWeighting } = {}) {
+  if (disableRecencyWeighting === true) return { halfLifeMonths: null, disabled: true };
+  if (Number.isFinite(halfLifeMonths) && halfLifeMonths > 0) {
+    return { halfLifeMonths, disabled: false };
+  }
+  if (kind && Object.prototype.hasOwnProperty.call(HALF_LIFE_MONTHS, kind)) {
+    const hl = HALF_LIFE_MONTHS[kind];
+    return hl == null ? { halfLifeMonths: null, disabled: true } : { halfLifeMonths: hl, disabled: false };
+  }
+  return { halfLifeMonths: DEFAULT_HALF_LIFE_MONTHS, disabled: false };
+}
+
+/**
+ * Decay multiplier in (0, 1]. 1 when weighting is disabled. Undated / unparseable
+ * candidates get UNDATED_DECAY (unknown age ⇒ unknown risk; don't let them beat
+ * fresh dated quotes).
+ */
+function decayFactor(publishedDate, halfLifeMonths, now = Date.now()) {
+  if (!halfLifeMonths || halfLifeMonths <= 0) return 1; // disabled
+  if (!publishedDate) return UNDATED_DECAY;
+  const t = new Date(publishedDate).getTime();
+  if (!Number.isFinite(t)) return UNDATED_DECAY;
+  const ageMonths = Math.max(0, (now - t) / MS_PER_MONTH);
+  return Math.exp(-ageMonths / halfLifeMonths);
+}
+
+/**
+ * Re-rank candidates by base_score × recency decay (descending) without
+ * mutating or leaking internal fields. `baseScoreFn(candidate)` defaults to the
+ * existing span-based key so non-recency ordering is otherwise preserved.
+ */
+function rankByRecency(candidates, { halfLifeMonths, disabled }, baseScoreFn = (c) => c.spanSec || 0, now = Date.now()) {
+  if (disabled) {
+    return [...candidates].sort((a, b) => baseScoreFn(b) - baseScoreFn(a));
+  }
+  return candidates
+    .map((c) => ({ c, w: baseScoreFn(c) * decayFactor(c.publishedDate, halfLifeMonths, now) }))
+    .sort((a, b) => b.w - a.w)
+    .map((x) => x.c);
+}
+
+/** Build the `_meta` recency block. */
+function recencyMeta({ halfLifeMonths, disabled }) {
+  return {
+    halfLifeApplied: disabled ? null : Math.round(halfLifeMonths * 100) / 100,
+    weightingDisabled: disabled,
+  };
+}
+
+module.exports = {
+  HALF_LIFE_MONTHS, DEFAULT_HALF_LIFE_MONTHS,
+  resolveHalfLife, decayFactor, rankByRecency, recencyMeta,
+};

--- a/services/tape/semanticCache.js
+++ b/services/tape/semanticCache.js
@@ -1,0 +1,90 @@
+/**
+ * Semantic cache layer for the kind endpoints — lets "essentially the same"
+ * query reuse a cached result even when the bytes differ ("spacex IPO" vs
+ * "spacex ipo" vs "when is SpaceX going public").
+ *
+ * How: embed the query's free-text (ada-002), compare by cosine to the embeddings
+ * of recent cached queries WITHIN the same hard scope (kind + prompt version +
+ * asOfDate + model); a match ≥ threshold returns that query's cache key. No
+ * LLM-per-comparison — just one embedding + an in-memory cosine scan.
+ *
+ * Storage is tiny and in-memory: ~6 KB per vector, LRU-capped per scope, wiped on
+ * restart exactly like the result cache. `refresh:true` bypasses it upstream.
+ *
+ * Read-in is intentionally NOT semantically matched — tickers are exact symbols
+ * (serving NVDA's read-in for an AVGO query would be a real error); free-text
+ * kinds (brief / split / narrative / dossier) are where this helps.
+ */
+
+const ENABLED = process.env.TAPE_SEMANTIC_CACHE !== 'false';
+const THRESHOLD = parseFloat(process.env.TAPE_SEMANTIC_CACHE_THRESHOLD || '0.93');
+const MAX_PER_SCOPE = parseInt(process.env.TAPE_SEMANTIC_CACHE_MAX || '2000', 10);
+const EMB_MODEL = process.env.TAPE_SEMANTIC_CACHE_MODEL || 'text-embedding-ada-002';
+
+// scope string -> [{ emb: Float32Array, key, t }]
+const index = new Map();
+
+function norm(s) { return String(s || '').toLowerCase().replace(/\s+/g, ' ').trim(); }
+
+/** The free-text to match on, per kind. Empty string → skip semantic matching. */
+function semanticText(kind, body = {}) {
+  switch (kind) {
+    case 'brief': return norm(body.topic);
+    case 'split': return norm([body.personA, body.personB, body.topic].filter(Boolean).join(' | '));
+    case 'narrative': return norm([body.topic, body.group].filter(Boolean).join(' | '));
+    case 'dossier': return norm(body.person);
+    default: return ''; // readin (tickers are exact) and anything else
+  }
+}
+
+/** Hard-key fields that must match exactly for two queries to be interchangeable. */
+function scopeOf(kind, body = {}, promptVersion = '') {
+  return [kind, promptVersion, body.asOfDate || '', body.model || 'default'].join('|');
+}
+
+async function embed(text, openai) {
+  if (!text || !openai) return null;
+  try {
+    const r = await openai.embeddings.create({ model: EMB_MODEL, input: text });
+    const v = r && r.data && r.data[0] && r.data[0].embedding;
+    return Array.isArray(v) ? Float32Array.from(v) : null;
+  } catch (_) { return null; }
+}
+
+function cosine(a, b) {
+  let dot = 0; let na = 0; let nb = 0;
+  for (let i = 0; i < a.length; i += 1) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+  const d = Math.sqrt(na) * Math.sqrt(nb);
+  return d ? dot / d : 0;
+}
+
+/** Nearest cached query in `scope` ≥ threshold → { key, sim }, else null. */
+function lookup(scope, emb) {
+  if (!emb) return null;
+  const arr = index.get(scope);
+  if (!arr || !arr.length) return null;
+  let best = null; let bestSim = -1;
+  for (const e of arr) { const s = cosine(emb, e.emb); if (s > bestSim) { bestSim = s; best = e; } }
+  return (best && bestSim >= THRESHOLD) ? { key: best.key, sim: bestSim } : null;
+}
+
+/** Record a query embedding → its cache key (LRU-capped per scope). */
+function remember(scope, emb, key) {
+  if (!emb || !key) return;
+  let arr = index.get(scope);
+  if (!arr) { arr = []; index.set(scope, arr); }
+  const i = arr.findIndex((e) => e.key === key);
+  if (i >= 0) arr.splice(i, 1); // refresh position
+  arr.push({ emb, key, t: Date.now() });
+  if (arr.length > MAX_PER_SCOPE) arr.splice(0, arr.length - MAX_PER_SCOPE);
+}
+
+/** Drop a mapping whose cached value has since expired. */
+function forget(scope, key) {
+  const arr = index.get(scope);
+  if (!arr) return;
+  const i = arr.findIndex((e) => e.key === key);
+  if (i >= 0) arr.splice(i, 1);
+}
+
+module.exports = { ENABLED, THRESHOLD, semanticText, scopeOf, embed, lookup, remember, forget };

--- a/services/tape/stanceClassifier.js
+++ b/services/tape/stanceClassifier.js
@@ -1,0 +1,101 @@
+/**
+ * Stance gate — classify each clip's directional stance toward a subject
+ * (bull / bear / neutral) so retrieval-seeded pools can be FILTERED to genuinely
+ * polarized quotes before they fill a bear slot (Read-in) or a camp side (Split).
+ *
+ * Why: polarity-seeded retrieval (e.g. "{ticker} bear case overvalued") improves
+ * RECALL of the bearish neighborhood, but a topically-adjacent quote that isn't
+ * actually bearish still comes back — and lands in the bear slot, making both
+ * sides look the same (eval: bear_slot_not_bearish, both_sides_same). This is the
+ * PRECISION half: a cheap gpt-4o-mini pass that scores each clip's stance so the
+ * orchestrator can keep only stance-correct quotes per side.
+ *
+ * One structured-output call (strict json_schema — the same shape that fixed the
+ * reranker). Fail-open: on any error the caller keeps its un-gated pool.
+ */
+
+const { printLog } = require('../../constants.js');
+
+const STANCE_MODEL = process.env.TAPE_STANCE_MODEL || 'gpt-4o-mini';
+const STANCES = ['bull', 'bear', 'neutral'];
+
+/**
+ * @param {object} opts
+ * @param {string} opts.subject  what the stance is measured TOWARD (ticker/company/topic)
+ * @param {Array}  opts.clips    clip objects (need .quote or .text, + .pineconeId)
+ * @param {object} opts.openai   OpenAI client
+ * @returns {{ stances: Map<string,'bull'|'bear'|'neutral'>, usage: object }}
+ *          stances keyed by pineconeId; clips without a verdict are absent.
+ */
+async function classifyStance({ subject, clips, openai }) {
+  const empty = { stances: new Map(), usage: { model: STANCE_MODEL, input_tokens: 0, output_tokens: 0 } };
+  if (!openai || !Array.isArray(clips) || clips.length === 0) return empty;
+
+  const list = clips.map((c, i) => {
+    const text = (c.quote || c.text || '').replace(/\s+/g, ' ').slice(0, 260);
+    return `[${i}] "${text}"`;
+  }).join('\n');
+
+  const system = `You classify each podcast clip's STANCE toward "${subject}". For each clip return exactly one of: bull, bear, neutral.
+- bull  = the speaker is directionally POSITIVE on ${subject}: upside, buy, growth, undervalued, will rise, secular tailwind.
+- bear  = the speaker is directionally NEGATIVE on ${subject}: downside, sell, overvalued, bubble, will fall, headwinds, structural risk to ${subject} itself.
+- neutral = descriptive only, mixed/balanced, a sponsor/ad/intro segment, OR not actually a directional view ON ${subject} (e.g. praises a competitor, generic market commentary, merely mentions ${subject} in passing).
+Be STRICT: merely mentioning ${subject}, or stating a fact about it, is NOT a stance — that is neutral. A "bear" must argue ${subject} specifically is likely to do badly.
+Return JSON {"stances":[{"i":0,"s":"bear"}, ...]} — exactly one entry per clip, i = the clip index.`;
+
+  try {
+    const resp = await openai.chat.completions.create({
+      model: STANCE_MODEL,
+      messages: [
+        { role: 'system', content: system },
+        { role: 'user', content: `Subject: "${subject}"\n\nClips:\n${list}` },
+      ],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'clip_stances',
+          strict: true,
+          schema: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['stances'],
+            properties: {
+              stances: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  additionalProperties: false,
+                  required: ['i', 's'],
+                  properties: {
+                    i: { type: 'integer' },
+                    s: { type: 'string', enum: STANCES },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      temperature: 0.0,
+      max_tokens: 700,
+    });
+
+    const usage = resp.usage || {};
+    const parsed = JSON.parse(resp.choices[0].message.content || '{"stances":[]}');
+    const stances = new Map();
+    let bull = 0; let bear = 0; let neutral = 0;
+    for (const entry of parsed.stances || []) {
+      const clip = clips[entry.i];
+      if (!clip || !clip.pineconeId || !STANCES.includes(entry.s)) continue;
+      stances.set(clip.pineconeId, entry.s);
+      if (entry.s === 'bull') bull += 1; else if (entry.s === 'bear') bear += 1; else neutral += 1;
+    }
+    printLog(`[STANCE] "${subject}" ${clips.length} clips → bull ${bull} / bear ${bear} / neutral ${neutral}, ${usage.total_tokens || 0} tokens`);
+    return { stances, usage: { model: STANCE_MODEL, input_tokens: usage.prompt_tokens || 0, output_tokens: usage.completion_tokens || 0 } };
+  } catch (err) {
+    printLog(`[STANCE] error: ${err.message} — failing open (no gate)`);
+    return empty;
+  }
+}
+
+module.exports = { classifyStance, STANCE_MODEL };

--- a/services/tape/synthesize.js
+++ b/services/tape/synthesize.js
@@ -25,7 +25,12 @@ const { checkRateLimit, logTape } = require('./tapeEndpoint');
 const { hashBody } = require('./tapeShared');
 const { printLog } = require('../../constants');
 
-const MAX_TOKENS = parseInt(process.env.TAPE_SYN_MAX_TOKENS || '2048', 10);
+// Headroom for REASONING models (DeepSeek V4, gpt-5-nano): they spend
+// reasoning_content tokens before emitting visible text, so a low cap makes
+// them hit max_tokens mid-think and return zero prose. 8k leaves room to reason
+// AND answer; non-reasoning models (Haiku, gpt-4o-mini) stop when done and don't
+// approach it, so the only cost effect is on reasoning models (still cheap).
+const MAX_TOKENS = parseInt(process.env.TAPE_SYN_MAX_TOKENS || '8000', 10);
 const DAILY_TOKEN_CAP = parseInt(process.env.TAPE_DAILY_OUTPUT_TOKEN_CAP || '5000000', 10);
 const DAILY_USD_CAP = process.env.TAPE_DAILY_USD_CAP ? parseFloat(process.env.TAPE_DAILY_USD_CAP) : null;
 const HOURLY_LIMIT = parseInt(process.env.TAPE_SYN_HOURLY_LIMIT || '30', 10);
@@ -132,7 +137,10 @@ async function runSynthesis({ kind, input, candidates, modelConfig, onDelta, ref
     system: systemPromptFor(kind),
     messages: [{ role: 'user', content: userMsg }],
     tools: undefined,
-    toolChoice: 'none',
+    // No tools on the synthesis path. Don't send tool_choice:'none' — OpenAI
+    // rejects tool_choice without tools (400); omitting it works across all
+    // providers (no tools ⇒ nothing to call anyway).
+    toolChoice: undefined,
     temperature: 0.4,
     onTextDelta: onDelta || (() => {}),
     aborted: () => false,

--- a/services/tape/synthesize.js
+++ b/services/tape/synthesize.js
@@ -10,10 +10,11 @@
  * (resolveModelSelection) + clip-token sanitizers.
  */
 
+const fs = require('fs');
 const { resolveModelSelection } = require('../../constants/agentModels');
 const { createProvider } = require('../../utils/agent/providers');
 const { sanitizeAgentText, createStreamSanitizer } = require('../../utils/agent/sanitizeOutput');
-const { VALID_KINDS, systemPromptFor, buildUserMessage, hasRequiredMarkers, EMPTY_SENTINEL, TICKERS_MARKER, PROMPT_VERSION } = require('./tapePrompts');
+const { VALID_KINDS, systemPromptFor, buildUserMessage, validateKindCompliance, EMPTY_SENTINEL, TICKERS_MARKER, PROMPT_VERSION } = require('./tapePrompts');
 const { extractTickers } = require('./tickerExtract');
 const { buildAliases } = require('./tickerResolver');
 const { getCached, setCached, addAndGet } = require('./tapeStore');
@@ -74,21 +75,17 @@ function stripUnknownClipTokens(text, validIds) {
 }
 
 /**
- * Sanitize the raw model output and classify it against the kind's contract.
- * Returns { text, synthesizedEmpty, reason } — text is '' when empty.
+ * Sanitize the raw model output and detect a GENUINELY empty result (blank or
+ * the explicit EMPTY_SENTINEL). Kind-contract conformance is NOT judged here —
+ * that's `validateKindCompliance` in `produce`, which can retry on a violation
+ * rather than silently emptying a wrong-shaped (but non-empty) result.
+ * Returns { text, synthesizedEmpty, reason }.
  */
 function finalizeText(rawText, kind, validIds) {
   const sanitized = stripUnknownClipTokens(sanitizeAgentText(rawText) || '', validIds);
   const trimmed = sanitized.trim();
-  // Model explicitly signaled "not enough on-topic material".
   if (!trimmed || trimmed.replace(/[.\s]+$/, '').toUpperCase() === EMPTY_SENTINEL) {
     return { text: '', synthesizedEmpty: true, reason: 'candidates did not contain enough on-topic material' };
-  }
-  // Guardrail: model produced text but not in the required shape for this kind.
-  // Returning empty is preferable to letting malformed/mismatched markers reach
-  // the strict client parser (which would render misleading or blank sections).
-  if (!hasRequiredMarkers(kind, sanitized)) {
-    return { text: '', synthesizedEmpty: true, reason: `output did not contain the required ${kind} markers` };
   }
   return { text: sanitized, synthesizedEmpty: false, reason: null };
 }
@@ -116,8 +113,9 @@ function companyHintFor(input = {}) {
   return name && name.toLowerCase() !== tk.toLowerCase() ? `${tk} = ${name}` : null;
 }
 
-/** One synthesis pass. Returns { rawText, usage }. */
-async function runSynthesis({ kind, input, candidates, modelConfig, onDelta }) {
+/** One synthesis pass. Returns { rawText, usage }. `reflection` is appended to
+ *  the user message on a compliance-retry to nudge the model back on-contract. */
+async function runSynthesis({ kind, input, candidates, modelConfig, onDelta, reflection }) {
   const companyHint = companyHintFor(input);
   const provider = createProvider(modelConfig.provider);
   const ready = await provider.validate();
@@ -125,11 +123,13 @@ async function runSynthesis({ kind, input, candidates, modelConfig, onDelta }) {
     throw new TapeHttpError(502, 'upstream-failure', 'Synthesis provider unavailable',
       `Provider ${modelConfig.provider} for model ${modelConfig.label} is not configured.`);
   }
+  let userMsg = buildUserMessage({ kind, input, candidates, companyHint });
+  if (reflection) userMsg += `\n\n${reflection}`;
   const result = await provider.createResponse({
     model: modelConfig.id,
     maxTokens: modelConfig.maxSynthesisTokens || MAX_TOKENS,
     system: systemPromptFor(kind),
-    messages: [{ role: 'user', content: buildUserMessage({ kind, input, candidates, companyHint }) }],
+    messages: [{ role: 'user', content: userMsg }],
     tools: undefined,
     toolChoice: 'none',
     temperature: 0.4,
@@ -158,6 +158,83 @@ async function recordCost(usage, modelConfig, dayKey, ttlDay) {
 function costUsd(usage, modelConfig) {
   return parseFloat((((usage.input_tokens || 0) * (modelConfig.inputPer1M || 0)
     + (usage.output_tokens || 0) * (modelConfig.outputPer1M || 0)) / 1e6).toFixed(4));
+}
+
+/**
+ * Log a kind-compliance failure (input + offending output) for the prompt-
+ * hardening / eval dataset. Always emits a structured stdout line; also appends
+ * to TAPE_COMPLIANCE_LOG_FILE (JSONL) when set, for local fixture collection.
+ */
+function logCompliance(ctx, info) {
+  const entry = {
+    event: 'kind-compliance-fail',
+    ts: new Date().toISOString(),
+    endpoint: 'synthesize',
+    jwt_sub: ctx.sub || null,
+    model: ctx.model || null,
+    kind: info.kind,
+    attempt: info.attempt,
+    reason: info.reason,
+    missing: !!info.missing,
+    leaked: info.leaked || [],
+    input: info.input || null,
+    candidatePineconeIds: (info.candidates || []).map((c) => c.pineconeId).filter(Boolean),
+    offendingText: info.offendingText || '',
+  };
+  try { printLog(`[tape:kind-compliance] ${JSON.stringify(entry)}`); } catch (_) { /* never throw */ }
+  console.warn(`[tape:kind-compliance] kind=${info.kind} attempt=${info.attempt} reason="${info.reason}"`);
+  const file = process.env.TAPE_COMPLIANCE_LOG_FILE;
+  if (file) { try { fs.appendFile(file, `${JSON.stringify(entry)}\n`, () => {}); } catch (_) { /* best-effort */ } }
+}
+
+/**
+ * Generate a synthesis, validate it against the kind contract, and auto-retry
+ * once with a reflection nudge on failure. Returns the validated result, or
+ * throws TapeHttpError(502, 'kind-compliance') if the retry also violates the
+ * contract — we never serve malformed text. A legitimately empty result
+ * (sentinel / sparse candidates) is returned as-is (valid render state).
+ *
+ * @returns {Promise<{finalText:string, tickers:string[], synthesizedEmpty:boolean,
+ *                    reason?:string, usage:object, attempts:number, recovered?:boolean}>}
+ */
+async function produce({ kind, input, candidates, modelConfig, validIds, onDelta, ctx, runner = runSynthesis }) {
+  const a1 = await runner({ kind, input, candidates, modelConfig, onDelta });
+  const e1 = extractTickers(a1.rawText);
+  const f1 = finalizeText(e1.cleanedText, kind, validIds);
+  if (f1.synthesizedEmpty) {
+    return { finalText: '', tickers: [], synthesizedEmpty: true, reason: f1.reason, usage: a1.usage, attempts: 1 };
+  }
+  const v1 = validateKindCompliance(kind, f1.text);
+  if (v1.ok) {
+    return { finalText: f1.text, tickers: e1.tickers, synthesizedEmpty: false, usage: a1.usage, attempts: 1 };
+  }
+
+  logCompliance(ctx, { attempt: 1, kind, input, candidates, reason: v1.reason, missing: v1.missing, leaked: v1.leaked, offendingText: f1.text });
+
+  // One auto-retry with an explicit reflection (no streaming on the retry).
+  const reflection = `Your previous output used the wrong markers (${v1.reason}). `
+    + `Produce ONLY the marker contract for kind: ${kind}. Do NOT use any markers from other kinds.`;
+  const a2 = await runner({ kind, input, candidates, modelConfig, reflection });
+  const usage = {
+    input_tokens: (a1.usage.input_tokens || 0) + (a2.usage.input_tokens || 0),
+    output_tokens: (a1.usage.output_tokens || 0) + (a2.usage.output_tokens || 0),
+  };
+  const e2 = extractTickers(a2.rawText);
+  const f2 = finalizeText(e2.cleanedText, kind, validIds);
+  if (!f2.synthesizedEmpty) {
+    const v2 = validateKindCompliance(kind, f2.text);
+    if (v2.ok) {
+      return { finalText: f2.text, tickers: e2.tickers, synthesizedEmpty: false, usage, attempts: 2, recovered: true };
+    }
+    logCompliance(ctx, { attempt: 2, kind, input, candidates, reason: v2.reason, missing: v2.missing, leaked: v2.leaked, offendingText: f2.text });
+    const e = new TapeHttpError(502, 'kind-compliance', 'Synthesizer output violated kind contract', `${kind}: ${v2.reason}`);
+    e.usage = usage;
+    throw e;
+  }
+  logCompliance(ctx, { attempt: 2, kind, input, candidates, reason: 'retry produced empty/sentinel after a wrong-kind attempt', missing: true, leaked: [] });
+  const e = new TapeHttpError(502, 'kind-compliance', 'Synthesizer output violated kind contract', `${kind}: retry failed to produce conformant output`);
+  e.usage = usage;
+  throw e;
 }
 
 // --- SSE helpers (same event shape as /api/pull) ---
@@ -269,62 +346,58 @@ function createSynthesizeHandler() {
         printLog(`[tape:synthesize] forced re-synthesize by ${sub} (#${perUser} today, kind=${kind})`);
       }
 
-      // --- run synthesis ---
+      // --- run synthesis (generate → validate kind contract → retry once → 502) ---
       const fetchedAt = new Date().toISOString();
+      const complianceCtx = { sub: req.tape?.sub, model: modelConfig.id };
 
+      // Stream attempt-1 tokens live (gating the `## TICKERS` block); on the
+      // rare compliance-retry the corrected text arrives via the final `text`
+      // event, which the client treats as authoritative.
+      let onDelta;
       if (stream) {
         sseInit(res);
         sseSend(res, 'status', { message: 'Synthesizing…', kind });
         const sanitizer = createStreamSanitizer();
-        // Gate the trailing `## TICKERS` block so it never leaks into text_delta.
         const cut = createMarkerCut(TICKERS_HEADER_RE);
-        const onDelta = (d) => {
+        onDelta = (d) => {
           const pre = cut.feed(d);
           if (pre) { const safe = sanitizer.feed(pre); if (safe) sseSend(res, 'text_delta', { text: safe }); }
         };
-
-        const { rawText, usage } = await runSynthesis({ kind, input, candidates, modelConfig, onDelta });
-        const preTail = cut.flush();
-        const tail = (preTail ? (sanitizer.feed(preTail) || '') : '') + (sanitizer.flush() || '');
-        if (tail) sseSend(res, 'text_delta', { text: tail });
-
-        const { cleanedText, tickers } = extractTickers(rawText);
-        const { text: finalText, synthesizedEmpty, reason } = finalizeText(cleanedText, kind, validIds);
-
-        const outBody = {
-          kind, text: finalText, tickers: synthesizedEmpty ? [] : tickers,
-          tokens: { input: usage.input_tokens, output: usage.output_tokens },
-          model: modelConfig.id, elapsedMs: Date.now() - startedAt,
-          _meta: { fetchedAt, forced: refresh, ...(synthesizedEmpty ? { synthesizedEmpty: true, reason } : {}) },
-        };
-        outBody._meta = { ...outBody._meta, ...buildFreshnessMeta({ tier: TIER.QUALITATIVE, cached: false, cachedAt: fetchedAt, fetchedAt, ttlSec: ttl }) };
-        // Don't cache empties — temperature>0 means a retry may yet produce content.
-        if (!noCache && !synthesizedEmpty) await setCached(cacheKey, outBody, ttl);
-        await recordCost(usage, modelConfig, dayKey, ttlDay);
-
-        // The final `text` event is authoritative and replaces accumulated
-        // deltas — so an empty result correctly clears any provisional stream.
-        sseSend(res, 'text', { text: finalText });
-        sseSend(res, 'done', { kind, model: modelConfig.id, tokens: outBody.tokens, tickers: outBody.tickers, cached: false, forced: refresh, synthesizedEmpty });
-        logTape({ endpoint: 'synthesize', kind, jwt_sub: req.tape?.sub, cache: 'miss', forced: refresh, synthesizedEmpty, tickers: outBody.tickers.length, tokens: outBody.tokens, model: modelConfig.id, cost_usd_est: costUsd(usage, modelConfig), status: 200, elapsed_ms: Date.now() - startedAt });
-        return res.end();
       }
 
-      // non-stream
-      const { rawText, usage } = await runSynthesis({ kind, input, candidates, modelConfig });
-      const { cleanedText, tickers } = extractTickers(rawText);
-      const { text: finalText, synthesizedEmpty, reason } = finalizeText(cleanedText, kind, validIds);
+      let r;
+      try {
+        r = await produce({ kind, input, candidates, modelConfig, validIds, onDelta, ctx: complianceCtx });
+      } catch (e) {
+        // Record tokens already spent across the failed attempts before bubbling.
+        if (e && e.usage) await recordCost(e.usage, modelConfig, dayKey, ttlDay);
+        throw e;
+      }
+
       const outBody = {
-        kind, text: finalText, tickers: synthesizedEmpty ? [] : tickers,
-        tokens: { input: usage.input_tokens, output: usage.output_tokens },
+        kind, text: r.finalText, tickers: r.synthesizedEmpty ? [] : r.tickers,
+        tokens: { input: r.usage.input_tokens, output: r.usage.output_tokens },
         model: modelConfig.id, elapsedMs: Date.now() - startedAt,
-        _meta: { fetchedAt, forced: refresh, ...(synthesizedEmpty ? { synthesizedEmpty: true, reason } : {}) },
+        _meta: {
+          fetchedAt, forced: refresh,
+          ...(r.synthesizedEmpty ? { synthesizedEmpty: true, reason: r.reason } : {}),
+          ...(r.recovered ? { complianceRecovered: true } : {}),
+        },
       };
       outBody._meta = { ...outBody._meta, ...buildFreshnessMeta({ tier: TIER.QUALITATIVE, cached: false, cachedAt: fetchedAt, fetchedAt, ttlSec: ttl }) };
-      if (!noCache && !synthesizedEmpty) await setCached(cacheKey, outBody, ttl);
-      await recordCost(usage, modelConfig, dayKey, ttlDay);
+      // Don't cache empties — temperature>0 means a retry may yet produce content.
+      if (!noCache && !r.synthesizedEmpty) await setCached(cacheKey, outBody, ttl);
+      await recordCost(r.usage, modelConfig, dayKey, ttlDay);
 
-      logTape({ endpoint: 'synthesize', kind, jwt_sub: req.tape?.sub, cache: 'miss', forced: refresh, synthesizedEmpty, tickers: outBody.tickers.length, tokens: outBody.tokens, model: modelConfig.id, cost_usd_est: costUsd(usage, modelConfig), status: 200, elapsed_ms: Date.now() - startedAt });
+      const logBase = { endpoint: 'synthesize', kind, jwt_sub: req.tape?.sub, cache: 'miss', forced: refresh, synthesizedEmpty: r.synthesizedEmpty, complianceRecovered: !!r.recovered, attempts: r.attempts, tickers: outBody.tickers.length, tokens: outBody.tokens, model: modelConfig.id, cost_usd_est: costUsd(r.usage, modelConfig), status: 200, elapsed_ms: Date.now() - startedAt };
+
+      if (stream) {
+        sseSend(res, 'text', { text: r.finalText });
+        sseSend(res, 'done', { kind, model: modelConfig.id, tokens: outBody.tokens, tickers: outBody.tickers, cached: false, forced: refresh, synthesizedEmpty: r.synthesizedEmpty });
+        logTape(logBase);
+        return res.end();
+      }
+      logTape(logBase);
       return res.status(200).json(outBody);
     } catch (err) {
       if (res.headersSent) {
@@ -343,4 +416,4 @@ function createSynthesizeHandler() {
   };
 }
 
-module.exports = { createSynthesizeHandler, runSynthesis, stripUnknownClipTokens };
+module.exports = { createSynthesizeHandler, runSynthesis, produce, stripUnknownClipTokens };

--- a/services/tape/synthesize.js
+++ b/services/tape/synthesize.js
@@ -13,7 +13,9 @@
 const { resolveModelSelection } = require('../../constants/agentModels');
 const { createProvider } = require('../../utils/agent/providers');
 const { sanitizeAgentText, createStreamSanitizer } = require('../../utils/agent/sanitizeOutput');
-const { VALID_KINDS, systemPromptFor, buildUserMessage, hasRequiredMarkers, EMPTY_SENTINEL, PROMPT_VERSION } = require('./tapePrompts');
+const { VALID_KINDS, systemPromptFor, buildUserMessage, hasRequiredMarkers, EMPTY_SENTINEL, TICKERS_MARKER, PROMPT_VERSION } = require('./tapePrompts');
+const { extractTickers } = require('./tickerExtract');
+const { buildAliases } = require('./tickerResolver');
 const { getCached, setCached, addAndGet } = require('./tapeStore');
 const { TIER, synTtlSec, buildFreshnessMeta } = require('./tapeFreshness');
 const { tapeError, tapeRateLimited, TapeHttpError } = require('./tapeErrors');
@@ -28,6 +30,42 @@ const HOURLY_LIMIT = parseInt(process.env.TAPE_SYN_HOURLY_LIMIT || '30', 10);
 const NOCACHE_ENABLED = process.env.TAPE_NOCACHE_ENABLED === 'true';
 
 const CLIP_RE = /\{\{clip:([^}]+)\}\}/g;
+const TICKERS_HEADER_RE = new RegExp(`#{1,3}\\s*${TICKERS_MARKER}\\b`, 'i');
+
+/**
+ * Streaming gate: suppress everything from the `## TICKERS` header onward so the
+ * parsed-off block never reaches the client as text_delta. Holds back a short
+ * tail each feed so a marker split across deltas is still caught.
+ */
+function createMarkerCut(headerRe) {
+  let full = '';
+  let emitted = 0;
+  let cut = false;
+  const HOLD = 16;
+  return {
+    feed(delta) {
+      if (cut) return '';
+      full += delta || '';
+      const m = full.match(headerRe);
+      if (m && m.index != null) {
+        const out = full.slice(emitted, Math.max(emitted, m.index));
+        emitted = full.length;
+        cut = true;
+        return out;
+      }
+      const safeEnd = Math.max(emitted, full.length - HOLD);
+      const out = full.slice(emitted, safeEnd);
+      emitted = safeEnd;
+      return out;
+    },
+    flush() {
+      if (cut) return '';
+      const out = full.slice(emitted);
+      emitted = full.length;
+      return out;
+    },
+  };
+}
 
 /** Strip {{clip:id}} tokens whose id was not in the provided candidate set. */
 function stripUnknownClipTokens(text, validIds) {
@@ -62,8 +100,25 @@ function secondsUntilUtcMidnight() {
   return Math.max(60, Math.ceil((next.getTime() - now.getTime()) / 1000));
 }
 
+/**
+ * Resolve a ticker the user typed (input.ticker for readin, input.topic for
+ * split/brief) to a company name — pure/curated lookup, no network — so the
+ * synthesis model picks sector-correct peers (e.g. APP → AppLovin → adtech).
+ * Returns "APP = AppLovin" or null.
+ */
+function companyHintFor(input = {}) {
+  const cand = [input.ticker, input.topic].find(
+    (v) => typeof v === 'string' && /^[A-Z]{1,5}$/.test(v.trim()),
+  );
+  if (!cand) return null;
+  const tk = cand.trim();
+  const { name } = buildAliases(tk);
+  return name && name.toLowerCase() !== tk.toLowerCase() ? `${tk} = ${name}` : null;
+}
+
 /** One synthesis pass. Returns { rawText, usage }. */
 async function runSynthesis({ kind, input, candidates, modelConfig, onDelta }) {
+  const companyHint = companyHintFor(input);
   const provider = createProvider(modelConfig.provider);
   const ready = await provider.validate();
   if (!ready) {
@@ -74,7 +129,7 @@ async function runSynthesis({ kind, input, candidates, modelConfig, onDelta }) {
     model: modelConfig.id,
     maxTokens: modelConfig.maxSynthesisTokens || MAX_TOKENS,
     system: systemPromptFor(kind),
-    messages: [{ role: 'user', content: buildUserMessage({ kind, input, candidates }) }],
+    messages: [{ role: 'user', content: buildUserMessage({ kind, input, candidates, companyHint }) }],
     tools: undefined,
     toolChoice: 'none',
     temperature: 0.4,
@@ -164,6 +219,7 @@ function createSynthesizeHandler() {
         if (prior) {
           const cachedBody = {
             ...prior.value,
+            tickers: Array.isArray(prior.value.tickers) ? prior.value.tickers : [],
             _meta: {
               ...(prior.value._meta || {}),
               ...buildFreshnessMeta({
@@ -177,7 +233,7 @@ function createSynthesizeHandler() {
             sseInit(res);
             sseSend(res, 'status', { message: 'Cached', kind });
             sseSend(res, 'text', { text: cachedBody.text });
-            sseSend(res, 'done', { kind, model: cachedBody.model, tokens: cachedBody.tokens, cached: true });
+            sseSend(res, 'done', { kind, model: cachedBody.model, tokens: cachedBody.tokens, tickers: cachedBody.tickers, cached: true });
             return res.end();
           }
           return res.status(200).json(cachedBody);
@@ -220,15 +276,23 @@ function createSynthesizeHandler() {
         sseInit(res);
         sseSend(res, 'status', { message: 'Synthesizing…', kind });
         const sanitizer = createStreamSanitizer();
-        const onDelta = (d) => { const safe = sanitizer.feed(d); if (safe) sseSend(res, 'text_delta', { text: safe }); };
+        // Gate the trailing `## TICKERS` block so it never leaks into text_delta.
+        const cut = createMarkerCut(TICKERS_HEADER_RE);
+        const onDelta = (d) => {
+          const pre = cut.feed(d);
+          if (pre) { const safe = sanitizer.feed(pre); if (safe) sseSend(res, 'text_delta', { text: safe }); }
+        };
 
         const { rawText, usage } = await runSynthesis({ kind, input, candidates, modelConfig, onDelta });
-        const tail = sanitizer.flush();
+        const preTail = cut.flush();
+        const tail = (preTail ? (sanitizer.feed(preTail) || '') : '') + (sanitizer.flush() || '');
         if (tail) sseSend(res, 'text_delta', { text: tail });
-        const { text: finalText, synthesizedEmpty, reason } = finalizeText(rawText, kind, validIds);
+
+        const { cleanedText, tickers } = extractTickers(rawText);
+        const { text: finalText, synthesizedEmpty, reason } = finalizeText(cleanedText, kind, validIds);
 
         const outBody = {
-          kind, text: finalText,
+          kind, text: finalText, tickers: synthesizedEmpty ? [] : tickers,
           tokens: { input: usage.input_tokens, output: usage.output_tokens },
           model: modelConfig.id, elapsedMs: Date.now() - startedAt,
           _meta: { fetchedAt, forced: refresh, ...(synthesizedEmpty ? { synthesizedEmpty: true, reason } : {}) },
@@ -241,16 +305,17 @@ function createSynthesizeHandler() {
         // The final `text` event is authoritative and replaces accumulated
         // deltas — so an empty result correctly clears any provisional stream.
         sseSend(res, 'text', { text: finalText });
-        sseSend(res, 'done', { kind, model: modelConfig.id, tokens: outBody.tokens, cached: false, forced: refresh, synthesizedEmpty });
-        logTape({ endpoint: 'synthesize', kind, jwt_sub: req.tape?.sub, cache: 'miss', forced: refresh, synthesizedEmpty, tokens: outBody.tokens, model: modelConfig.id, cost_usd_est: costUsd(usage, modelConfig), status: 200, elapsed_ms: Date.now() - startedAt });
+        sseSend(res, 'done', { kind, model: modelConfig.id, tokens: outBody.tokens, tickers: outBody.tickers, cached: false, forced: refresh, synthesizedEmpty });
+        logTape({ endpoint: 'synthesize', kind, jwt_sub: req.tape?.sub, cache: 'miss', forced: refresh, synthesizedEmpty, tickers: outBody.tickers.length, tokens: outBody.tokens, model: modelConfig.id, cost_usd_est: costUsd(usage, modelConfig), status: 200, elapsed_ms: Date.now() - startedAt });
         return res.end();
       }
 
       // non-stream
       const { rawText, usage } = await runSynthesis({ kind, input, candidates, modelConfig });
-      const { text: finalText, synthesizedEmpty, reason } = finalizeText(rawText, kind, validIds);
+      const { cleanedText, tickers } = extractTickers(rawText);
+      const { text: finalText, synthesizedEmpty, reason } = finalizeText(cleanedText, kind, validIds);
       const outBody = {
-        kind, text: finalText,
+        kind, text: finalText, tickers: synthesizedEmpty ? [] : tickers,
         tokens: { input: usage.input_tokens, output: usage.output_tokens },
         model: modelConfig.id, elapsedMs: Date.now() - startedAt,
         _meta: { fetchedAt, forced: refresh, ...(synthesizedEmpty ? { synthesizedEmpty: true, reason } : {}) },
@@ -259,7 +324,7 @@ function createSynthesizeHandler() {
       if (!noCache && !synthesizedEmpty) await setCached(cacheKey, outBody, ttl);
       await recordCost(usage, modelConfig, dayKey, ttlDay);
 
-      logTape({ endpoint: 'synthesize', kind, jwt_sub: req.tape?.sub, cache: 'miss', forced: refresh, synthesizedEmpty, tokens: outBody.tokens, model: modelConfig.id, cost_usd_est: costUsd(usage, modelConfig), status: 200, elapsed_ms: Date.now() - startedAt });
+      logTape({ endpoint: 'synthesize', kind, jwt_sub: req.tape?.sub, cache: 'miss', forced: refresh, synthesizedEmpty, tickers: outBody.tickers.length, tokens: outBody.tokens, model: modelConfig.id, cost_usd_est: costUsd(usage, modelConfig), status: 200, elapsed_ms: Date.now() - startedAt });
       return res.status(200).json(outBody);
     } catch (err) {
       if (res.headersSent) {

--- a/services/tape/synthesize.js
+++ b/services/tape/synthesize.js
@@ -17,6 +17,7 @@ const { sanitizeAgentText, createStreamSanitizer } = require('../../utils/agent/
 const { VALID_KINDS, systemPromptFor, buildUserMessage, validateKindCompliance, EMPTY_SENTINEL, TICKERS_MARKER, PROMPT_VERSION } = require('./tapePrompts');
 const { extractTickers } = require('./tickerExtract');
 const { buildAliases } = require('./tickerResolver');
+const { assessConfidence } = require('./confidence');
 const { getCached, setCached, addAndGet } = require('./tapeStore');
 const { TIER, synTtlSec, buildFreshnessMeta } = require('./tapeFreshness');
 const { tapeError, tapeRateLimited, TapeHttpError } = require('./tapeErrors');
@@ -374,12 +375,26 @@ function createSynthesizeHandler() {
         throw e;
       }
 
+      // Confidence tier (deterministic, all kinds). windowDays/windowExpanded
+      // come from the Brief retrieval response if the client forwards them.
+      const windowDays = input.windowDays ?? body.windowDays ?? null;
+      const windowExpanded = input.windowExpanded ?? body.windowExpanded ?? false;
+      const conf = assessConfidence({
+        kind, candidates, finalText: r.finalText,
+        synthesizedEmpty: r.synthesizedEmpty, emptyReason: r.reason,
+        windowDays, windowExpanded,
+      });
+
       const outBody = {
         kind, text: r.finalText, tickers: r.synthesizedEmpty ? [] : r.tickers,
         tokens: { input: r.usage.input_tokens, output: r.usage.output_tokens },
         model: modelConfig.id, elapsedMs: Date.now() - startedAt,
         _meta: {
           fetchedAt, forced: refresh,
+          confidence: conf.confidence,
+          confidenceReason: conf.confidenceReason,
+          candidateCount: conf.candidateCount,
+          ...(windowExpanded ? { windowDays, windowExpanded: true } : {}),
           ...(r.synthesizedEmpty ? { synthesizedEmpty: true, reason: r.reason } : {}),
           ...(r.recovered ? { complianceRecovered: true } : {}),
         },
@@ -389,11 +404,11 @@ function createSynthesizeHandler() {
       if (!noCache && !r.synthesizedEmpty) await setCached(cacheKey, outBody, ttl);
       await recordCost(r.usage, modelConfig, dayKey, ttlDay);
 
-      const logBase = { endpoint: 'synthesize', kind, jwt_sub: req.tape?.sub, cache: 'miss', forced: refresh, synthesizedEmpty: r.synthesizedEmpty, complianceRecovered: !!r.recovered, attempts: r.attempts, tickers: outBody.tickers.length, tokens: outBody.tokens, model: modelConfig.id, cost_usd_est: costUsd(r.usage, modelConfig), status: 200, elapsed_ms: Date.now() - startedAt };
+      const logBase = { endpoint: 'synthesize', kind, jwt_sub: req.tape?.sub, cache: 'miss', forced: refresh, synthesizedEmpty: r.synthesizedEmpty, confidence: conf.confidence, complianceRecovered: !!r.recovered, attempts: r.attempts, tickers: outBody.tickers.length, tokens: outBody.tokens, model: modelConfig.id, cost_usd_est: costUsd(r.usage, modelConfig), status: 200, elapsed_ms: Date.now() - startedAt };
 
       if (stream) {
         sseSend(res, 'text', { text: r.finalText });
-        sseSend(res, 'done', { kind, model: modelConfig.id, tokens: outBody.tokens, tickers: outBody.tickers, cached: false, forced: refresh, synthesizedEmpty: r.synthesizedEmpty });
+        sseSend(res, 'done', { kind, model: modelConfig.id, tokens: outBody.tokens, tickers: outBody.tickers, confidence: conf.confidence, confidenceReason: conf.confidenceReason, cached: false, forced: refresh, synthesizedEmpty: r.synthesizedEmpty });
         logTape(logBase);
         return res.end();
       }

--- a/services/tape/synthesize.js
+++ b/services/tape/synthesize.js
@@ -17,6 +17,7 @@ const { sanitizeAgentText, createStreamSanitizer } = require('../../utils/agent/
 const { VALID_KINDS, systemPromptFor, buildUserMessage, validateKindCompliance, EMPTY_SENTINEL, TICKERS_MARKER, PROMPT_VERSION } = require('./tapePrompts');
 const { extractTickers } = require('./tickerExtract');
 const { buildAliases } = require('./tickerResolver');
+const { cardContext } = require('./companyCards');
 const { assessConfidence } = require('./confidence');
 const { getCached, setCached, addAndGet } = require('./tapeStore');
 const { TIER, synTtlSec, buildFreshnessMeta } = require('./tapeFreshness');
@@ -115,6 +116,11 @@ function companyHintFor(input = {}) {
   );
   if (!cand) return null;
   const tk = cand.trim();
+  // Prefer the full company card (name + industry + description + products +
+  // execs) — authoritative identity that stops the writer inferring the wrong
+  // company from sparse clips (the CEG = Constellation Energy-not-Software bug).
+  const card = cardContext(tk);
+  if (card) return card;
   const { name } = buildAliases(tk);
   return name && name.toLowerCase() !== tk.toLowerCase() ? `${tk} = ${name}` : null;
 }

--- a/services/tape/synthesize.js
+++ b/services/tape/synthesize.js
@@ -13,7 +13,7 @@
 const { resolveModelSelection } = require('../../constants/agentModels');
 const { createProvider } = require('../../utils/agent/providers');
 const { sanitizeAgentText, createStreamSanitizer } = require('../../utils/agent/sanitizeOutput');
-const { VALID_KINDS, systemPromptFor, buildUserMessage, PROMPT_VERSION } = require('./tapePrompts');
+const { VALID_KINDS, systemPromptFor, buildUserMessage, hasRequiredMarkers, EMPTY_SENTINEL, PROMPT_VERSION } = require('./tapePrompts');
 const { getCached, setCached, addAndGet } = require('./tapeStore');
 const { TIER, synTtlSec, buildFreshnessMeta } = require('./tapeFreshness');
 const { tapeError, tapeRateLimited, TapeHttpError } = require('./tapeErrors');
@@ -33,6 +33,26 @@ const CLIP_RE = /\{\{clip:([^}]+)\}\}/g;
 function stripUnknownClipTokens(text, validIds) {
   if (typeof text !== 'string') return text;
   return text.replace(CLIP_RE, (m, id) => (validIds.has(id.trim()) ? m : ''));
+}
+
+/**
+ * Sanitize the raw model output and classify it against the kind's contract.
+ * Returns { text, synthesizedEmpty, reason } — text is '' when empty.
+ */
+function finalizeText(rawText, kind, validIds) {
+  const sanitized = stripUnknownClipTokens(sanitizeAgentText(rawText) || '', validIds);
+  const trimmed = sanitized.trim();
+  // Model explicitly signaled "not enough on-topic material".
+  if (!trimmed || trimmed.replace(/[.\s]+$/, '').toUpperCase() === EMPTY_SENTINEL) {
+    return { text: '', synthesizedEmpty: true, reason: 'candidates did not contain enough on-topic material' };
+  }
+  // Guardrail: model produced text but not in the required shape for this kind.
+  // Returning empty is preferable to letting malformed/mismatched markers reach
+  // the strict client parser (which would render misleading or blank sections).
+  if (!hasRequiredMarkers(kind, sanitized)) {
+    return { text: '', synthesizedEmpty: true, reason: `output did not contain the required ${kind} markers` };
+  }
+  return { text: sanitized, synthesizedEmpty: false, reason: null };
 }
 
 function utcDateKey() { return new Date().toISOString().slice(0, 10); }
@@ -61,7 +81,9 @@ async function runSynthesis({ kind, input, candidates, modelConfig, onDelta }) {
     onTextDelta: onDelta || (() => {}),
     aborted: () => false,
   });
-  const rawText = (result.contentBlocks || [])
+  // Provider returns { content: [...blocks], usage, stop_reason } — the blocks
+  // live under `content`, not `contentBlocks`.
+  const rawText = (result.content || [])
     .filter((b) => b.type === 'text')
     .map((b) => b.text)
     .join('');
@@ -203,38 +225,41 @@ function createSynthesizeHandler() {
         const { rawText, usage } = await runSynthesis({ kind, input, candidates, modelConfig, onDelta });
         const tail = sanitizer.flush();
         if (tail) sseSend(res, 'text_delta', { text: tail });
-        const finalText = stripUnknownClipTokens(sanitizeAgentText(rawText), validIds);
+        const { text: finalText, synthesizedEmpty, reason } = finalizeText(rawText, kind, validIds);
 
         const outBody = {
           kind, text: finalText,
           tokens: { input: usage.input_tokens, output: usage.output_tokens },
           model: modelConfig.id, elapsedMs: Date.now() - startedAt,
-          _meta: { fetchedAt },
+          _meta: { fetchedAt, forced: refresh, ...(synthesizedEmpty ? { synthesizedEmpty: true, reason } : {}) },
         };
-        outBody._meta = { ...outBody._meta, forced: refresh, ...buildFreshnessMeta({ tier: TIER.QUALITATIVE, cached: false, cachedAt: fetchedAt, fetchedAt, ttlSec: ttl }) };
-        if (!noCache) await setCached(cacheKey, outBody, ttl);
+        outBody._meta = { ...outBody._meta, ...buildFreshnessMeta({ tier: TIER.QUALITATIVE, cached: false, cachedAt: fetchedAt, fetchedAt, ttlSec: ttl }) };
+        // Don't cache empties — temperature>0 means a retry may yet produce content.
+        if (!noCache && !synthesizedEmpty) await setCached(cacheKey, outBody, ttl);
         await recordCost(usage, modelConfig, dayKey, ttlDay);
 
+        // The final `text` event is authoritative and replaces accumulated
+        // deltas — so an empty result correctly clears any provisional stream.
         sseSend(res, 'text', { text: finalText });
-        sseSend(res, 'done', { kind, model: modelConfig.id, tokens: outBody.tokens, cached: false, forced: refresh });
-        logTape({ endpoint: 'synthesize', kind, jwt_sub: req.tape?.sub, cache: 'miss', forced: refresh, tokens: outBody.tokens, model: modelConfig.id, cost_usd_est: costUsd(usage, modelConfig), status: 200, elapsed_ms: Date.now() - startedAt });
+        sseSend(res, 'done', { kind, model: modelConfig.id, tokens: outBody.tokens, cached: false, forced: refresh, synthesizedEmpty });
+        logTape({ endpoint: 'synthesize', kind, jwt_sub: req.tape?.sub, cache: 'miss', forced: refresh, synthesizedEmpty, tokens: outBody.tokens, model: modelConfig.id, cost_usd_est: costUsd(usage, modelConfig), status: 200, elapsed_ms: Date.now() - startedAt });
         return res.end();
       }
 
       // non-stream
       const { rawText, usage } = await runSynthesis({ kind, input, candidates, modelConfig });
-      const finalText = stripUnknownClipTokens(sanitizeAgentText(rawText), validIds);
+      const { text: finalText, synthesizedEmpty, reason } = finalizeText(rawText, kind, validIds);
       const outBody = {
         kind, text: finalText,
         tokens: { input: usage.input_tokens, output: usage.output_tokens },
         model: modelConfig.id, elapsedMs: Date.now() - startedAt,
-        _meta: { fetchedAt },
+        _meta: { fetchedAt, forced: refresh, ...(synthesizedEmpty ? { synthesizedEmpty: true, reason } : {}) },
       };
-      outBody._meta = { ...outBody._meta, forced: refresh, ...buildFreshnessMeta({ tier: TIER.QUALITATIVE, cached: false, cachedAt: fetchedAt, fetchedAt, ttlSec: ttl }) };
-      if (!noCache) await setCached(cacheKey, outBody, ttl);
+      outBody._meta = { ...outBody._meta, ...buildFreshnessMeta({ tier: TIER.QUALITATIVE, cached: false, cachedAt: fetchedAt, fetchedAt, ttlSec: ttl }) };
+      if (!noCache && !synthesizedEmpty) await setCached(cacheKey, outBody, ttl);
       await recordCost(usage, modelConfig, dayKey, ttlDay);
 
-      logTape({ endpoint: 'synthesize', kind, jwt_sub: req.tape?.sub, cache: 'miss', forced: refresh, tokens: outBody.tokens, model: modelConfig.id, cost_usd_est: costUsd(usage, modelConfig), status: 200, elapsed_ms: Date.now() - startedAt });
+      logTape({ endpoint: 'synthesize', kind, jwt_sub: req.tape?.sub, cache: 'miss', forced: refresh, synthesizedEmpty, tokens: outBody.tokens, model: modelConfig.id, cost_usd_est: costUsd(usage, modelConfig), status: 200, elapsed_ms: Date.now() - startedAt });
       return res.status(200).json(outBody);
     } catch (err) {
       if (res.headersSent) {

--- a/services/tape/synthesize.js
+++ b/services/tape/synthesize.js
@@ -1,0 +1,256 @@
+/**
+ * synthesize (spec §4) — the direct LLM writer.
+ *
+ * Takes pre-filtered candidates from person-quotes / topic-quotes and runs ONE
+ * synthesis pass (no tools, no agent loop, no re-search) grounded strictly on
+ * those candidates. Deterministic for a fixed (candidates + input + model +
+ * prompt version), so the result is content-addressed and cached aggressively.
+ *
+ * Reuses the existing provider abstraction (createProvider) + model routing
+ * (resolveModelSelection) + clip-token sanitizers.
+ */
+
+const { resolveModelSelection } = require('../../constants/agentModels');
+const { createProvider } = require('../../utils/agent/providers');
+const { sanitizeAgentText, createStreamSanitizer } = require('../../utils/agent/sanitizeOutput');
+const { VALID_KINDS, systemPromptFor, buildUserMessage, PROMPT_VERSION } = require('./tapePrompts');
+const { getCached, setCached, addAndGet } = require('./tapeStore');
+const { TIER, synTtlSec, buildFreshnessMeta } = require('./tapeFreshness');
+const { tapeError, tapeRateLimited, TapeHttpError } = require('./tapeErrors');
+const { checkRateLimit, logTape } = require('./tapeEndpoint');
+const { hashBody } = require('./tapeShared');
+const { printLog } = require('../../constants');
+
+const MAX_TOKENS = parseInt(process.env.TAPE_SYN_MAX_TOKENS || '2048', 10);
+const DAILY_TOKEN_CAP = parseInt(process.env.TAPE_DAILY_OUTPUT_TOKEN_CAP || '5000000', 10);
+const DAILY_USD_CAP = process.env.TAPE_DAILY_USD_CAP ? parseFloat(process.env.TAPE_DAILY_USD_CAP) : null;
+const HOURLY_LIMIT = parseInt(process.env.TAPE_SYN_HOURLY_LIMIT || '30', 10);
+const NOCACHE_ENABLED = process.env.TAPE_NOCACHE_ENABLED === 'true';
+
+const CLIP_RE = /\{\{clip:([^}]+)\}\}/g;
+
+/** Strip {{clip:id}} tokens whose id was not in the provided candidate set. */
+function stripUnknownClipTokens(text, validIds) {
+  if (typeof text !== 'string') return text;
+  return text.replace(CLIP_RE, (m, id) => (validIds.has(id.trim()) ? m : ''));
+}
+
+function utcDateKey() { return new Date().toISOString().slice(0, 10); }
+function secondsUntilUtcMidnight() {
+  const now = new Date();
+  const next = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1));
+  return Math.max(60, Math.ceil((next.getTime() - now.getTime()) / 1000));
+}
+
+/** One synthesis pass. Returns { rawText, usage }. */
+async function runSynthesis({ kind, input, candidates, modelConfig, onDelta }) {
+  const provider = createProvider(modelConfig.provider);
+  const ready = await provider.validate();
+  if (!ready) {
+    throw new TapeHttpError(502, 'upstream-failure', 'Synthesis provider unavailable',
+      `Provider ${modelConfig.provider} for model ${modelConfig.label} is not configured.`);
+  }
+  const result = await provider.createResponse({
+    model: modelConfig.id,
+    maxTokens: modelConfig.maxSynthesisTokens || MAX_TOKENS,
+    system: systemPromptFor(kind),
+    messages: [{ role: 'user', content: buildUserMessage({ kind, input, candidates }) }],
+    tools: undefined,
+    toolChoice: 'none',
+    temperature: 0.4,
+    onTextDelta: onDelta || (() => {}),
+    aborted: () => false,
+  });
+  const rawText = (result.contentBlocks || [])
+    .filter((b) => b.type === 'text')
+    .map((b) => b.text)
+    .join('');
+  return { rawText, usage: result.usage || { input_tokens: 0, output_tokens: 0 } };
+}
+
+async function recordCost(usage, modelConfig, dayKey, ttlDay) {
+  const outTok = usage.output_tokens || 0;
+  if (DAILY_TOKEN_CAP > 0) await addAndGet(`tape:syn:tok:${dayKey}`, outTok, ttlDay);
+  if (DAILY_USD_CAP) {
+    const cost = ((usage.input_tokens || 0) * (modelConfig.inputPer1M || 0)
+      + outTok * (modelConfig.outputPer1M || 0)) / 1e6;
+    await addAndGet(`tape:syn:usd:${dayKey}`, Math.round(cost * 1e6), ttlDay);
+  }
+}
+
+function costUsd(usage, modelConfig) {
+  return parseFloat((((usage.input_tokens || 0) * (modelConfig.inputPer1M || 0)
+    + (usage.output_tokens || 0) * (modelConfig.outputPer1M || 0)) / 1e6).toFixed(4));
+}
+
+// --- SSE helpers (same event shape as /api/pull) ---
+function sseInit(res) {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache, no-transform',
+    Connection: 'keep-alive',
+    'X-Accel-Buffering': 'no',
+  });
+  res.socket?.setNoDelay?.(true);
+}
+function sseSend(res, event, data) {
+  try { res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`); } catch (_) { /* client gone */ }
+}
+
+/** Express handler for POST /api/tape/synthesize. */
+function createSynthesizeHandler() {
+  return async (req, res) => {
+    const startedAt = Date.now();
+    const body = req.body || {};
+    const stream = body.stream === true;
+
+    try {
+      if (!(await checkRateLimit(req, res, 'synthesize', HOURLY_LIMIT))) return;
+
+      const { kind, input = {}, candidates = [], model = 'fast' } = body;
+      if (!VALID_KINDS.includes(kind)) {
+        throw new TapeHttpError(400, 'bad-request', 'Bad request', `kind must be one of: ${VALID_KINDS.join(', ')}`);
+      }
+      if (!Array.isArray(candidates) || candidates.length === 0) {
+        throw new TapeHttpError(400, 'bad-request', 'Bad request', 'candidates must be a non-empty array');
+      }
+
+      const { modelConfig } = resolveModelSelection({ model });
+      const validIds = new Set(candidates.map((c) => c.pineconeId).filter(Boolean));
+
+      const keyHash = hashBody({
+        candidates: candidates.map((c) => ({ id: c.pineconeId, text: c.text })),
+        input, model: modelConfig.id, pv: PROMPT_VERSION,
+      });
+      const cacheKey = `tape:syn:v1:${kind}:${keyHash}`;
+      const ttl = synTtlSec();
+      const noCache = NOCACHE_ENABLED && body._nocache === true;
+      // User-facing "force re-synthesize": bypasses the cache READ so a fresh
+      // pass is generated, but still WRITES the result back (unlike _nocache,
+      // which is a gated debug bypass of both read and write). Spends tokens
+      // and counts against the daily cap.
+      //
+      // TODO(beta): cap force-resynthesize per user (e.g. N/day) once we have a
+      // baseline. Left UNLIMITED during beta on purpose — we only measure it
+      // for now (see the `tape:syn:resynth:*` counters + the `forced` log
+      // field) so the limit we pick before GA is grounded in real usage.
+      const refresh = body.refresh === true;
+
+      // --- cache hit (free; no LLM tokens) ---
+      if (!noCache && !refresh) {
+        const prior = await getCached(cacheKey);
+        if (prior) {
+          const cachedBody = {
+            ...prior.value,
+            _meta: {
+              ...(prior.value._meta || {}),
+              ...buildFreshnessMeta({
+                tier: TIER.QUALITATIVE, cached: true, cachedAt: prior.cachedAt,
+                fetchedAt: prior.value._meta?.fetchedAt, ttlSec: ttl,
+              }),
+            },
+          };
+          logTape({ endpoint: 'synthesize', kind, jwt_sub: req.tape?.sub, cache: 'hit', tokens: { input: 0, output: 0 }, status: 200, elapsed_ms: Date.now() - startedAt });
+          if (stream) {
+            sseInit(res);
+            sseSend(res, 'status', { message: 'Cached', kind });
+            sseSend(res, 'text', { text: cachedBody.text });
+            sseSend(res, 'done', { kind, model: cachedBody.model, tokens: cachedBody.tokens, cached: true });
+            return res.end();
+          }
+          return res.status(200).json(cachedBody);
+        }
+      }
+
+      // --- global daily cap (check before spending) ---
+      const dayKey = utcDateKey();
+      const ttlDay = secondsUntilUtcMidnight();
+      if (DAILY_TOKEN_CAP > 0) {
+        const tot = await addAndGet(`tape:syn:tok:${dayKey}`, 0, ttlDay);
+        if (tot >= DAILY_TOKEN_CAP) {
+          console.warn(`[tape:synthesize] DAILY OUTPUT TOKEN CAP reached (${tot}/${DAILY_TOKEN_CAP}) — refusing until next UTC day`);
+          logTape({ endpoint: 'synthesize', kind, jwt_sub: req.tape?.sub, status: 429, error: 'daily-cap', elapsed_ms: Date.now() - startedAt });
+          return tapeRateLimited(res, { detail: 'Daily synthesis token cap reached; resets at UTC midnight.', retryAfterSec: ttlDay });
+        }
+      }
+      if (DAILY_USD_CAP) {
+        const micro = await addAndGet(`tape:syn:usd:${dayKey}`, 0, ttlDay);
+        if (micro / 1e6 >= DAILY_USD_CAP) {
+          console.warn(`[tape:synthesize] DAILY USD CAP reached ($${(micro / 1e6).toFixed(2)}/$${DAILY_USD_CAP})`);
+          return tapeRateLimited(res, { detail: 'Daily synthesis cost cap reached; resets at UTC midnight.', retryAfterSec: ttlDay });
+        }
+      }
+
+      // Measure force-resynthesize usage (beta: unlimited, measured only — see
+      // the TODO above). Per-user + global daily counters so we can see who is
+      // hammering it and the overall volume before setting a cap.
+      if (refresh) {
+        const sub = req.tape?.sub || 'anon';
+        const perUser = await addAndGet(`tape:syn:resynth:${sub}:${dayKey}`, 1, ttlDay);
+        await addAndGet(`tape:syn:resynth:all:${dayKey}`, 1, ttlDay);
+        printLog(`[tape:synthesize] forced re-synthesize by ${sub} (#${perUser} today, kind=${kind})`);
+      }
+
+      // --- run synthesis ---
+      const fetchedAt = new Date().toISOString();
+
+      if (stream) {
+        sseInit(res);
+        sseSend(res, 'status', { message: 'Synthesizing…', kind });
+        const sanitizer = createStreamSanitizer();
+        const onDelta = (d) => { const safe = sanitizer.feed(d); if (safe) sseSend(res, 'text_delta', { text: safe }); };
+
+        const { rawText, usage } = await runSynthesis({ kind, input, candidates, modelConfig, onDelta });
+        const tail = sanitizer.flush();
+        if (tail) sseSend(res, 'text_delta', { text: tail });
+        const finalText = stripUnknownClipTokens(sanitizeAgentText(rawText), validIds);
+
+        const outBody = {
+          kind, text: finalText,
+          tokens: { input: usage.input_tokens, output: usage.output_tokens },
+          model: modelConfig.id, elapsedMs: Date.now() - startedAt,
+          _meta: { fetchedAt },
+        };
+        outBody._meta = { ...outBody._meta, forced: refresh, ...buildFreshnessMeta({ tier: TIER.QUALITATIVE, cached: false, cachedAt: fetchedAt, fetchedAt, ttlSec: ttl }) };
+        if (!noCache) await setCached(cacheKey, outBody, ttl);
+        await recordCost(usage, modelConfig, dayKey, ttlDay);
+
+        sseSend(res, 'text', { text: finalText });
+        sseSend(res, 'done', { kind, model: modelConfig.id, tokens: outBody.tokens, cached: false, forced: refresh });
+        logTape({ endpoint: 'synthesize', kind, jwt_sub: req.tape?.sub, cache: 'miss', forced: refresh, tokens: outBody.tokens, model: modelConfig.id, cost_usd_est: costUsd(usage, modelConfig), status: 200, elapsed_ms: Date.now() - startedAt });
+        return res.end();
+      }
+
+      // non-stream
+      const { rawText, usage } = await runSynthesis({ kind, input, candidates, modelConfig });
+      const finalText = stripUnknownClipTokens(sanitizeAgentText(rawText), validIds);
+      const outBody = {
+        kind, text: finalText,
+        tokens: { input: usage.input_tokens, output: usage.output_tokens },
+        model: modelConfig.id, elapsedMs: Date.now() - startedAt,
+        _meta: { fetchedAt },
+      };
+      outBody._meta = { ...outBody._meta, forced: refresh, ...buildFreshnessMeta({ tier: TIER.QUALITATIVE, cached: false, cachedAt: fetchedAt, fetchedAt, ttlSec: ttl }) };
+      if (!noCache) await setCached(cacheKey, outBody, ttl);
+      await recordCost(usage, modelConfig, dayKey, ttlDay);
+
+      logTape({ endpoint: 'synthesize', kind, jwt_sub: req.tape?.sub, cache: 'miss', forced: refresh, tokens: outBody.tokens, model: modelConfig.id, cost_usd_est: costUsd(usage, modelConfig), status: 200, elapsed_ms: Date.now() - startedAt });
+      return res.status(200).json(outBody);
+    } catch (err) {
+      if (res.headersSent) {
+        // streaming already started — surface as an SSE error and close.
+        sseSend(res, 'error', { error: err instanceof TapeHttpError ? err.detail || err.title : err.message });
+        return res.end();
+      }
+      if (err instanceof TapeHttpError) {
+        logTape({ endpoint: 'synthesize', jwt_sub: req.tape?.sub, status: err.status, error: err.slug, elapsed_ms: Date.now() - startedAt });
+        return tapeError(res, err.status, err.slug, err.title, err.detail, err.extra);
+      }
+      printLog(`[tape:synthesize] error: ${err.message}`);
+      logTape({ endpoint: 'synthesize', jwt_sub: req.tape?.sub, status: 502, error: 'upstream', detail: err.message, elapsed_ms: Date.now() - startedAt });
+      return tapeError(res, 502, 'upstream-failure', 'Upstream failure', err.message);
+    }
+  };
+}
+
+module.exports = { createSynthesizeHandler, runSynthesis, stripUnknownClipTokens };

--- a/services/tape/tapeAudit.js
+++ b/services/tape/tapeAudit.js
@@ -1,0 +1,64 @@
+/**
+ * Tape audit log — captures the FULL pipeline (input → retrieval → synthesis →
+ * parsed output) per kind-endpoint request, for offline inspection.
+ *
+ * Gated behind TAPE_AUDIT_ENABLED=true (default OFF). When on, every stage is
+ * written as one JSONL line to TAPE_AUDIT_FILE (default logs/tape-audit.jsonl)
+ * and echoed to stdout as `[tape:audit]`. It logs quote text + prompts + model
+ * output verbatim, so it is VERBOSE and contains content — DISABLE before prod.
+ *
+ * A loud boot warning fires on startup whenever it's enabled (see bootWarn).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { printLog } = require('../../constants');
+
+const ENABLED = process.env.TAPE_AUDIT_ENABLED === 'true';
+const FILE = process.env.TAPE_AUDIT_FILE || path.join(process.cwd(), 'logs', 'tape-audit.jsonl');
+
+function isEnabled() { return ENABLED; }
+
+/** Compact a candidate to the audit-relevant fields. */
+function slimCandidate(c) {
+  if (!c) return null;
+  return {
+    pineconeId: c.pineconeId,
+    creator: c.creator,
+    publishedDate: c.publishedDate,
+    similarity: c.similarity,
+    spanSec: c.spanSec,
+    text: c.text,
+  };
+}
+
+/**
+ * Append one audit entry. `stage` ∈ request | retrieval | synthesis | response
+ * | cache_hit | error. No-op unless TAPE_AUDIT_ENABLED.
+ */
+function audit(stage, auditId, payload = {}) {
+  if (!ENABLED) return;
+  const entry = { ts: new Date().toISOString(), auditId, stage, ...payload };
+  let line;
+  try { line = JSON.stringify(entry); } catch (_) { line = JSON.stringify({ ts: entry.ts, auditId, stage, error: 'unserializable-payload' }); }
+  printLog(`[tape:audit] ${line}`);
+  try {
+    fs.mkdirSync(path.dirname(FILE), { recursive: true });
+    fs.appendFile(FILE, `${line}\n`, () => {});
+  } catch (_) { /* best-effort */ }
+}
+
+/** Loud one-time startup warning when audit logging is on. */
+function bootWarn() {
+  if (!ENABLED) return;
+  console.warn(
+    '\n⚠️  [tape:audit] TAPE_AUDIT_ENABLED=true — full input/intermediate/output '
+    + `audit logging is ON → ${FILE}\n`
+    + '    It records quote text, prompts, and model output verbatim. '
+    + 'DISABLE (unset TAPE_AUDIT_ENABLED) before deploying to production.\n',
+  );
+}
+
+bootWarn();
+
+module.exports = { audit, isEnabled, slimCandidate, FILE };

--- a/services/tape/tapeAuth.js
+++ b/services/tape/tapeAuth.js
@@ -1,0 +1,86 @@
+/**
+ * Tape demo auth (spec §1).
+ *
+ * One shared password, exchanged for a scoped HS256 JWT, globally revocable by
+ * bumping a server-side `kid`. Independent of the main CASCDR_AUTH_SECRET.
+ *
+ * Env:
+ *   TAPE_AUTH_PASSWORD  — the shared secret (string)
+ *   TAPE_AUTH_SECRET    — HS256 signing key (32+ random bytes)
+ *   TAPE_AUTH_KID       — current key id (e.g. "v1"). Bump to revoke all tokens.
+ *   TAPE_AUTH_TTL_DAYS  — token lifetime (default 30)
+ */
+
+const crypto = require('crypto');
+const jwt = require('jsonwebtoken');
+const { tapeError } = require('./tapeErrors');
+
+const SCOPE = 'tape-demo';
+const TTL_DAYS = parseInt(process.env.TAPE_AUTH_TTL_DAYS || '30', 10);
+
+function currentKid() { return process.env.TAPE_AUTH_KID || 'v1'; }
+function signingSecret() { return process.env.TAPE_AUTH_SECRET || ''; }
+
+/** Constant-time password comparison. */
+function passwordMatches(provided) {
+  const expected = process.env.TAPE_AUTH_PASSWORD || '';
+  if (!expected) return false; // never accept when unconfigured
+  const a = Buffer.from(String(provided || ''), 'utf8');
+  const b = Buffer.from(expected, 'utf8');
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}
+
+/**
+ * Mint a scoped Tape JWT. Returns { token, expiresAt, scope }.
+ */
+function signTapeToken() {
+  const secret = signingSecret();
+  if (!secret) throw new Error('TAPE_AUTH_SECRET is not configured');
+  const expiresInSec = Math.max(1, TTL_DAYS) * 86_400;
+  const token = jwt.sign(
+    { sub: SCOPE, scope: SCOPE, kid: currentKid() },
+    secret,
+    { algorithm: 'HS256', expiresIn: expiresInSec },
+  );
+  const expiresAt = new Date(Date.now() + expiresInSec * 1000).toISOString();
+  return { token, expiresAt, scope: SCOPE };
+}
+
+/**
+ * Express middleware enforcing a valid, current, in-scope Tape JWT.
+ * Attaches `req.tape = { sub, scope }`.
+ */
+function requireTapeAuth(req, res, next) {
+  const header = String(req.headers.authorization || '');
+  const m = header.match(/^Bearer\s+(.+)$/i);
+  if (!m) {
+    return tapeError(res, 401, 'auth-failed', 'Missing or malformed Authorization header');
+  }
+  const secret = signingSecret();
+  if (!secret) {
+    return tapeError(res, 500, 'auth-misconfigured', 'Tape auth is not configured');
+  }
+
+  let payload;
+  try {
+    payload = jwt.verify(m[1], secret, { algorithms: ['HS256'] });
+  } catch (err) {
+    const expired = err && err.name === 'TokenExpiredError';
+    return tapeError(res, 401, 'auth-failed',
+      expired ? 'Token expired' : 'Invalid token');
+  }
+
+  // Revocation path: stale kid → reject.
+  if (payload.kid !== currentKid()) {
+    return tapeError(res, 401, 'auth-failed', 'Token revoked (stale key id)');
+  }
+  if (payload.scope !== SCOPE) {
+    return tapeError(res, 401, 'auth-failed', 'Token out of scope');
+  }
+
+  req.tape = { sub: payload.sub || SCOPE, scope: payload.scope };
+  return next();
+}
+
+module.exports = { signTapeToken, requireTapeAuth, passwordMatches, SCOPE };

--- a/services/tape/tapeEndpoint.js
+++ b/services/tape/tapeEndpoint.js
@@ -216,6 +216,8 @@ function withKindEndpoint({ kind, hourlyLimit, run }) {
         _meta: {
           ...(result._meta || {}),
           fetchedAt,
+          // Synthesis token usage (for cost tracking / model A-B in the eval harness).
+          tokens: usage ? { input: usage.input_tokens || 0, output: usage.output_tokens || 0 } : null,
           ...buildFreshnessMeta({ tier: TIER.QUALITATIVE, cached: false, cachedAt: fetchedAt, fetchedAt, ttlSec: KIND_TTL_SEC }),
         },
       };

--- a/services/tape/tapeEndpoint.js
+++ b/services/tape/tapeEndpoint.js
@@ -159,6 +159,61 @@ function withCachedEndpoint({ endpoint, hourlyLimit, tier, ttlSec, cacheKey, han
 }
 
 /**
+ * The kind cache identity: `tape:kind:<kind>:<PROMPT_VERSION>:<hash(body)>`.
+ * Single source of truth — both the live request path and the offline warmer
+ * derive the key here so a warmed entry is byte-for-byte what a live request
+ * reads. Note `hashBody` strips `refresh`/`_nocache`, so warming with
+ * `refresh:true` writes the same key the frontend (no refresh) will hit.
+ */
+function kindCacheKey(kind, body) {
+  return `tape:kind:${kind}:${PROMPT_VERSION}:${hashBody(body)}`;
+}
+
+/**
+ * Compute one kind result and write it to cache (+ semantic map). Shared by the
+ * HTTP handler and the cache warmer so the key formula, freshness `_meta`, token
+ * accounting, cache write, and semantic-remember live in exactly one place.
+ *
+ * Caller is responsible for the rate-limit, cache READ, and (HTTP only) the
+ * daily-cap pre-check + 429 rendering — those differ by path (the warmer just
+ * stops). Token usage is always added to the shared daily counter here.
+ *
+ * @returns {{ out:object, key:string, usage:object|null, synthesizedEmpty:boolean }}
+ */
+async function computeAndCacheKind({ kind, body, run, openai, refresh = false, noCache = false, jwtSub, auditId, queryEmb = null }) {
+  const day = utcDay();
+  const ttlDay = secsToUtcMidnight();
+  const fetchedAt = new Date().toISOString();
+  const { result, usage, synthesizedEmpty } = await run(body, { jwtSub, refresh, auditId });
+  if (usage && DAILY_TOKEN_CAP > 0) await addAndGet(`tape:syn:tok:${day}`, usage.output_tokens || 0, ttlDay);
+  audit('response', auditId, { kind, synthesizedEmpty, confidence: result?._meta?.confidence, result });
+
+  const out = {
+    ...result,
+    _meta: {
+      ...(result._meta || {}),
+      fetchedAt,
+      // Synthesis token usage (for cost tracking / model A-B in the eval harness).
+      tokens: usage ? { input: usage.input_tokens || 0, output: usage.output_tokens || 0 } : null,
+      ...buildFreshnessMeta({ tier: TIER.QUALITATIVE, cached: false, cachedAt: fetchedAt, fetchedAt, ttlSec: KIND_TTL_SEC }),
+    },
+  };
+
+  const key = kindCacheKey(kind, body);
+  if (!noCache && !synthesizedEmpty) {
+    await setCached(key, out, KIND_TTL_SEC);
+    // Remember the query embedding → key so near-identical future queries hit.
+    const semText = (semanticCache.ENABLED && openai) ? semanticCache.semanticText(kind, body) : '';
+    if (semText) {
+      const scope = semanticCache.scopeOf(kind, body, PROMPT_VERSION);
+      const emb = queryEmb || await semanticCache.embed(semText, openai);
+      semanticCache.remember(scope, emb, key);
+    }
+  }
+  return { out, key, usage, synthesizedEmpty };
+}
+
+/**
  * Wrap a kind-level endpoint (dossier/brief/split/narrative/readin): rate-limit
  * → kind cache (full parsed Result, 2h) → daily-token-cap → run() → cache write
  * → freshness _meta → log. `run(body, { jwtSub })` returns
@@ -178,7 +233,7 @@ function withKindEndpoint({ kind, hourlyLimit, run, openai }) {
       const noCache = NOCACHE_ENABLED && body._nocache === true;
       // Tie the kind cache to PROMPT_VERSION so prompt/pipeline fixes evict stale
       // (e.g. pre-fix empty-citation) entries instead of serving them for the TTL.
-      const key = `tape:kind:${kind}:${PROMPT_VERSION}:${hashBody(body)}`;
+      const key = kindCacheKey(kind, body);
       // Semantic cache: "essentially the same" query (within the same kind +
       // asOfDate + model scope) reuses a cached result. Free-text kinds only.
       const scope = semanticCache.scopeOf(kind, body, PROMPT_VERSION);
@@ -226,26 +281,9 @@ function withKindEndpoint({ kind, hourlyLimit, run, openai }) {
         }
       }
 
-      const fetchedAt = new Date().toISOString();
-      const { result, usage, synthesizedEmpty } = await run(body, { jwtSub: req.tape?.sub, refresh, auditId });
-      if (usage && DAILY_TOKEN_CAP > 0) await addAndGet(`tape:syn:tok:${day}`, usage.output_tokens || 0, ttlDay);
-      audit('response', auditId, { kind, synthesizedEmpty, confidence: result?._meta?.confidence, result });
-
-      const out = {
-        ...result,
-        _meta: {
-          ...(result._meta || {}),
-          fetchedAt,
-          // Synthesis token usage (for cost tracking / model A-B in the eval harness).
-          tokens: usage ? { input: usage.input_tokens || 0, output: usage.output_tokens || 0 } : null,
-          ...buildFreshnessMeta({ tier: TIER.QUALITATIVE, cached: false, cachedAt: fetchedAt, fetchedAt, ttlSec: KIND_TTL_SEC }),
-        },
-      };
-      if (!noCache && !synthesizedEmpty) {
-        await setCached(key, out, KIND_TTL_SEC);
-        // Remember the query embedding → key so near-identical future queries hit.
-        if (semText) { const emb = queryEmb || await semanticCache.embed(semText, openai); semanticCache.remember(scope, emb, key); }
-      }
+      const { out, usage } = await computeAndCacheKind({
+        kind, body, run, openai, refresh, noCache, jwtSub: req.tape?.sub, auditId, queryEmb,
+      });
       logTape({ endpoint: kind, jwt_sub: req.tape?.sub, cache: refresh ? 'refresh' : 'miss', confidence: out._meta?.confidence, tokens: usage || null, status: 200, elapsed_ms: Date.now() - startedAt });
       return res.status(200).json(out);
     } catch (err) {
@@ -260,4 +298,4 @@ function withKindEndpoint({ kind, hourlyLimit, run, openai }) {
   };
 }
 
-module.exports = { withCachedEndpoint, withKindEndpoint, checkRateLimit, logTape, hourBucket };
+module.exports = { withCachedEndpoint, withKindEndpoint, computeAndCacheKind, kindCacheKey, checkRateLimit, logTape, hourBucket };

--- a/services/tape/tapeEndpoint.js
+++ b/services/tape/tapeEndpoint.js
@@ -11,12 +11,25 @@
  * (custom streaming + cost guards) can reuse them without the cache wrapper.
  */
 
-const { incrWindow, getCached, setCached } = require('./tapeStore');
+const { incrWindow, getCached, setCached, addAndGet } = require('./tapeStore');
 const { tapeError, tapeRateLimited, TapeHttpError } = require('./tapeErrors');
-const { buildFreshnessMeta } = require('./tapeFreshness');
+const { buildFreshnessMeta, TIER } = require('./tapeFreshness');
+const { hashBody } = require('./tapeShared');
+const { PROMPT_VERSION } = require('./tapePrompts');
+const { audit } = require('./tapeAudit');
 const { printLog } = require('../../constants');
 
+let auditSeq = 0;
+
 const NOCACHE_ENABLED = process.env.TAPE_NOCACHE_ENABLED === 'true';
+const KIND_TTL_SEC = parseInt(process.env.TAPE_KIND_TTL_SEC || '7200', 10); // 2h
+const DAILY_TOKEN_CAP = parseInt(process.env.TAPE_DAILY_OUTPUT_TOKEN_CAP || '5000000', 10);
+function utcDay() { return new Date().toISOString().slice(0, 10); }
+function secsToUtcMidnight() {
+  const n = new Date();
+  const nx = new Date(Date.UTC(n.getUTCFullYear(), n.getUTCMonth(), n.getUTCDate() + 1));
+  return Math.max(60, Math.ceil((nx.getTime() - n.getTime()) / 1000));
+}
 
 /** Current UTC hour bucket, e.g. "2026-06-01T14". */
 function hourBucket(now = new Date()) {
@@ -144,4 +157,81 @@ function withCachedEndpoint({ endpoint, hourlyLimit, tier, ttlSec, cacheKey, han
   };
 }
 
-module.exports = { withCachedEndpoint, checkRateLimit, logTape, hourBucket };
+/**
+ * Wrap a kind-level endpoint (dossier/brief/split/narrative/readin): rate-limit
+ * → kind cache (full parsed Result, 2h) → daily-token-cap → run() → cache write
+ * → freshness _meta → log. `run(body, { jwtSub })` returns
+ * `{ result, usage, synthesizedEmpty }`; throws TapeHttpError on hard failure.
+ * Empty results are not cached (a retry may succeed).
+ */
+function withKindEndpoint({ kind, hourlyLimit, run }) {
+  return async (req, res) => {
+    const startedAt = Date.now();
+    // eslint-disable-next-line no-plusplus
+    const auditId = `${kind}-${Date.now().toString(36)}-${(auditSeq++).toString(36)}`;
+    try {
+      if (!(await checkRateLimit(req, res, kind, hourlyLimit))) return;
+      const body = req.body || {};
+      audit('request', auditId, { kind, jwt_sub: req.tape?.sub, body });
+      const refresh = body.refresh === true;
+      const noCache = NOCACHE_ENABLED && body._nocache === true;
+      // Tie the kind cache to PROMPT_VERSION so prompt/pipeline fixes evict stale
+      // (e.g. pre-fix empty-citation) entries instead of serving them for the TTL.
+      const key = `tape:kind:${kind}:${PROMPT_VERSION}:${hashBody(body)}`;
+
+      if (!noCache && !refresh) {
+        const prior = await getCached(key);
+        if (prior) {
+          const out = {
+            ...prior.value,
+            _meta: {
+              ...(prior.value._meta || {}),
+              ...buildFreshnessMeta({ tier: TIER.QUALITATIVE, cached: true, cachedAt: prior.cachedAt, fetchedAt: prior.value._meta?.fetchedAt, ttlSec: KIND_TTL_SEC }),
+            },
+          };
+          logTape({ endpoint: kind, jwt_sub: req.tape?.sub, cache: 'hit', status: 200, elapsed_ms: Date.now() - startedAt });
+          audit('cache_hit', auditId, { kind });
+          return res.status(200).json(out);
+        }
+      }
+
+      // Global daily output-token cap (shared with /synthesize).
+      const day = utcDay();
+      const ttlDay = secsToUtcMidnight();
+      if (DAILY_TOKEN_CAP > 0) {
+        const tot = await addAndGet(`tape:syn:tok:${day}`, 0, ttlDay);
+        if (tot >= DAILY_TOKEN_CAP) {
+          logTape({ endpoint: kind, jwt_sub: req.tape?.sub, status: 429, error: 'daily-cap', elapsed_ms: Date.now() - startedAt });
+          return tapeRateLimited(res, { detail: 'Daily synthesis token cap reached; resets at UTC midnight.', retryAfterSec: ttlDay });
+        }
+      }
+
+      const fetchedAt = new Date().toISOString();
+      const { result, usage, synthesizedEmpty } = await run(body, { jwtSub: req.tape?.sub, refresh, auditId });
+      if (usage && DAILY_TOKEN_CAP > 0) await addAndGet(`tape:syn:tok:${day}`, usage.output_tokens || 0, ttlDay);
+      audit('response', auditId, { kind, synthesizedEmpty, confidence: result?._meta?.confidence, result });
+
+      const out = {
+        ...result,
+        _meta: {
+          ...(result._meta || {}),
+          fetchedAt,
+          ...buildFreshnessMeta({ tier: TIER.QUALITATIVE, cached: false, cachedAt: fetchedAt, fetchedAt, ttlSec: KIND_TTL_SEC }),
+        },
+      };
+      if (!noCache && !synthesizedEmpty) await setCached(key, out, KIND_TTL_SEC);
+      logTape({ endpoint: kind, jwt_sub: req.tape?.sub, cache: refresh ? 'refresh' : 'miss', confidence: out._meta?.confidence, tokens: usage || null, status: 200, elapsed_ms: Date.now() - startedAt });
+      return res.status(200).json(out);
+    } catch (err) {
+      if (err instanceof TapeHttpError) {
+        logTape({ endpoint: kind, jwt_sub: req.tape?.sub, status: err.status, error: err.slug, elapsed_ms: Date.now() - startedAt });
+        return tapeError(res, err.status, err.slug, err.title, err.detail, err.extra);
+      }
+      printLog(`[tape:${kind}] error: ${err.message}`);
+      logTape({ endpoint: kind, jwt_sub: req.tape?.sub, status: 502, error: 'upstream', detail: err.message, elapsed_ms: Date.now() - startedAt });
+      return tapeError(res, 502, 'upstream-failure', 'Upstream failure', err.message);
+    }
+  };
+}
+
+module.exports = { withCachedEndpoint, withKindEndpoint, checkRateLimit, logTape, hourBucket };

--- a/services/tape/tapeEndpoint.js
+++ b/services/tape/tapeEndpoint.js
@@ -16,6 +16,7 @@ const { tapeError, tapeRateLimited, TapeHttpError } = require('./tapeErrors');
 const { buildFreshnessMeta, TIER } = require('./tapeFreshness');
 const { hashBody } = require('./tapeShared');
 const { PROMPT_VERSION } = require('./tapePrompts');
+const semanticCache = require('./semanticCache');
 const { audit } = require('./tapeAudit');
 const { printLog } = require('../../constants');
 
@@ -164,7 +165,7 @@ function withCachedEndpoint({ endpoint, hourlyLimit, tier, ttlSec, cacheKey, han
  * `{ result, usage, synthesizedEmpty }`; throws TapeHttpError on hard failure.
  * Empty results are not cached (a retry may succeed).
  */
-function withKindEndpoint({ kind, hourlyLimit, run }) {
+function withKindEndpoint({ kind, hourlyLimit, run, openai }) {
   return async (req, res) => {
     const startedAt = Date.now();
     // eslint-disable-next-line no-plusplus
@@ -178,20 +179,39 @@ function withKindEndpoint({ kind, hourlyLimit, run }) {
       // Tie the kind cache to PROMPT_VERSION so prompt/pipeline fixes evict stale
       // (e.g. pre-fix empty-citation) entries instead of serving them for the TTL.
       const key = `tape:kind:${kind}:${PROMPT_VERSION}:${hashBody(body)}`;
+      // Semantic cache: "essentially the same" query (within the same kind +
+      // asOfDate + model scope) reuses a cached result. Free-text kinds only.
+      const scope = semanticCache.scopeOf(kind, body, PROMPT_VERSION);
+      const semText = (semanticCache.ENABLED && openai) ? semanticCache.semanticText(kind, body) : '';
+      let queryEmb = null;
+
+      const serveCached = (prior, match, sim) => {
+        const out = {
+          ...prior.value,
+          _meta: {
+            ...(prior.value._meta || {}),
+            cacheMatch: match,
+            ...(sim != null ? { cacheSimilarity: parseFloat(sim.toFixed(3)) } : {}),
+            ...buildFreshnessMeta({ tier: TIER.QUALITATIVE, cached: true, cachedAt: prior.cachedAt, fetchedAt: prior.value._meta?.fetchedAt, ttlSec: KIND_TTL_SEC }),
+          },
+        };
+        logTape({ endpoint: kind, jwt_sub: req.tape?.sub, cache: match === 'semantic' ? 'semantic-hit' : 'hit', sim: sim != null ? parseFloat(sim.toFixed(3)) : undefined, status: 200, elapsed_ms: Date.now() - startedAt });
+        audit('cache_hit', auditId, { kind, match, sim });
+        return res.status(200).json(out);
+      };
 
       if (!noCache && !refresh) {
         const prior = await getCached(key);
-        if (prior) {
-          const out = {
-            ...prior.value,
-            _meta: {
-              ...(prior.value._meta || {}),
-              ...buildFreshnessMeta({ tier: TIER.QUALITATIVE, cached: true, cachedAt: prior.cachedAt, fetchedAt: prior.value._meta?.fetchedAt, ttlSec: KIND_TTL_SEC }),
-            },
-          };
-          logTape({ endpoint: kind, jwt_sub: req.tape?.sub, cache: 'hit', status: 200, elapsed_ms: Date.now() - startedAt });
-          audit('cache_hit', auditId, { kind });
-          return res.status(200).json(out);
+        if (prior) return serveCached(prior, 'exact');
+        // Semantic fallback: a near-identical prior query in the same scope.
+        if (semText) {
+          queryEmb = await semanticCache.embed(semText, openai);
+          const sem = semanticCache.lookup(scope, queryEmb);
+          if (sem) {
+            const semPrior = await getCached(sem.key);
+            if (semPrior) return serveCached(semPrior, 'semantic', sem.sim);
+            semanticCache.forget(scope, sem.key); // mapping outlived the cached value
+          }
         }
       }
 
@@ -221,7 +241,11 @@ function withKindEndpoint({ kind, hourlyLimit, run }) {
           ...buildFreshnessMeta({ tier: TIER.QUALITATIVE, cached: false, cachedAt: fetchedAt, fetchedAt, ttlSec: KIND_TTL_SEC }),
         },
       };
-      if (!noCache && !synthesizedEmpty) await setCached(key, out, KIND_TTL_SEC);
+      if (!noCache && !synthesizedEmpty) {
+        await setCached(key, out, KIND_TTL_SEC);
+        // Remember the query embedding → key so near-identical future queries hit.
+        if (semText) { const emb = queryEmb || await semanticCache.embed(semText, openai); semanticCache.remember(scope, emb, key); }
+      }
       logTape({ endpoint: kind, jwt_sub: req.tape?.sub, cache: refresh ? 'refresh' : 'miss', confidence: out._meta?.confidence, tokens: usage || null, status: 200, elapsed_ms: Date.now() - startedAt });
       return res.status(200).json(out);
     } catch (err) {

--- a/services/tape/tapeEndpoint.js
+++ b/services/tape/tapeEndpoint.js
@@ -64,8 +64,11 @@ function logTape(entry) {
  * @param {(req)=>string|null} opts.cacheKey       null => skip caching
  * @param {(req)=>Promise<{body:object,fetchedAt?:string,underlying?:object}>} opts.handler
  * @param {(body:object)=>string[]} [opts.idsOf]   identity set for revalidation detection
+ * @param {(body:object)=>boolean} [opts.cacheable] gate caching of a result
+ *        (default: always). Used to NOT cache empty results so a transient/empty
+ *        retrieval doesn't get pinned for the full TTL.
  */
-function withCachedEndpoint({ endpoint, hourlyLimit, tier, ttlSec, cacheKey, handler, idsOf }) {
+function withCachedEndpoint({ endpoint, hourlyLimit, tier, ttlSec, cacheKey, handler, idsOf, cacheable }) {
   return async (req, res) => {
     const startedAt = Date.now();
     try {
@@ -117,11 +120,15 @@ function withCachedEndpoint({ endpoint, hourlyLimit, tier, ttlSec, cacheKey, han
       });
       const body = { ...payload, _meta: { ...(payload._meta || {}), ...meta } };
 
-      if (key && !noCache) await setCached(key, body, ttl);
+      // Don't pin empty/uncacheable results — otherwise a zero-candidate
+      // retrieval (e.g. an odd phrasing) gets stuck in cache for the full TTL.
+      const shouldCache = typeof cacheable === 'function' ? cacheable(body) : true;
+      if (key && !noCache && shouldCache) await setCached(key, body, ttl);
 
       logTape({
         endpoint, jwt_sub: req.tape?.sub,
         cache: refresh ? (revalidated ? 'revalidate' : 'refresh') : 'miss',
+        cached_write: shouldCache,
         upstream_calls: result.underlying || undefined,
         status: 200, elapsed_ms: Date.now() - startedAt,
       });

--- a/services/tape/tapeEndpoint.js
+++ b/services/tape/tapeEndpoint.js
@@ -1,0 +1,140 @@
+/**
+ * DRY request scaffolding for /api/tape/* handlers.
+ *
+ * Provides:
+ *   - checkRateLimit(req, res, endpoint, hourlyLimit) — per-(sub, endpoint, hour)
+ *   - logTape(entry)                                  — single-line structured log (§8)
+ *   - withCachedEndpoint({...})                        — full cached-JSON handler:
+ *         rate-limit -> cache read -> handler -> cache write -> freshness _meta -> log
+ *
+ * Rate-limit and logging are also exported standalone so `synthesize`
+ * (custom streaming + cost guards) can reuse them without the cache wrapper.
+ */
+
+const { incrWindow, getCached, setCached } = require('./tapeStore');
+const { tapeError, tapeRateLimited, TapeHttpError } = require('./tapeErrors');
+const { buildFreshnessMeta } = require('./tapeFreshness');
+const { printLog } = require('../../constants');
+
+const NOCACHE_ENABLED = process.env.TAPE_NOCACHE_ENABLED === 'true';
+
+/** Current UTC hour bucket, e.g. "2026-06-01T14". */
+function hourBucket(now = new Date()) {
+  return now.toISOString().slice(0, 13);
+}
+
+/**
+ * Enforce the per-JWT hourly limit for `endpoint`. Returns true when allowed;
+ * when exceeded it has already sent a 429 and returns false.
+ */
+async function checkRateLimit(req, res, endpoint, hourlyLimit) {
+  if (!Number.isFinite(hourlyLimit) || hourlyLimit <= 0) return true;
+  const sub = (req.tape && req.tape.sub) || 'anon';
+  const key = `tape:rl:${sub}:${endpoint}:${hourBucket()}`;
+  const count = await incrWindow(key, 3600);
+  if (count > hourlyLimit) {
+    const resetDate = new Date(Date.now() + (3600 - (Date.now() / 1000 % 3600)) * 1000);
+    tapeRateLimited(res, {
+      detail: `Rate limit of ${hourlyLimit}/hour for ${endpoint} exceeded.`,
+      used: count - 1,
+      max: hourlyLimit,
+      resetDate,
+      retryAfterSec: 3600 - Math.floor((Date.now() / 1000) % 3600),
+    });
+    return false;
+  }
+  return true;
+}
+
+/** Emit a single-line structured log per request (§8). */
+function logTape(entry) {
+  try {
+    printLog(JSON.stringify({ ts: new Date().toISOString(), ...entry }));
+  } catch (_) { /* logging must never throw */ }
+}
+
+/**
+ * Wrap a cached JSON endpoint.
+ *
+ * @param {object} opts
+ * @param {string}   opts.endpoint                 name (log + rate-limit key)
+ * @param {number}   opts.hourlyLimit              per-sub hourly cap
+ * @param {string}   opts.tier                     freshness TIER.* value
+ * @param {(req)=>number} opts.ttlSec              cache TTL for this response
+ * @param {(req)=>string|null} opts.cacheKey       null => skip caching
+ * @param {(req)=>Promise<{body:object,fetchedAt?:string,underlying?:object}>} opts.handler
+ * @param {(body:object)=>string[]} [opts.idsOf]   identity set for revalidation detection
+ */
+function withCachedEndpoint({ endpoint, hourlyLimit, tier, ttlSec, cacheKey, handler, idsOf }) {
+  return async (req, res) => {
+    const startedAt = Date.now();
+    try {
+      if (!(await checkRateLimit(req, res, endpoint, hourlyLimit))) return;
+
+      const key = cacheKey ? cacheKey(req) : null;
+      const noCache = NOCACHE_ENABLED && req.body && req.body._nocache === true;
+      const refresh = req.body && req.body.refresh === true;
+      const ttl = Math.max(1, Math.floor(ttlSec(req)));
+
+      // --- cache read (skip on refresh / _nocache) ---
+      let prior = null;
+      if (key && !noCache) {
+        prior = await getCached(key);
+        if (prior && !refresh) {
+          const body = {
+            ...prior.value,
+            _meta: {
+              ...(prior.value._meta || {}),
+              ...buildFreshnessMeta({
+                tier, cached: true, cachedAt: prior.cachedAt,
+                fetchedAt: prior.value._meta?.fetchedAt, ttlSec: ttl,
+              }),
+            },
+          };
+          logTape({ endpoint, jwt_sub: req.tape?.sub, cache: 'hit', status: 200, elapsed_ms: Date.now() - startedAt });
+          return res.status(200).json(body);
+        }
+      }
+
+      // --- compute fresh ---
+      const result = await handler(req);
+      const payload = result.body || {};
+      const fetchedAt = result.fetchedAt || new Date().toISOString();
+
+      // Revalidation: refreshed payload identical to the prior cached one →
+      // reuse the original cachedAt and flag it, so identical downstream
+      // synthesize keys keep hitting cache (zero LLM tokens).
+      let revalidated = false;
+      let cachedAt = new Date().toISOString();
+      if (refresh && prior && typeof idsOf === 'function') {
+        const a = JSON.stringify(idsOf(prior.value) || []);
+        const b = JSON.stringify(idsOf(payload) || []);
+        if (a === b) { revalidated = true; cachedAt = prior.cachedAt; }
+      }
+
+      const meta = buildFreshnessMeta({
+        tier, cached: false, revalidated, cachedAt, fetchedAt, ttlSec: ttl,
+      });
+      const body = { ...payload, _meta: { ...(payload._meta || {}), ...meta } };
+
+      if (key && !noCache) await setCached(key, body, ttl);
+
+      logTape({
+        endpoint, jwt_sub: req.tape?.sub,
+        cache: refresh ? (revalidated ? 'revalidate' : 'refresh') : 'miss',
+        upstream_calls: result.underlying || undefined,
+        status: 200, elapsed_ms: Date.now() - startedAt,
+      });
+      return res.status(200).json(body);
+    } catch (err) {
+      if (err instanceof TapeHttpError) {
+        logTape({ endpoint, jwt_sub: req.tape?.sub, status: err.status, error: err.slug, elapsed_ms: Date.now() - startedAt });
+        return tapeError(res, err.status, err.slug, err.title, err.detail, err.extra);
+      }
+      logTape({ endpoint, jwt_sub: req.tape?.sub, status: 502, error: 'upstream', detail: err.message, elapsed_ms: Date.now() - startedAt });
+      return tapeError(res, 502, 'upstream-failure', 'Upstream failure', err.message);
+    }
+  };
+}
+
+module.exports = { withCachedEndpoint, checkRateLimit, logTape, hourBucket };

--- a/services/tape/tapeEndpoint.js
+++ b/services/tape/tapeEndpoint.js
@@ -166,7 +166,16 @@ function withCachedEndpoint({ endpoint, hourlyLimit, tier, ttlSec, cacheKey, han
  * `refresh:true` writes the same key the frontend (no refresh) will hit.
  */
 function kindCacheKey(kind, body) {
-  return `tape:kind:${kind}:${PROMPT_VERSION}:${hashBody(body)}`;
+  // Read-In keys on the TICKER ALONE (normalized) — deliberately ignoring `model`
+  // and every other body field. The frontend sends model:"quality" but the warmer
+  // synthesizes on the cheap model; keying on ticker lets ANY read-in request hit
+  // the single warmed entry. We accept the minor quality-vs-fast inaccuracy in
+  // favor of cost + cache-hit rate. Other kinds key on their full body (topic /
+  // persons / dates genuinely change the result).
+  const identity = kind === 'readin'
+    ? { ticker: String((body && body.ticker) || '').trim().toUpperCase() }
+    : body;
+  return `tape:kind:${kind}:${PROMPT_VERSION}:${hashBody(identity)}`;
 }
 
 /**

--- a/services/tape/tapeErrors.js
+++ b/services/tape/tapeErrors.js
@@ -1,0 +1,86 @@
+/**
+ * Consistent error model for /api/tape/* (spec §9).
+ *
+ * All errors return an RFC7807-ish body:
+ *   { type, title, status, detail, ...extra }
+ *
+ * The 429 path additionally carries a `creditInfo` object shaped like the
+ * existing /api/pull quota response so the frontend's
+ * `parseQuotaExceededResponse` works unchanged.
+ */
+
+const TYPE_BASE = 'https://pullthatupjamie.ai/tape';
+
+/**
+ * Throwable error a recipe handler can raise to produce a structured response.
+ * The endpoint wrapper catches it and renders via `tapeError`.
+ */
+class TapeHttpError extends Error {
+  constructor(status, slug, title, detail, extra = {}) {
+    super(detail || title);
+    this.name = 'TapeHttpError';
+    this.status = status;
+    this.slug = slug;
+    this.title = title;
+    this.detail = detail;
+    this.extra = extra;
+  }
+}
+
+/**
+ * Send a structured error response.
+ *
+ * @param {import('express').Response} res
+ * @param {number} status            HTTP status code
+ * @param {string} slug              short error slug (becomes part of `type`)
+ * @param {string} title             human-readable title
+ * @param {string} [detail]          longer explanation
+ * @param {object} [extra]           merged into the body (e.g. creditInfo)
+ */
+function tapeError(res, status, slug, title, detail, extra = {}) {
+  const body = {
+    type: `${TYPE_BASE}/${slug}`,
+    title,
+    status,
+    ...(detail ? { detail } : {}),
+    ...extra,
+  };
+  return res.status(status).json(body);
+}
+
+/**
+ * 429 quota/rate-limit response. `creditInfo` mirrors the /api/pull 429 shape
+ * (used, max, resetDate, daysUntilReset) so existing clients can parse it.
+ *
+ * @param {object} opts
+ * @param {string} opts.detail
+ * @param {number} [opts.used]
+ * @param {number} [opts.max]
+ * @param {Date|string} [opts.resetDate]
+ * @param {number} [opts.retryAfterSec]
+ */
+function tapeRateLimited(res, { detail, used, max, resetDate, retryAfterSec } = {}) {
+  const resetIso = resetDate
+    ? (resetDate instanceof Date ? resetDate.toISOString() : String(resetDate))
+    : null;
+  const daysUntilReset = resetDate
+    ? Math.max(0, Math.ceil((new Date(resetIso).getTime() - Date.now()) / 86_400_000))
+    : null;
+
+  if (Number.isFinite(retryAfterSec)) {
+    res.setHeader('Retry-After', String(Math.ceil(retryAfterSec)));
+  }
+
+  return tapeError(res, 429, 'rate-limited', 'Rate limit exceeded', detail, {
+    creditInfo: {
+      error: 'Quota exceeded',
+      code: 'QUOTA_EXCEEDED',
+      ...(Number.isFinite(used) ? { used } : {}),
+      ...(Number.isFinite(max) ? { max } : {}),
+      ...(resetIso ? { resetDate: resetIso } : {}),
+      ...(daysUntilReset != null ? { daysUntilReset } : {}),
+    },
+  });
+}
+
+module.exports = { tapeError, tapeRateLimited, TapeHttpError, TYPE_BASE };

--- a/services/tape/tapeFreshness.js
+++ b/services/tape/tapeFreshness.js
@@ -1,0 +1,139 @@
+/**
+ * Two-tier freshness policy + "last updated" metadata for /api/tape/*.
+ *
+ * Single source of truth for *how stale data may be* and *how that staleness
+ * is reported*, so no handler invents its own TTL.
+ *
+ *   QUANTITATIVE — ticker prices. Cache TTL is short (60s open / 5m closed);
+ *                  the 1-hour ceiling governs the stale-fallback path.
+ *   QUALITATIVE  — podcast quotes + synthesized editorial. Cached up to
+ *                  3 business days (skips weekends).
+ *
+ * Defaults encode the finance-professional standard and are env-overridable.
+ */
+
+const QUAL_TTL_BUSINESS_DAYS = parseInt(process.env.TAPE_QUAL_TTL_BUSINESS_DAYS || '3', 10);
+const QUANT_MAX_AGE_SEC = parseInt(process.env.TAPE_QUANT_MAX_AGE_SEC || '3600', 10);
+const QUOTE_TTL_OPEN_SEC = parseInt(process.env.TAPE_QUOTE_TTL_OPEN_SEC || '60', 10);
+const QUOTE_TTL_CLOSED_SEC = parseInt(process.env.TAPE_QUOTE_TTL_CLOSED_SEC || '300', 10);
+const SYN_TTL_DAYS = parseInt(process.env.TAPE_SYN_TTL_DAYS || '30', 10);
+
+const TIER = { QUANTITATIVE: 'quantitative', QUALITATIVE: 'qualitative' };
+
+/**
+ * Seconds from `now` until `n` business days have elapsed. Counts forward over
+ * weekdays only — a Friday result naturally lives through the weekend.
+ *
+ * @param {number} n          number of business days
+ * @param {Date} [now=new Date()]
+ * @returns {number} seconds
+ */
+function businessDaysToSeconds(n, now = new Date()) {
+  const target = new Date(now.getTime());
+  let added = 0;
+  while (added < n) {
+    target.setDate(target.getDate() + 1);
+    const day = target.getDay(); // 0 = Sun, 6 = Sat
+    if (day !== 0 && day !== 6) added += 1;
+  }
+  return Math.max(1, Math.round((target.getTime() - now.getTime()) / 1000));
+}
+
+/** Is the US equity market open right now? (9:30–16:00 ET, Mon–Fri.) */
+function isUsMarketOpen(now = new Date()) {
+  // Convert to ET via Intl; robust across server timezones / DST.
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    weekday: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).formatToParts(now);
+  const get = (t) => parts.find((p) => p.type === t)?.value;
+  const weekday = get('weekday');
+  if (weekday === 'Sat' || weekday === 'Sun') return false;
+  const hour = parseInt(get('hour'), 10);
+  const minute = parseInt(get('minute'), 10);
+  const mins = hour * 60 + minute;
+  return mins >= 9 * 60 + 30 && mins < 16 * 60;
+}
+
+/** Cache TTL for a price quote, depending on market hours. */
+function quantTtlSec({ marketOpen } = {}) {
+  const open = typeof marketOpen === 'boolean' ? marketOpen : isUsMarketOpen();
+  return open ? QUOTE_TTL_OPEN_SEC : QUOTE_TTL_CLOSED_SEC;
+}
+
+/** Cache TTL for qualitative (quote/editorial) responses. */
+function qualTtlSec(now = new Date()) {
+  return businessDaysToSeconds(QUAL_TTL_BUSINESS_DAYS, now);
+}
+
+/** Cache TTL for content-addressed synthesis output. */
+function synTtlSec() {
+  return Math.max(1, SYN_TTL_DAYS) * 86_400;
+}
+
+/** Hard staleness ceiling for prices (seconds). */
+function quantMaxAgeSec() {
+  return QUANT_MAX_AGE_SEC;
+}
+
+/**
+ * Build the uniform `_meta` "last updated" block merged into every response.
+ *
+ * `ageSec` / `freshUntil` are derived at read time so they're correct on cache
+ * hits, not frozen at write time.
+ *
+ * @param {object} opts
+ * @param {string} opts.tier               TIER.* value
+ * @param {Date|string} opts.cachedAt      when the payload entered the cache
+ * @param {Date|string} [opts.fetchedAt]   when the underlying data was produced
+ * @param {number} opts.ttlSec             cache TTL used for this payload
+ * @param {boolean} [opts.cached=false]
+ * @param {boolean} [opts.revalidated=false]
+ * @param {boolean} [opts.stale=false]
+ * @param {string} [opts.staleReason=null]
+ * @param {Date} [opts.now=new Date()]
+ */
+function buildFreshnessMeta({
+  tier,
+  cachedAt,
+  fetchedAt,
+  ttlSec,
+  cached = false,
+  revalidated = false,
+  stale = false,
+  staleReason = null,
+  now = new Date(),
+}) {
+  const cachedAtMs = cachedAt ? new Date(cachedAt).getTime() : now.getTime();
+  const fetchedAtMs = fetchedAt ? new Date(fetchedAt).getTime() : cachedAtMs;
+  const ageSec = Math.max(0, Math.round((now.getTime() - cachedAtMs) / 1000));
+  const freshUntil = Number.isFinite(ttlSec)
+    ? new Date(cachedAtMs + ttlSec * 1000).toISOString()
+    : null;
+
+  return {
+    cached,
+    revalidated,
+    tier: tier || null,
+    fetchedAt: new Date(fetchedAtMs).toISOString(),
+    cachedAt: new Date(cachedAtMs).toISOString(),
+    ageSec,
+    freshUntil,
+    stale,
+    staleReason: stale ? (staleReason || 'stale') : null,
+  };
+}
+
+module.exports = {
+  TIER,
+  businessDaysToSeconds,
+  isUsMarketOpen,
+  quantTtlSec,
+  qualTtlSec,
+  synTtlSec,
+  quantMaxAgeSec,
+  buildFreshnessMeta,
+};

--- a/services/tape/tapePrompts.js
+++ b/services/tape/tapePrompts.js
@@ -19,7 +19,9 @@
 // the structured `tickers` field — see synthesize.js). Invalidates v3 caches.
 // v5: added the `narrative` kind (## THESIS + ## BUCKET | with signed sentiment +
 // optional ## INFLECTION/## FORWARD). Invalidates v4 caches.
-const PROMPT_VERSION = 'v5';
+// v6: narrative adaptive cadence — variable-width buckets by density, floor
+// relaxed from 3 to 1 bucket. Invalidates v5 caches.
+const PROMPT_VERSION = 'v6';
 
 const EMPTY_SENTINEL = 'EMPTY_SYNTHESIS';
 
@@ -123,9 +125,14 @@ const CONTRACTS = {
 ## BUCKET | <ISO start date> | <ISO end date> | <signed sentiment -5..+5>
 <2-3 sentence stance summary for this window>
 {{clip:<id>}}
-# AT LEAST 3 ## BUCKET blocks REQUIRED, in chronological order oldest→newest.
-# Each bucket carries 1-4 {{clip:<id>}} citations. The sentiment is the THIRD
-# pipe-delimited field and is REQUIRED on EVERY bucket: an integer -5..+5.
+# ADAPTIVE CADENCE: choose 3-8 bucket boundaries that follow the RHYTHM of the
+# conversation — NARROWER windows where coverage is dense, WIDER where it is
+# sparse. Do NOT force uniform widths (no fixed monthly/quarterly/yearly rule);
+# variable widths are correct output. Each bucket needs >= 2 candidates. If the
+# data only supports fewer, emit fewer — at least 1 bucket. Chronological,
+# non-overlapping, oldest→newest. Each bucket carries 1-4 {{clip:<id>}}
+# citations. Sentiment is the THIRD pipe-delimited field, REQUIRED on EVERY
+# bucket: an integer -5..+5.
 
 ## INFLECTION
 - <YYYY-Qn OR ISO date>: <one-sentence what changed and, briefly, why>
@@ -204,7 +211,9 @@ function countMatches(text, re) { return (text.match(re) || []).length; }
 // the trajectory chart on the client is driven entirely off these values.
 function narrativeBucketsValid(text) {
   const lines = text.match(/^##\s*BUCKET\s*\|.*$/gim) || [];
-  if (lines.length < 3) return false;
+  // Adaptive cadence: bucket count follows data density, so the floor is >= 1
+  // (was 3). Every bucket present must still carry a valid signed-sentiment field.
+  if (lines.length < 1) return false;
   return lines.every((line) => {
     const parts = line.split('|'); // [ "## BUCKET ", start, end, sentiment ]
     if (parts.length < 4) return false;

--- a/services/tape/tapePrompts.js
+++ b/services/tape/tapePrompts.js
@@ -1,0 +1,117 @@
+/**
+ * Synthesis prompts, one per Tape `kind` (spec §4).
+ *
+ * Each prompt reuses the section markers the client already parses
+ * (`## TOPIC:`, `## PERSON:`, `## PUBLISHER:`, etc.) and instructs the model
+ * to cite quotes using the exact `{{clip:<pineconeId>}}` token form — the
+ * frontend renders these as embedded audio. Bump PROMPT_VERSION when any
+ * template changes (it is part of the synthesize cache key).
+ */
+
+const PROMPT_VERSION = 'v1';
+
+const SHARED_RULES = `
+You are Tape, an editorial finance assistant. You write tight, neutral,
+publication-grade copy grounded ONLY in the provided quotes. Rules:
+- Use ONLY the supplied candidate quotes as evidence. Do not invent facts,
+  numbers, names, or quotes.
+- Cite a quote by placing its token {{clip:<pineconeId>}} immediately after the
+  sentence it supports. Use the EXACT pineconeId given for that quote. Never
+  fabricate or guess a clip id; never cite a quote that was not provided.
+- Keep it concise and skimmable. Prefer specific claims over hedged generalities.
+- Do not include preambles like "Here is" or "Based on the quotes". Start
+  directly with the first section marker.
+`.trim();
+
+const KINDS = {
+  dossier: {
+    label: 'Dossier',
+    system: `${SHARED_RULES}
+
+FORMAT — a Dossier on a single PERSON's views.
+Structure with these markers:
+## PERSON: <name>
+A 1–2 sentence framing of who they are and the throughline of their view.
+## TOPIC: <topic>
+2–4 short paragraphs synthesizing their position, each grounded with {{clip:...}} citations.
+Group by sub-theme where natural. End with the sharpest single takeaway.`,
+  },
+  arc: {
+    label: 'Arc',
+    system: `${SHARED_RULES}
+
+FORMAT — an Arc tracing how a PERSON's view evolved over time.
+## PERSON: <name>
+One-sentence framing.
+## TOPIC: <topic>
+Walk chronologically (earliest → latest) through their position, noting shifts
+or consistency. Anchor each phase to dated quotes via {{clip:...}}. Close with
+where they stand now.`,
+  },
+  brief: {
+    label: 'Brief',
+    system: `${SHARED_RULES}
+
+FORMAT — a Brief: a cross-publisher roundup on a TOPIC.
+## TOPIC: <topic>
+A 2–3 sentence summary of the current state of the conversation.
+## PUBLISHER: <creator>
+For each notable creator/show, a short paragraph on their angle, grounded with
+{{clip:...}}. Cover the range of views, not just one side.`,
+  },
+  split: {
+    label: 'Split',
+    system: `${SHARED_RULES}
+
+FORMAT — a Split presenting two opposing sides (two people, or bull vs bear).
+## TOPIC: <topic>
+One-sentence framing of the disagreement.
+## SIDE: <label A>
+The case for side A, grounded with {{clip:...}}.
+## SIDE: <label B>
+The case for side B, grounded with {{clip:...}}.
+Be even-handed; give each side its strongest grounded argument.`,
+  },
+  readin: {
+    label: 'Read-in',
+    system: `${SHARED_RULES}
+
+FORMAT — a Read-in: a fast briefing pairing a market move with commentary.
+## TOPIC: <topic>
+2–3 sentences on what's happening and why it matters now.
+## CONTEXT:
+The relevant commentary, grounded with {{clip:...}} citations, in 2–4 short
+paragraphs. Keep it punchy — this is a get-up-to-speed brief.`,
+  },
+};
+
+const VALID_KINDS = Object.keys(KINDS);
+
+function systemPromptFor(kind) {
+  const entry = KINDS[kind];
+  return entry ? entry.system : null;
+}
+
+/** Build the user message: the input framing + the candidate evidence list. */
+function buildUserMessage({ kind, input = {}, candidates = [] }) {
+  const lines = [];
+  lines.push(`KIND: ${kind}`);
+  if (input.person) lines.push(`PERSON: ${input.person}`);
+  if (input.personB) lines.push(`PERSON B: ${input.personB}`);
+  if (input.topic) lines.push(`TOPIC: ${input.topic}`);
+  if (input.ticker) lines.push(`TICKER: ${input.ticker}`);
+  lines.push('');
+  lines.push('CANDIDATE QUOTES (cite by pineconeId):');
+  candidates.forEach((c, i) => {
+    const who = c.creator ? ` — ${c.creator}` : '';
+    const ep = c.episodeTitle ? ` (${c.episodeTitle})` : '';
+    const date = c.publishedDate ? ` [${String(c.publishedDate).slice(0, 10)}]` : '';
+    lines.push(`${i + 1}. pineconeId=${c.pineconeId}${who}${ep}${date}`);
+    lines.push(`   "${(c.text || '').replace(/\s+/g, ' ').trim()}"`);
+  });
+  lines.push('');
+  lines.push('Write the piece now, following the FORMAT for this KIND.');
+  return lines.join('\n');
+}
+
+module.exports = { PROMPT_VERSION, VALID_KINDS, systemPromptFor, buildUserMessage, KINDS };

--- a/services/tape/tapePrompts.js
+++ b/services/tape/tapePrompts.js
@@ -27,7 +27,9 @@
 // v9: retrieval — adjacent-paragraph context stitching on truncated clips, source-
 // diversity cap, min-word fragment drop, looser literal-anchor for multi-word
 // topics. Synthesis sees fuller passages, so output changes. Invalidates v8 caches.
-const PROMPT_VERSION = 'v9';
+// v10: company-card grounding — authoritative name/industry/description/products/
+// execs injected as the COMPANY reference (fixes wrong-entity primers, e.g. CEG).
+const PROMPT_VERSION = 'v10';
 
 const EMPTY_SENTINEL = 'EMPTY_SYNTHESIS';
 
@@ -319,7 +321,7 @@ function buildUserMessage({ kind, input = {}, candidates = [], companyHint = nul
   if (input.group) lines.push(`GROUP: ${input.group}`);
   // Resolved company identity for a ticker the user typed (e.g. "APP" =
   // AppLovin) — lets the model pick sector-correct peer tickers.
-  if (companyHint) lines.push(`COMPANY: ${companyHint} — pick sector-appropriate peers/relevant names.`);
+  if (companyHint) lines.push(`COMPANY (authoritative reference — ground the company's identity/primer on THIS, not on inference from the clips; also use it to pick sector-appropriate peers): ${companyHint}`);
   lines.push('');
   lines.push('CANDIDATE QUOTES (cite by pineconeId):');
   candidates.forEach((c, i) => {

--- a/services/tape/tapePrompts.js
+++ b/services/tape/tapePrompts.js
@@ -21,7 +21,13 @@
 // optional ## INFLECTION/## FORWARD). Invalidates v4 caches.
 // v6: narrative adaptive cadence — variable-width buckets by density, floor
 // relaxed from 3 to 1 bucket. Invalidates v5 caches.
-const PROMPT_VERSION = 'v7';
+// v8: stance gate — candidates may carry a {stance: bull/bear/neutral} hint;
+// readin BEAR slot + split PERSON sides must be stance-correct and quotes must
+// not be reused across split sides. Invalidates v7 caches.
+// v9: retrieval — adjacent-paragraph context stitching on truncated clips, source-
+// diversity cap, min-word fragment drop, looser literal-anchor for multi-word
+// topics. Synthesis sees fuller passages, so output changes. Invalidates v8 caches.
+const PROMPT_VERSION = 'v9';
 
 const EMPTY_SENTINEL = 'EMPTY_SYNTHESIS';
 
@@ -73,7 +79,11 @@ inline with {{clip:<id>}} — at least 2 across the primer.>
                 # to cite. NEVER emit this header with no {{clip:<id>}} beneath it.
 
 ## SMART_MONEY: BEAR
-{{clip:<id>}}   # OPTIONAL — same rule: omit if no bear quote; never empty.
+{{clip:<id>}}   # OPTIONAL. Only GENUINELY BEARISH quotes (the speaker argues the
+                # stock is overvalued / faces downside / structural risk). A clip
+                # marked {stance: bull} or {stance: neutral} is NOT a bear quote —
+                # do not place it here. If NO candidate is actually bearish, OMIT
+                # this header AND the "BEAR:" half of the PULSE line. Never empty.
 
 ## RISKS
 - <one-line risk>
@@ -100,15 +110,24 @@ inline with {{clip:<id>}} — at least 2 across the primer.>
 - <show> | <episode title> | <YYYY-MM-DD>   # OPTIONAL (client backfills from appearances).`,
 
   split: `## PERSON: <name A>
-<2-3 sentence stance summary>
+<2-3 sentence stance summary — state ONLY the position the cited quotes support>
 {{clip:<id>}}
 
 ## PERSON: <name B>
-<2-3 sentence stance summary>
+<2-3 sentence stance summary — must be the OPPOSING side of the debate>
 {{clip:<id>}}   # both PERSON blocks REQUIRED.
 
 ## CONTRAST
-<1-2 sentence contrast>   # OPTIONAL but encouraged.`,
+<1-2 sentence contrast>   # OPTIONAL but encouraged.
+
+# CITATION RULES (strict):
+# - Each PERSON's quotes must support THAT person's/camp's stance. When a clip is
+#   tagged {stance: bull/bear}, put it only under the side whose view it matches.
+# - NEVER cite the same {{clip:<id>}} under both PERSON blocks. A quote belongs to
+#   exactly one side.
+# - Do not assert a position a cited quote does not actually make. If one side has
+#   no genuinely supporting quote, write only what its quotes support (the backend
+#   will mark the result one-sided) — do NOT manufacture a symmetric opposing view.`,
 
   arc: `## THESIS: <one-line summary of the thesis being tracked>   # REQUIRED.
 ## VERDICT: <one-line verdict, e.g. "Conviction rising — calls landing">   # REQUIRED.
@@ -307,7 +326,10 @@ function buildUserMessage({ kind, input = {}, candidates = [], companyHint = nul
     const who = c.creator ? ` — ${c.creator}` : '';
     const ep = c.episodeTitle ? ` (${c.episodeTitle})` : '';
     const date = c.publishedDate ? ` [${String(c.publishedDate).slice(0, 10)}]` : '';
-    lines.push(`${i + 1}. pineconeId=${c.pineconeId}${who}${ep}${date}`);
+    // Optional pre-computed stance (bull/bear/neutral) from the stance gate —
+    // helps the model sort quotes into the correct bull/bear slot or camp side.
+    const stance = c._stance ? ` {stance: ${c._stance}}` : '';
+    lines.push(`${i + 1}. pineconeId=${c.pineconeId}${who}${ep}${date}${stance}`);
     lines.push(`   "${(c.text || '').replace(/\s+/g, ' ').trim()}"`);
   });
   lines.push('');

--- a/services/tape/tapePrompts.js
+++ b/services/tape/tapePrompts.js
@@ -1,95 +1,149 @@
 /**
  * Synthesis prompts, one per Tape `kind` (spec §4).
  *
- * Each prompt reuses the section markers the client already parses
- * (`## TOPIC:`, `## PERSON:`, `## PUBLISHER:`, etc.) and instructs the model
- * to cite quotes using the exact `{{clip:<pineconeId>}}` token form — the
- * frontend renders these as embedded audio. Bump PROMPT_VERSION when any
- * template changes (it is part of the synthesize cache key).
+ * Each kind emits a STRICT marker contract that the client parser splits on.
+ * The contracts are defined per the frontend's typed shape — see the
+ * "conform synthesize prompts to the client contract" ask. The client will not
+ * loosen its parser, so the model must emit ONLY the listed markers, in order,
+ * with exact names and literal punctuation (`|`, `:`).
+ *
+ * Optional sections are OMITTED entirely when candidates don't support them
+ * (never an empty header). When even the REQUIRED sections can't be produced,
+ * the model emits the EMPTY_SENTINEL and synthesize.js returns empty text with
+ * `_meta.synthesizedEmpty`.
+ *
+ * Bump PROMPT_VERSION on any change (it is part of the synthesize cache key).
  */
 
-const PROMPT_VERSION = 'v1';
+// v3: rewrote every per-kind contract to the strict client marker shapes
+// (readin WHAT_THEY_DO/PULSE/SMART_MONEY/RISKS, brief HEADLINE/PUBLISHER, arc
+// THESIS/VERDICT/CALL, etc.) + empty-sentinel handling. Invalidates v2 caches.
+const PROMPT_VERSION = 'v3';
 
-const SHARED_RULES = `
-You are Tape, an editorial finance assistant. You write tight, neutral,
-publication-grade copy grounded ONLY in the provided quotes. Rules:
-- Use ONLY the supplied candidate quotes as evidence. Do not invent facts,
-  numbers, names, or quotes.
-- Cite a quote by placing its token {{clip:<pineconeId>}} immediately after the
-  sentence it supports. Use the EXACT pineconeId given for that quote. Never
-  fabricate or guess a clip id; never cite a quote that was not provided.
-- Keep it concise and skimmable. Prefer specific claims over hedged generalities.
-- Do not include preambles like "Here is" or "Based on the quotes". Start
-  directly with the first section marker.
-`.trim();
+const EMPTY_SENTINEL = 'EMPTY_SYNTHESIS';
 
-const KINDS = {
-  dossier: {
-    label: 'Dossier',
-    system: `${SHARED_RULES}
+// --- per-kind marker contract blocks (pasted verbatim into the prompt) ---
 
-FORMAT — a Dossier on a single PERSON's views.
-Structure with these markers:
-## PERSON: <name>
-A 1–2 sentence framing of who they are and the throughline of their view.
-## TOPIC: <topic>
-2–4 short paragraphs synthesizing their position, each grounded with {{clip:...}} citations.
-Group by sub-theme where natural. End with the sharpest single takeaway.`,
-  },
-  arc: {
-    label: 'Arc',
-    system: `${SHARED_RULES}
+const CONTRACTS = {
+  readin: `## WHAT_THEY_DO
+<2-3 paragraph plain-English primer on the company. REQUIRED.>
 
-FORMAT — an Arc tracing how a PERSON's view evolved over time.
-## PERSON: <name>
-One-sentence framing.
-## TOPIC: <topic>
-Walk chronologically (earliest → latest) through their position, noting shifts
-or consistency. Anchor each phase to dated quotes via {{clip:...}}. Close with
-where they stand now.`,
-  },
-  brief: {
-    label: 'Brief',
-    system: `${SHARED_RULES}
+## PULSE | BULL: <one-sentence bull case> | BEAR: <one-sentence bear case>
+{{clip:<id>}}   # the single strongest marquee quote. OPTIONAL section.
 
-FORMAT — a Brief: a cross-publisher roundup on a TOPIC.
-## TOPIC: <topic>
-A 2–3 sentence summary of the current state of the conversation.
-## PUBLISHER: <creator>
-For each notable creator/show, a short paragraph on their angle, grounded with
-{{clip:...}}. Cover the range of views, not just one side.`,
-  },
-  split: {
-    label: 'Split',
-    system: `${SHARED_RULES}
+## SMART_MONEY: BULL
+{{clip:<id>}}
+{{clip:<id>}}   # OPTIONAL section.
 
-FORMAT — a Split presenting two opposing sides (two people, or bull vs bear).
-## TOPIC: <topic>
-One-sentence framing of the disagreement.
-## SIDE: <label A>
-The case for side A, grounded with {{clip:...}}.
-## SIDE: <label B>
-The case for side B, grounded with {{clip:...}}.
-Be even-handed; give each side its strongest grounded argument.`,
-  },
-  readin: {
-    label: 'Read-in',
-    system: `${SHARED_RULES}
+## SMART_MONEY: BEAR
+{{clip:<id>}}   # OPTIONAL section.
 
-FORMAT — a Read-in: a fast briefing pairing a market move with commentary.
-## TOPIC: <topic>
-2–3 sentences on what's happening and why it matters now.
-## CONTEXT:
-The relevant commentary, grounded with {{clip:...}} citations, in 2–4 short
-paragraphs. Keep it punchy — this is a get-up-to-speed brief.`,
-  },
+## RISKS
+- <one-line risk>
+- <one-line risk>   # OPTIONAL section.`,
+
+  brief: `# HEADLINE: <one-sentence newsroom-style takeaway>   # REQUIRED.
+
+## PUBLISHER: <show name>
+<2-3 sentence summary of what this publisher said>
+{{clip:<id>}}
+{{clip:<id>}}
+
+## PUBLISHER: <next show>
+...   # at least one PUBLISHER block REQUIRED; group candidates by their creator.`,
+
+  dossier: `## TOPIC: <topic name>
+<2-3 sentence stance summary>
+{{clip:<id>}}
+
+## TOPIC: <next>
+...   # one or more TOPIC blocks REQUIRED.
+
+## APPEARANCES
+- <show> | <episode title> | <YYYY-MM-DD>   # OPTIONAL (client backfills from appearances).`,
+
+  split: `## PERSON: <name A>
+<2-3 sentence stance summary>
+{{clip:<id>}}
+
+## PERSON: <name B>
+<2-3 sentence stance summary>
+{{clip:<id>}}   # both PERSON blocks REQUIRED.
+
+## CONTRAST
+<1-2 sentence contrast>   # OPTIONAL but encouraged.`,
+
+  arc: `## THESIS: <one-line summary of the thesis being tracked>   # REQUIRED.
+## VERDICT: <one-line verdict, e.g. "Conviction rising — calls landing">   # REQUIRED.
+## CALL | <ISO date> | <short label> | <conviction 1-5> | <optional outcome>
+{{clip:<id>}}
+## CALL | <ISO date> | <short label> | <conviction 1-5> |
+{{clip:<id>}}
+# at least 3 CALL entries REQUIRED; each MUST be followed by a {{clip:<id>}} line.
+## FORWARD: <one-line forward prediction>   # OPTIONAL.`,
 };
 
-const VALID_KINDS = Object.keys(KINDS);
+const LABELS = {
+  readin: 'Read-in', brief: 'Brief', dossier: 'Dossier', split: 'Split', arc: 'Arc',
+};
 
 function systemPromptFor(kind) {
-  const entry = KINDS[kind];
-  return entry ? entry.system : null;
+  const contract = CONTRACTS[kind];
+  if (!contract) return null;
+  return `You are Tape, an editorial finance assistant producing a structured \`${kind}\`
+(${LABELS[kind]}) result for the Tape UI. Your output is parsed by a STRICT
+client-side parser that splits the response on exact marker lines.
+
+Follow the marker contract below VERBATIM:
+- Use ONLY these markers, in this order, with these EXACT names and literal
+  punctuation (\`|\`, \`:\`). The marker name is case-insensitive but the
+  structure is literal.
+- Do NOT use markers from other Tape result types (e.g. ## TOPIC, ## CONTEXT,
+  ## PUBLISHER) unless they appear in the contract below.
+- Ground every claim ONLY in the supplied candidate quotes. Do not invent facts,
+  numbers, names, or quotes.
+- Every {{clip:<id>}} token MUST reference a pineconeId from the candidate pool
+  in the user message. Never invent ids; never cite an id not in the pool. Put a
+  citation on its own line where the contract shows one.
+- OPTIONAL sections: if the candidate pool does not confidently support a section
+  marked OPTIONAL, OMIT that section entirely (header AND body). Returning less is
+  better than empty scaffolding.
+- Output no preamble, explanation, or text outside the markers. Start directly
+  with the first marker.
+
+If the candidates are too sparse or off-topic to produce even the REQUIRED
+sections, output EXACTLY this line and nothing else:
+${EMPTY_SENTINEL}
+
+MARKER CONTRACT for \`${kind}\`:
+${contract}`;
+}
+
+const VALID_KINDS = Object.keys(CONTRACTS);
+
+// Required-marker validators (case-insensitive on the marker name). Used as a
+// server-side guardrail: if the model failed to emit the required shape, we
+// return synthesizedEmpty rather than letting malformed markers reach the UI.
+function countMatches(text, re) { return (text.match(re) || []).length; }
+
+function hasRequiredMarkers(kind, text) {
+  if (typeof text !== 'string' || !text.trim()) return false;
+  switch (kind) {
+    case 'readin':
+      return /^##\s*WHAT_THEY_DO\b/im.test(text);
+    case 'brief':
+      return /^#\s*HEADLINE\s*:/im.test(text) && /^##\s*PUBLISHER\s*:/im.test(text);
+    case 'dossier':
+      return /^##\s*TOPIC\s*:/im.test(text);
+    case 'split':
+      return countMatches(text, /^##\s*PERSON\s*:/gim) >= 2;
+    case 'arc':
+      return /^##\s*THESIS\s*:/im.test(text)
+        && /^##\s*VERDICT\s*:/im.test(text)
+        && countMatches(text, /^##\s*CALL\b/gim) >= 3;
+    default:
+      return false;
+  }
 }
 
 /** Build the user message: the input framing + the candidate evidence list. */
@@ -110,8 +164,11 @@ function buildUserMessage({ kind, input = {}, candidates = [] }) {
     lines.push(`   "${(c.text || '').replace(/\s+/g, ' ').trim()}"`);
   });
   lines.push('');
-  lines.push('Write the piece now, following the FORMAT for this KIND.');
+  lines.push('Produce the result now, following the MARKER CONTRACT for this KIND exactly.');
   return lines.join('\n');
 }
 
-module.exports = { PROMPT_VERSION, VALID_KINDS, systemPromptFor, buildUserMessage, KINDS };
+module.exports = {
+  PROMPT_VERSION, EMPTY_SENTINEL, VALID_KINDS,
+  systemPromptFor, buildUserMessage, hasRequiredMarkers, CONTRACTS,
+};

--- a/services/tape/tapePrompts.js
+++ b/services/tape/tapePrompts.js
@@ -17,7 +17,9 @@
 
 // v4: appended the `## TICKERS` relevance block to every kind (parsed off into
 // the structured `tickers` field — see synthesize.js). Invalidates v3 caches.
-const PROMPT_VERSION = 'v4';
+// v5: added the `narrative` kind (## THESIS + ## BUCKET | with signed sentiment +
+// optional ## INFLECTION/## FORWARD). Invalidates v4 caches.
+const PROMPT_VERSION = 'v5';
 
 const EMPTY_SENTINEL = 'EMPTY_SYNTHESIS';
 
@@ -31,6 +33,7 @@ const TICKER_GUIDANCE = {
   split: 'What is at stake in the debate — reflect the TOPIC, not the side names. Include peer context. (bulls vs bears on AAPL → AAPL, MSFT, GOOGL; dollar debate → DX-Y.NYB, ^TNX, GLD, BTC-USD.)',
   arc: 'Names referenced IN THE TRACKED THESIS — bias toward the thesis, not the person\'s full beat. (Gromen debt-spiral → GLD, ^TNX, DX-Y.NYB, BTC-USD; Druckenmiller AI capex → NVDA, MSFT, META.)',
   readin: 'The queried company\'s SECTOR PEERS, not the company itself (the client already has the primary ticker). 4-6 peers a finance pro would actually triangulate with — match the company\'s real industry, do NOT default to mega-cap tech unless that IS the sector. (AAPL → MSFT, GOOGL, META, AMZN, NVDA; CRWV → NVDA, ORCL, MSFT, GOOGL; APP/AppLovin → TTD, U, RBLX, META, GOOGL [adtech/gaming]; XOM → CVX, OXY, SLB, COP [energy].) If the queried ticker is not a real listed equity, output no symbols.',
+  narrative: 'Names most exposed to the TOPIC of the narrative, NOT the group filter — pick the same tickers whether the lens is bulls, bears, or a named person. (AI capex narrative → NVDA, MSFT, GOOGL, META, AMZN, AVGO regardless of bull/bear; sovereign debt endgame → GLD, ^TNX, DX-Y.NYB, BTC-USD; rate cuts in 2026 → ^TNX, TLT, GLD, DX-Y.NYB.)',
 };
 
 function tickersBlock(kind) {
@@ -109,10 +112,49 @@ const CONTRACTS = {
 {{clip:<id>}}
 # at least 3 CALL entries REQUIRED; each MUST be followed by a {{clip:<id>}} line.
 ## FORWARD: <one-line forward prediction>   # OPTIONAL.`,
+
+  narrative: `## THESIS: <one-sentence current consensus / the group's current view>   # REQUIRED.
+
+## BUCKET | <ISO start date> | <ISO end date> | <signed sentiment -5..+5>
+<2-3 sentence stance summary for this window>
+{{clip:<id>}}
+{{clip:<id>}}
+
+## BUCKET | <ISO start date> | <ISO end date> | <signed sentiment -5..+5>
+<2-3 sentence stance summary for this window>
+{{clip:<id>}}
+# AT LEAST 3 ## BUCKET blocks REQUIRED, in chronological order oldest→newest.
+# Each bucket carries 1-4 {{clip:<id>}} citations. The sentiment is the THIRD
+# pipe-delimited field and is REQUIRED on EVERY bucket: an integer -5..+5.
+
+## INFLECTION
+- <YYYY-Qn OR ISO date>: <one-sentence what changed and, briefly, why>
+- <...>   # OPTIONAL — omit the whole section (header included) if the candidates don't confidently support it.
+
+## FORWARD: <one-line where this trajectory is heading>   # OPTIONAL — omit if unsupported.
+
+SENTIMENT RUBRIC (the third ## BUCKET field — signed conviction on the THESIS):
+- SIGN = direction. Positive = the prevailing voices in the window SUPPORTED /
+  advanced the thesis; negative = they CONTRADICTED / pushed back; 0 = mixed,
+  ambivalent, or genuinely neutral.
+- A sign-flip across zero between adjacent buckets is a REVERSAL — do NOT smooth
+  it out; if the data reversed, let the numbers reverse.
+- MAGNITUDE (1-5) = how forcefully the position was stated:
+  5 absolute, no hedging ("definitely", "guaranteed", "the only outcome");
+  4 strong ("I'm convinced", "the data is unambiguous");
+  3 confident but caveated ("I think", "probably", "the best read is");
+  2 soft ("could", "might", "leaning toward");
+  1 highly hedged ("possibly", "one scenario is", "not impossible").
+- If the GROUP is a NAMED PERSON: sentiment = THAT person's conviction strength
+  on the thesis; sign reflects whether they support (usually +) or oppose it.
+- If the GROUP is bulls / bears / all: sentiment = the aggregate direction ×
+  confidence of that group's quotes in the window (capitulation can flip it
+  negative).`,
 };
 
 const LABELS = {
   readin: 'Read-in', brief: 'Brief', dossier: 'Dossier', split: 'Split', arc: 'Arc',
+  narrative: 'Narrative',
 };
 
 function systemPromptFor(kind) {
@@ -156,6 +198,23 @@ const VALID_KINDS = Object.keys(CONTRACTS);
 // return synthesizedEmpty rather than letting malformed markers reach the UI.
 function countMatches(text, re) { return (text.match(re) || []).length; }
 
+// Narrative buckets: every `## BUCKET | start | end | sentiment` line MUST carry
+// a parseable signed integer in the THIRD pipe slot, range -5..+5. A missing or
+// malformed sentiment is a compliance failure (→ one auto-retry → 502), since
+// the trajectory chart on the client is driven entirely off these values.
+function narrativeBucketsValid(text) {
+  const lines = text.match(/^##\s*BUCKET\s*\|.*$/gim) || [];
+  if (lines.length < 3) return false;
+  return lines.every((line) => {
+    const parts = line.split('|'); // [ "## BUCKET ", start, end, sentiment ]
+    if (parts.length < 4) return false;
+    const raw = parts[3].trim();
+    if (!/^[+-]?\d+$/.test(raw)) return false;
+    const n = parseInt(raw, 10);
+    return n >= -5 && n <= 5;
+  });
+}
+
 function hasRequiredMarkers(kind, text) {
   if (typeof text !== 'string' || !text.trim()) return false;
   switch (kind) {
@@ -171,6 +230,9 @@ function hasRequiredMarkers(kind, text) {
       return /^##\s*THESIS\s*:/im.test(text)
         && /^##\s*VERDICT\s*:/im.test(text)
         && countMatches(text, /^##\s*CALL\b/gim) >= 3;
+    case 'narrative':
+      return /^##\s*THESIS\s*:/im.test(text)
+        && narrativeBucketsValid(text);
     default:
       return false;
   }
@@ -181,11 +243,15 @@ function hasRequiredMarkers(kind, text) {
 // Note: brief's headline is a single-# `# HEADLINE`, so the forbidden token uses
 // one # to actually catch it leaking into other kinds.
 const FORBIDDEN_CROSS_KIND = {
-  readin: ['## PUBLISHER', '## TOPIC:', '## THESIS', '## PERSON:', '# HEADLINE'],
-  brief: ['## WHAT_THEY_DO', '## PULSE |', '## SMART_MONEY', '## THESIS', '## PERSON:'],
-  dossier: ['## WHAT_THEY_DO', '## PULSE |', '# HEADLINE', '## PUBLISHER', '## THESIS', '## PERSON:'],
-  split: ['## WHAT_THEY_DO', '## PULSE |', '# HEADLINE', '## TOPIC:'],
-  arc: ['## WHAT_THEY_DO', '## PULSE |', '# HEADLINE', '## PUBLISHER', '## PERSON:'],
+  readin: ['## PUBLISHER', '## TOPIC:', '## THESIS', '## PERSON:', '# HEADLINE', '## BUCKET |'],
+  brief: ['## WHAT_THEY_DO', '## PULSE |', '## SMART_MONEY', '## THESIS', '## PERSON:', '## BUCKET |'],
+  dossier: ['## WHAT_THEY_DO', '## PULSE |', '# HEADLINE', '## PUBLISHER', '## THESIS', '## PERSON:', '## BUCKET |'],
+  split: ['## WHAT_THEY_DO', '## PULSE |', '# HEADLINE', '## TOPIC:', '## BUCKET |'],
+  arc: ['## WHAT_THEY_DO', '## PULSE |', '# HEADLINE', '## PUBLISHER', '## PERSON:', '## BUCKET |'],
+  // narrative shares `## THESIS:` (and optional `## FORWARD:`) with arc, so those
+  // are NOT forbidden; everything else from other kinds — including arc's own
+  // `## VERDICT:`/`## CALL` — is, to keep the two time-series kinds distinct.
+  narrative: ['## WHAT_THEY_DO', '## PULSE |', '# HEADLINE', '## PUBLISHER', '## TOPIC:', '## PERSON:', '## VERDICT:', '## CALL'],
 };
 
 /**
@@ -215,6 +281,9 @@ function buildUserMessage({ kind, input = {}, candidates = [], companyHint = nul
   if (input.personB) lines.push(`PERSON B: ${input.personB}`);
   if (input.topic) lines.push(`TOPIC: ${input.topic}`);
   if (input.ticker) lines.push(`TICKER: ${input.ticker}`);
+  // Narrative group filter ('bulls' | 'bears' | 'all' | a named person) — drives
+  // which sentiment lens the model applies (see the narrative SENTIMENT RUBRIC).
+  if (input.group) lines.push(`GROUP: ${input.group}`);
   // Resolved company identity for a ticker the user typed (e.g. "APP" =
   // AppLovin) — lets the model pick sector-correct peer tickers.
   if (companyHint) lines.push(`COMPANY: ${companyHint} — pick sector-appropriate peers/relevant names.`);

--- a/services/tape/tapePrompts.js
+++ b/services/tape/tapePrompts.js
@@ -15,12 +15,40 @@
  * Bump PROMPT_VERSION on any change (it is part of the synthesize cache key).
  */
 
-// v3: rewrote every per-kind contract to the strict client marker shapes
-// (readin WHAT_THEY_DO/PULSE/SMART_MONEY/RISKS, brief HEADLINE/PUBLISHER, arc
-// THESIS/VERDICT/CALL, etc.) + empty-sentinel handling. Invalidates v2 caches.
-const PROMPT_VERSION = 'v3';
+// v4: appended the `## TICKERS` relevance block to every kind (parsed off into
+// the structured `tickers` field — see synthesize.js). Invalidates v3 caches.
+const PROMPT_VERSION = 'v4';
 
 const EMPTY_SENTINEL = 'EMPTY_SYNTHESIS';
+
+// Marker the model appends; synthesize.js parses it off and strips it from text.
+const TICKERS_MARKER = 'TICKERS';
+
+// Per-kind definition of "relevant tickers" (baked into the prompt).
+const TICKER_GUIDANCE = {
+  dossier: 'Tickers this person is on record about — names they are known for covering, plus anything heavily represented in the supplied candidates. Skip names merely mentioned in passing. (El-Erian → ^TNX, DX-Y.NYB, GLD; Cathie Wood → TSLA, COIN, PATH, RBLX.)',
+  brief: 'Tickers most exposed to the story being briefed. For commodity/macro stories include the underlying (CL=F, GLD, ^TNX); for company/sector stories the obvious operators. (Hormuz oil → CL=F, XOM, CVX, OXY, SLB, ^TNX; AI bubble → NVDA, MSFT, GOOGL, META, AMZN, AVGO.)',
+  split: 'What is at stake in the debate — reflect the TOPIC, not the side names. Include peer context. (bulls vs bears on AAPL → AAPL, MSFT, GOOGL; dollar debate → DX-Y.NYB, ^TNX, GLD, BTC-USD.)',
+  arc: 'Names referenced IN THE TRACKED THESIS — bias toward the thesis, not the person\'s full beat. (Gromen debt-spiral → GLD, ^TNX, DX-Y.NYB, BTC-USD; Druckenmiller AI capex → NVDA, MSFT, META.)',
+  readin: 'The queried company\'s SECTOR PEERS, not the company itself (the client already has the primary ticker). 4-6 peers a finance pro would actually triangulate with — match the company\'s real industry, do NOT default to mega-cap tech unless that IS the sector. (AAPL → MSFT, GOOGL, META, AMZN, NVDA; CRWV → NVDA, ORCL, MSFT, GOOGL; APP/AppLovin → TTD, U, RBLX, META, GOOGL [adtech/gaming]; XOM → CVX, OXY, SLB, COP [energy].) If the queried ticker is not a real listed equity, output no symbols.',
+};
+
+function tickersBlock(kind) {
+  return `After all content sections, ALWAYS end with this block:
+## ${TICKERS_MARKER}
+- <SYMBOL>
+- <SYMBOL>
+
+Ticker rules:
+- 4-8 real, currently-listed symbols in RELEVANCE order, highest first.
+- Use the form a user types into Yahoo Finance: US listings preferred; \`^TNX\`
+  for the 10-year, \`DX-Y.NYB\` for the dollar index, \`CL=F\` for crude,
+  \`BTC-USD\`, \`GLD\`, \`TM\` (not 7203.T), \`BRK-B\`.
+- Do NOT fabricate. If the topic is not about specific names, emit the
+  \`## ${TICKERS_MARKER}\` header with NO symbols beneath it.
+- This block is parsed off by the backend and NOT shown to the user.
+- Relevance for this kind: ${TICKER_GUIDANCE[kind]}`;
+}
 
 // --- per-kind marker contract blocks (pasted verbatim into the prompt) ---
 
@@ -116,7 +144,9 @@ sections, output EXACTLY this line and nothing else:
 ${EMPTY_SENTINEL}
 
 MARKER CONTRACT for \`${kind}\`:
-${contract}`;
+${contract}
+
+${tickersBlock(kind)}`;
 }
 
 const VALID_KINDS = Object.keys(CONTRACTS);
@@ -147,13 +177,16 @@ function hasRequiredMarkers(kind, text) {
 }
 
 /** Build the user message: the input framing + the candidate evidence list. */
-function buildUserMessage({ kind, input = {}, candidates = [] }) {
+function buildUserMessage({ kind, input = {}, candidates = [], companyHint = null }) {
   const lines = [];
   lines.push(`KIND: ${kind}`);
   if (input.person) lines.push(`PERSON: ${input.person}`);
   if (input.personB) lines.push(`PERSON B: ${input.personB}`);
   if (input.topic) lines.push(`TOPIC: ${input.topic}`);
   if (input.ticker) lines.push(`TICKER: ${input.ticker}`);
+  // Resolved company identity for a ticker the user typed (e.g. "APP" =
+  // AppLovin) — lets the model pick sector-correct peer tickers.
+  if (companyHint) lines.push(`COMPANY: ${companyHint} — pick sector-appropriate peers/relevant names.`);
   lines.push('');
   lines.push('CANDIDATE QUOTES (cite by pineconeId):');
   candidates.forEach((c, i) => {
@@ -169,6 +202,6 @@ function buildUserMessage({ kind, input = {}, candidates = [] }) {
 }
 
 module.exports = {
-  PROMPT_VERSION, EMPTY_SENTINEL, VALID_KINDS,
+  PROMPT_VERSION, EMPTY_SENTINEL, TICKERS_MARKER, VALID_KINDS,
   systemPromptFor, buildUserMessage, hasRequiredMarkers, CONTRACTS,
 };

--- a/services/tape/tapePrompts.js
+++ b/services/tape/tapePrompts.js
@@ -21,7 +21,7 @@
 // optional ## INFLECTION/## FORWARD). Invalidates v4 caches.
 // v6: narrative adaptive cadence — variable-width buckets by density, floor
 // relaxed from 3 to 1 bucket. Invalidates v5 caches.
-const PROMPT_VERSION = 'v6';
+const PROMPT_VERSION = 'v7';
 
 const EMPTY_SENTINEL = 'EMPTY_SYNTHESIS';
 
@@ -59,17 +59,21 @@ Ticker rules:
 
 const CONTRACTS = {
   readin: `## WHAT_THEY_DO
-<2-3 paragraph plain-English primer on the company. REQUIRED.>
+<2-3 paragraph plain-English primer on the company, BUILT FROM THE SUPPLIED
+QUOTES (not general knowledge). REQUIRED. Cite the specific quotes you draw on
+inline with {{clip:<id>}} — at least 2 across the primer.>
 
 ## PULSE | BULL: <one-sentence bull case> | BEAR: <one-sentence bear case>
-{{clip:<id>}}   # the single strongest marquee quote. OPTIONAL section.
+{{clip:<id>}}   # the single strongest marquee quote. OPTIONAL — but if you emit
+                # this header you MUST put a {{clip:<id>}} under it.
 
 ## SMART_MONEY: BULL
 {{clip:<id>}}
-{{clip:<id>}}   # OPTIONAL section.
+{{clip:<id>}}   # OPTIONAL — omit the header entirely if you have no bull quotes
+                # to cite. NEVER emit this header with no {{clip:<id>}} beneath it.
 
 ## SMART_MONEY: BEAR
-{{clip:<id>}}   # OPTIONAL section.
+{{clip:<id>}}   # OPTIONAL — same rule: omit if no bear quote; never empty.
 
 ## RISKS
 - <one-line risk>
@@ -289,6 +293,7 @@ function buildUserMessage({ kind, input = {}, candidates = [], companyHint = nul
   if (input.person) lines.push(`PERSON: ${input.person}`);
   if (input.personB) lines.push(`PERSON B: ${input.personB}`);
   if (input.topic) lines.push(`TOPIC: ${input.topic}`);
+  if (input.group) lines.push(`GROUP / LENS: ${input.group} (apply the sentiment rubric to this group's view)`);
   if (input.ticker) lines.push(`TICKER: ${input.ticker}`);
   // Narrative group filter ('bulls' | 'bears' | 'all' | a named person) — drives
   // which sentiment lens the model applies (see the narrative SENTIMENT RUBRIC).

--- a/services/tape/tapePrompts.js
+++ b/services/tape/tapePrompts.js
@@ -176,6 +176,37 @@ function hasRequiredMarkers(kind, text) {
   }
 }
 
+// Markers that must NOT appear in a given kind (cross-kind bleed). Matched as
+// case-insensitive substrings. Each kind's own legitimate markers are excluded.
+// Note: brief's headline is a single-# `# HEADLINE`, so the forbidden token uses
+// one # to actually catch it leaking into other kinds.
+const FORBIDDEN_CROSS_KIND = {
+  readin: ['## PUBLISHER', '## TOPIC:', '## THESIS', '## PERSON:', '# HEADLINE'],
+  brief: ['## WHAT_THEY_DO', '## PULSE |', '## SMART_MONEY', '## THESIS', '## PERSON:'],
+  dossier: ['## WHAT_THEY_DO', '## PULSE |', '# HEADLINE', '## PUBLISHER', '## THESIS', '## PERSON:'],
+  split: ['## WHAT_THEY_DO', '## PULSE |', '# HEADLINE', '## TOPIC:'],
+  arc: ['## WHAT_THEY_DO', '## PULSE |', '# HEADLINE', '## PUBLISHER', '## PERSON:'],
+};
+
+/**
+ * Validate a synthesis response against the requested kind's marker contract:
+ * all REQUIRED markers present AND no FORBIDDEN cross-kind markers leaked.
+ *
+ * @returns {{ ok:boolean, reason:string|null, missing:boolean, leaked:string[] }}
+ */
+function validateKindCompliance(kind, text) {
+  const t = typeof text === 'string' ? text : '';
+  if (!hasRequiredMarkers(kind, t)) {
+    return { ok: false, reason: `missing required ${kind} markers`, missing: true, leaked: [] };
+  }
+  const lower = t.toLowerCase();
+  const leaked = (FORBIDDEN_CROSS_KIND[kind] || []).filter((m) => lower.includes(m.toLowerCase()));
+  if (leaked.length) {
+    return { ok: false, reason: `cross-kind markers leaked into ${kind}: ${leaked.join(', ')}`, missing: false, leaked };
+  }
+  return { ok: true, reason: null, missing: false, leaked: [] };
+}
+
 /** Build the user message: the input framing + the candidate evidence list. */
 function buildUserMessage({ kind, input = {}, candidates = [], companyHint = null }) {
   const lines = [];
@@ -203,5 +234,6 @@ function buildUserMessage({ kind, input = {}, candidates = [], companyHint = nul
 
 module.exports = {
   PROMPT_VERSION, EMPTY_SENTINEL, TICKERS_MARKER, VALID_KINDS,
-  systemPromptFor, buildUserMessage, hasRequiredMarkers, CONTRACTS,
+  systemPromptFor, buildUserMessage, hasRequiredMarkers, validateKindCompliance,
+  FORBIDDEN_CROSS_KIND, CONTRACTS,
 };

--- a/services/tape/tapeShared.js
+++ b/services/tape/tapeShared.js
@@ -26,6 +26,7 @@ function candidateFromResult(r) {
     text: r.quote || '',
     episodeTitle: r.episode || null,
     creator: r.creator || null,
+    feedId: r.feedId != null ? String(r.feedId) : null, // for source gating (tapeTaste.feed_allow)
     episodeImage: r.episodeImage && r.episodeImage !== 'Image unavailable' ? r.episodeImage : null,
     audioUrl: r.audioUrl && r.audioUrl !== 'URL unavailable' ? r.audioUrl : null,
     startTime: Number.isFinite(start) ? start : null,

--- a/services/tape/tapeShared.js
+++ b/services/tape/tapeShared.js
@@ -20,6 +20,7 @@ function candidateFromResult(r) {
   const spanSec = Number.isFinite(start) && Number.isFinite(end)
     ? Math.round(end - start)
     : null;
+  const sim = r.similarity && Number.isFinite(r.similarity.combined) ? r.similarity.combined : null;
   return {
     pineconeId: r.shareLink,
     text: r.quote || '',
@@ -31,6 +32,7 @@ function candidateFromResult(r) {
     endTime: Number.isFinite(end) ? end : null,
     publishedDate: r.date && r.date !== 'Date not provided' ? r.date : null,
     spanSec,
+    similarity: sim, // vector relevance (0..1); null for lexical-only / literal hits
   };
 }
 

--- a/services/tape/tapeShared.js
+++ b/services/tape/tapeShared.js
@@ -1,0 +1,70 @@
+/**
+ * Small shared helpers for the Tape recipes: map a searchQuotes result to the
+ * TapeCitation candidate shape, validate dates, and hash request bodies for
+ * cache keys.
+ */
+
+const crypto = require('crypto');
+const { TapeHttpError } = require('./tapeErrors');
+
+/**
+ * Map a `searchQuotes` result object to the TapeCitation candidate shape.
+ * Field mapping (see services/searchQuotesService.js result builder):
+ *   pineconeId <- shareLink, text <- quote, episodeTitle <- episode,
+ *   startTime/endTime <- timeContext, publishedDate <- date.
+ */
+function candidateFromResult(r) {
+  if (!r || !r.shareLink) return null;
+  const start = r.timeContext?.start_time;
+  const end = r.timeContext?.end_time;
+  const spanSec = Number.isFinite(start) && Number.isFinite(end)
+    ? Math.round(end - start)
+    : null;
+  return {
+    pineconeId: r.shareLink,
+    text: r.quote || '',
+    episodeTitle: r.episode || null,
+    creator: r.creator || null,
+    episodeImage: r.episodeImage && r.episodeImage !== 'Image unavailable' ? r.episodeImage : null,
+    audioUrl: r.audioUrl && r.audioUrl !== 'URL unavailable' ? r.audioUrl : null,
+    startTime: Number.isFinite(start) ? start : null,
+    endTime: Number.isFinite(end) ? end : null,
+    publishedDate: r.date && r.date !== 'Date not provided' ? r.date : null,
+    spanSec,
+  };
+}
+
+/** Validate an optional YYYY-MM-DD date. Returns the string or null; throws 400 if malformed. */
+function validateDate(value, label) {
+  if (value == null || value === '') return null;
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}/.test(value)) {
+    throw new TapeHttpError(400, 'bad-request', 'Bad request', `${label} must be an ISO date (YYYY-MM-DD)`);
+  }
+  return value;
+}
+
+/** Stable SHA-256 of a canonicalized object, for cache keys. */
+function hashBody(obj) {
+  const canonical = JSON.stringify(sortKeys(obj || {}));
+  return crypto.createHash('sha256').update(canonical).digest('hex');
+}
+
+function sortKeys(value) {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (value && typeof value === 'object') {
+    return Object.keys(value).sort().reduce((acc, k) => {
+      // ignore control flags that must not affect the cache identity
+      if (k === '_nocache' || k === 'refresh') return acc;
+      acc[k] = sortKeys(value[k]);
+      return acc;
+    }, {});
+  }
+  return value;
+}
+
+/** Sorted list of candidate pineconeIds — the identity set for revalidation. */
+function candidateIds(body) {
+  return (body?.candidates || []).map((c) => c.pineconeId).filter(Boolean).sort();
+}
+
+module.exports = { candidateFromResult, validateDate, hashBody, candidateIds };

--- a/services/tape/tapeStore.js
+++ b/services/tape/tapeStore.js
@@ -21,11 +21,20 @@ const { printLog } = require('../../constants');
 
 const nowIso = () => new Date().toISOString();
 
+// Bounded LRU cap for the in-memory response cache (no Redis path). At ~10-14 KB
+// per Tape payload (measured), 2000 entries ≈ ~25 MB — expansive but trivial for
+// the box, and it closes the latent unbounded-Map growth on long uptime. The warm
+// set (~150 read-ins) is <8% of this, so organic traffic won't evict warmed
+// entries before the next daily warm. With Redis, use its own maxmemory/allkeys-lru
+// instead — this cap only governs the in-process Map. Counters are excluded (TTL-
+// bounded and tiny).
+const CACHE_MAX_ENTRIES = Math.max(1, parseInt(process.env.TAPE_CACHE_MAX_ENTRIES || '2000', 10));
+
 // ----------------------------------------------------------------------------
 // In-memory backend
 // ----------------------------------------------------------------------------
 function createMemoryStore() {
-  const cache = new Map();    // key -> { value, expiresAt }
+  const cache = new Map();    // key -> { value, expiresAt } — Map preserves insertion order; we use it as an LRU
   const counters = new Map(); // key -> { count, expiresAt }
 
   // Periodic sweep so abandoned keys don't leak. Unref so it never holds the
@@ -43,10 +52,20 @@ function createMemoryStore() {
       const e = cache.get(key);
       if (!e) return null;
       if (e.expiresAt <= Date.now()) { cache.delete(key); return null; }
+      // LRU touch: re-insert so this key becomes most-recently-used.
+      cache.delete(key);
+      cache.set(key, e);
       return e.value;
     },
     async setJSON(key, value, ttlSec) {
+      cache.delete(key); // ensure re-insert lands at the most-recent end
       cache.set(key, { value, expiresAt: Date.now() + ttlSec * 1000 });
+      // Evict least-recently-used (oldest insertion) while over the cap.
+      while (cache.size > CACHE_MAX_ENTRIES) {
+        const lru = cache.keys().next().value;
+        if (lru === undefined) break;
+        cache.delete(lru);
+      }
     },
     async incrWindow(key, ttlSec) {
       const t = Date.now();
@@ -120,7 +139,7 @@ if (process.env.REDIS_URL) {
   }
 } else {
   store = createMemoryStore();
-  printLog('[tapeStore] using in-memory backend (no REDIS_URL)');
+  printLog(`[tapeStore] using in-memory backend (no REDIS_URL); LRU cap ${CACHE_MAX_ENTRIES} entries`);
 }
 
 /**

--- a/services/tape/tapeStore.js
+++ b/services/tape/tapeStore.js
@@ -1,0 +1,150 @@
+/**
+ * Pluggable cache + counter store for /api/tape/*.
+ *
+ * Interface (used by every handler — never branch on backend in handlers):
+ *   getJSON(key)                 -> Promise<value|null>
+ *   setJSON(key, value, ttlSec)  -> Promise<void>     (stamps cachedAt alongside)
+ *   incrWindow(key, ttlSec)      -> Promise<number>   (rate-limit counter)
+ *   addAndGet(key, n, ttlSec)    -> Promise<number>   (running total, e.g. daily cap)
+ *
+ * Backend selection:
+ *   - REDIS_URL set  -> Redis adapter (lazy `require('ioredis')`, so the dep is
+ *                       only needed when Redis is actually enabled).
+ *   - otherwise      -> in-process Map + TTL (zero infra; fine for the demo,
+ *                       per-container under autoscale).
+ *
+ * Values are stored as `{ v, cachedAt }` so callers can reconstruct the
+ * freshness `_meta` block on a cache hit.
+ */
+
+const { printLog } = require('../../constants');
+
+const nowIso = () => new Date().toISOString();
+
+// ----------------------------------------------------------------------------
+// In-memory backend
+// ----------------------------------------------------------------------------
+function createMemoryStore() {
+  const cache = new Map();    // key -> { value, expiresAt }
+  const counters = new Map(); // key -> { count, expiresAt }
+
+  // Periodic sweep so abandoned keys don't leak. Unref so it never holds the
+  // process open.
+  const sweep = setInterval(() => {
+    const t = Date.now();
+    for (const [k, e] of cache) if (e.expiresAt <= t) cache.delete(k);
+    for (const [k, e] of counters) if (e.expiresAt <= t) counters.delete(k);
+  }, 60_000);
+  if (typeof sweep.unref === 'function') sweep.unref();
+
+  return {
+    backend: 'memory',
+    async getJSON(key) {
+      const e = cache.get(key);
+      if (!e) return null;
+      if (e.expiresAt <= Date.now()) { cache.delete(key); return null; }
+      return e.value;
+    },
+    async setJSON(key, value, ttlSec) {
+      cache.set(key, { value, expiresAt: Date.now() + ttlSec * 1000 });
+    },
+    async incrWindow(key, ttlSec) {
+      const t = Date.now();
+      const e = counters.get(key);
+      if (!e || e.expiresAt <= t) {
+        counters.set(key, { count: 1, expiresAt: t + ttlSec * 1000 });
+        return 1;
+      }
+      e.count += 1;
+      return e.count;
+    },
+    async addAndGet(key, n, ttlSec) {
+      const t = Date.now();
+      const e = counters.get(key);
+      if (!e || e.expiresAt <= t) {
+        counters.set(key, { count: n, expiresAt: t + ttlSec * 1000 });
+        return n;
+      }
+      e.count += n;
+      return e.count;
+    },
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Redis backend (opt-in)
+// ----------------------------------------------------------------------------
+function createRedisStore(url) {
+  // eslint-disable-next-line global-require, import/no-unresolved
+  const Redis = require('ioredis'); // only loaded when REDIS_URL is set
+  const client = new Redis(url, { lazyConnect: false, maxRetriesPerRequest: 2 });
+  client.on('error', (err) => printLog(`[tapeStore] redis error: ${err.message}`));
+
+  return {
+    backend: 'redis',
+    async getJSON(key) {
+      const raw = await client.get(key);
+      if (!raw) return null;
+      try { return JSON.parse(raw); } catch (_) { return null; }
+    },
+    async setJSON(key, value, ttlSec) {
+      await client.set(key, JSON.stringify(value), 'EX', Math.max(1, Math.ceil(ttlSec)));
+    },
+    async incrWindow(key, ttlSec) {
+      const count = await client.incr(key);
+      if (count === 1) await client.expire(key, Math.max(1, Math.ceil(ttlSec)));
+      return count;
+    },
+    async addAndGet(key, n, ttlSec) {
+      const total = await client.incrby(key, n);
+      // Set expiry once (when the key is first created). incrby on a fresh key
+      // returns n; treat that as "first write" and stamp the TTL.
+      if (total === n) await client.expire(key, Math.max(1, Math.ceil(ttlSec)));
+      return total;
+    },
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Selection
+// ----------------------------------------------------------------------------
+let store;
+if (process.env.REDIS_URL) {
+  try {
+    store = createRedisStore(process.env.REDIS_URL);
+    printLog('[tapeStore] using Redis backend (REDIS_URL set)');
+  } catch (err) {
+    console.warn(`[tapeStore] REDIS_URL set but Redis init failed (${err.message}); ` +
+      `falling back to in-memory. Did you \`npm i ioredis\`?`);
+    store = createMemoryStore();
+  }
+} else {
+  store = createMemoryStore();
+  printLog('[tapeStore] using in-memory backend (no REDIS_URL)');
+}
+
+/**
+ * Cache helper that stamps cachedAt with the stored value and returns it on
+ * read so freshness `_meta` can be reconstructed.
+ *
+ *   setCached(key, value, ttlSec) -> stores { v: value, cachedAt }
+ *   getCached(key)                -> { value, cachedAt } | null
+ */
+async function setCached(key, value, ttlSec) {
+  await store.setJSON(key, { v: value, cachedAt: nowIso() }, ttlSec);
+}
+async function getCached(key) {
+  const wrapped = await store.getJSON(key);
+  if (!wrapped || typeof wrapped !== 'object') return null;
+  return { value: wrapped.v, cachedAt: wrapped.cachedAt || nowIso() };
+}
+
+module.exports = {
+  store,
+  backend: store.backend,
+  setCached,
+  getCached,
+  // raw passthroughs for counters / caps
+  incrWindow: (...a) => store.incrWindow(...a),
+  addAndGet: (...a) => store.addAndGet(...a),
+};

--- a/services/tape/tapeTaste.js
+++ b/services/tape/tapeTaste.js
@@ -24,6 +24,7 @@ let cachedMtimeMs = 0;
 const DEFAULTS = {
   mainstream_allow: [],
   mainstream_deny: [],
+  feed_allow: {},
   dedicated_match: 'last-name',
   confidence_signals: {
     dedicated_weight: 0.4, mainstream_weight: 0.3, span_weight: 0.3,
@@ -52,9 +53,12 @@ function load() {
       mainstream_deny: (parsed.mainstream_deny || []).map((s) => String(s).toLowerCase()),
       bull_keywords: (parsed.bull_keywords || []).map((s) => String(s).toLowerCase()),
       bear_keywords: (parsed.bear_keywords || []).map((s) => String(s).toLowerCase()),
+      feed_allow: parsed.feed_allow || {},
     };
+    // Canonical feedId allowlist as a Set of strings for O(1) lookup.
+    cached.feedAllowSet = new Set(Object.keys(cached.feed_allow).map(String));
     cachedMtimeMs = mtimeMs;
-    printLog(`[tapeTaste] loaded config (${cached.mainstream_allow.length} allow / ${cached.mainstream_deny.length} deny)`);
+    printLog(`[tapeTaste] loaded config (${cached.feedAllowSet.size} feed_allow / ${cached.mainstream_allow.length} creator-fallback / ${cached.mainstream_deny.length} deny)`);
   } catch (err) {
     printLog(`[tapeTaste] failed to parse config (${err.message}) — keeping previous/defaults`);
     if (!cached) cached = { ...DEFAULTS };
@@ -87,12 +91,16 @@ function isBitcoinRelevant(topic) {
 }
 
 /**
- * Whether a candidate's `creator` is an acceptable source for this query.
- * Normal: mainstream allowlist (minus deny). When the topic is bitcoin-relevant,
- * the curated bitcoin-native shows (bitcoin_allow) are admitted too.
+ * Whether a candidate is an acceptable source for this query. CANONICAL signal is
+ * the feedId allowlist (feed_allow) — exact, no substring false-positives, catches
+ * null-creator docs. Falls back to the creator-substring allowlist for feeds not
+ * yet mapped to a feedId. When the topic is bitcoin-relevant, the curated
+ * bitcoin-native shows (bitcoin_allow) are admitted too (still creator-based).
  */
-function isAcceptableSource(creator, { bitcoinMode } = {}) {
-  if (isMainstream(creator)) return true;
+function isAcceptableSource(creator, { feedId, bitcoinMode } = {}) {
+  const cfg = load();
+  if (feedId != null && cfg.feedAllowSet && cfg.feedAllowSet.has(String(feedId))) return true;
+  if (isMainstream(creator)) return true; // creator-substring fallback
   if (bitcoinMode && isBitcoinAllowed(creator)) return true;
   return false;
 }

--- a/services/tape/tapeTaste.js
+++ b/services/tape/tapeTaste.js
@@ -70,6 +70,33 @@ function isMainstream(creator) {
   return cfg.mainstream_allow.some((a) => c.includes(a));
 }
 
+/** Is `creator` one of the curated high-signal bitcoin-native shows? */
+function isBitcoinAllowed(creator) {
+  const cfg = load();
+  const c = String(creator || '').toLowerCase();
+  if (!c) return false;
+  return (cfg.bitcoin_allow || []).some((a) => c.includes(a));
+}
+
+/** Does the topic concern bitcoin / hard-money themes? (admits bitcoin_allow shows) */
+function isBitcoinRelevant(topic) {
+  const cfg = load();
+  const t = String(topic || '').toLowerCase();
+  if (!t) return false;
+  return (cfg.bitcoin_relevance_terms || []).some((term) => t.includes(term));
+}
+
+/**
+ * Whether a candidate's `creator` is an acceptable source for this query.
+ * Normal: mainstream allowlist (minus deny). When the topic is bitcoin-relevant,
+ * the curated bitcoin-native shows (bitcoin_allow) are admitted too.
+ */
+function isAcceptableSource(creator, { bitcoinMode } = {}) {
+  if (isMainstream(creator)) return true;
+  if (bitcoinMode && isBitcoinAllowed(creator)) return true;
+  return false;
+}
+
 function lastNameOf(name) {
   const parts = String(name || '').trim().split(/\s+/).filter(Boolean);
   return parts.length ? parts[parts.length - 1].toLowerCase() : '';
@@ -125,4 +152,7 @@ function classifyBullBear(text) {
   return 'neutral';
 }
 
-module.exports = { isMainstream, isDedicated, scoreConfidence, classifyBullBear, lastNameOf, load };
+module.exports = {
+  isMainstream, isDedicated, scoreConfidence, classifyBullBear, lastNameOf, load,
+  isBitcoinAllowed, isBitcoinRelevant, isAcceptableSource,
+};

--- a/services/tape/tapeTaste.js
+++ b/services/tape/tapeTaste.js
@@ -1,0 +1,128 @@
+/**
+ * Editorial taste config loader + helpers (spec §6).
+ *
+ * Loads config/tape-taste.yaml at startup and lazily reloads when the file's
+ * mtime changes (cheap stat on each access) — no restart / SIGHUP wiring.
+ *
+ * Exposes:
+ *   isMainstream(creator)        -> boolean
+ *   isDedicated(title, name)     -> boolean
+ *   scoreConfidence(signals)     -> { score, tier }
+ *   classifyBullBear(text)       -> 'bull' | 'bear' | 'neutral'
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const { printLog } = require('../../constants');
+
+const CONFIG_PATH = path.join(__dirname, '..', '..', 'config', 'tape-taste.yaml');
+
+let cached = null;
+let cachedMtimeMs = 0;
+
+const DEFAULTS = {
+  mainstream_allow: [],
+  mainstream_deny: [],
+  dedicated_match: 'last-name',
+  confidence_signals: {
+    dedicated_weight: 0.4, mainstream_weight: 0.3, span_weight: 0.3,
+    high_min: 0.7, medium_min: 0.4,
+  },
+  bull_keywords: [],
+  bear_keywords: [],
+};
+
+function load() {
+  let mtimeMs = 0;
+  try {
+    mtimeMs = fs.statSync(CONFIG_PATH).mtimeMs;
+  } catch (_) {
+    if (!cached) { printLog('[tapeTaste] config file missing — using defaults'); cached = { ...DEFAULTS }; }
+    return cached;
+  }
+  if (cached && mtimeMs === cachedMtimeMs) return cached;
+  try {
+    const parsed = yaml.load(fs.readFileSync(CONFIG_PATH, 'utf8')) || {};
+    cached = {
+      ...DEFAULTS,
+      ...parsed,
+      confidence_signals: { ...DEFAULTS.confidence_signals, ...(parsed.confidence_signals || {}) },
+      mainstream_allow: (parsed.mainstream_allow || []).map((s) => String(s).toLowerCase()),
+      mainstream_deny: (parsed.mainstream_deny || []).map((s) => String(s).toLowerCase()),
+      bull_keywords: (parsed.bull_keywords || []).map((s) => String(s).toLowerCase()),
+      bear_keywords: (parsed.bear_keywords || []).map((s) => String(s).toLowerCase()),
+    };
+    cachedMtimeMs = mtimeMs;
+    printLog(`[tapeTaste] loaded config (${cached.mainstream_allow.length} allow / ${cached.mainstream_deny.length} deny)`);
+  } catch (err) {
+    printLog(`[tapeTaste] failed to parse config (${err.message}) — keeping previous/defaults`);
+    if (!cached) cached = { ...DEFAULTS };
+  }
+  return cached;
+}
+
+function isMainstream(creator) {
+  const cfg = load();
+  const c = String(creator || '').toLowerCase();
+  if (!c) return false;
+  if (cfg.mainstream_deny.some((d) => c.includes(d))) return false;
+  return cfg.mainstream_allow.some((a) => c.includes(a));
+}
+
+function lastNameOf(name) {
+  const parts = String(name || '').trim().split(/\s+/).filter(Boolean);
+  return parts.length ? parts[parts.length - 1].toLowerCase() : '';
+}
+
+function isDedicated(title, name) {
+  const cfg = load();
+  const t = String(title || '').toLowerCase();
+  const full = String(name || '').toLowerCase();
+  if (!t || !full) return false;
+  switch (cfg.dedicated_match) {
+    case 'exact-title':
+      return t.includes(full);
+    case 'full-name':
+      return t.includes(full);
+    case 'last-name':
+    default: {
+      const ln = lastNameOf(name);
+      return ln.length >= 2 && t.includes(ln);
+    }
+  }
+}
+
+/**
+ * @param {object} signals
+ * @param {boolean} signals.dedicated
+ * @param {boolean} signals.mainstream
+ * @param {number}  signals.spanRank   normalized 0..1 (longer span = higher)
+ * @param {boolean} [signals.firstPerson]
+ * @returns {{score:number, tier:'high'|'medium'|'low'}}
+ */
+function scoreConfidence({ dedicated, mainstream, spanRank = 0, firstPerson = false }) {
+  const w = load().confidence_signals;
+  let score =
+    (dedicated ? w.dedicated_weight : 0) +
+    (mainstream ? w.mainstream_weight : 0) +
+    (Math.max(0, Math.min(1, spanRank)) * w.span_weight);
+  if (firstPerson) score = Math.min(1, score + 0.05); // small nudge
+  score = parseFloat(score.toFixed(3));
+  let tier = 'low';
+  if (score >= w.high_min) tier = 'high';
+  else if (score >= w.medium_min) tier = 'medium';
+  return { score, tier };
+}
+
+function classifyBullBear(text) {
+  const cfg = load();
+  const t = String(text || '').toLowerCase();
+  const bull = cfg.bull_keywords.reduce((n, k) => n + (t.includes(k) ? 1 : 0), 0);
+  const bear = cfg.bear_keywords.reduce((n, k) => n + (t.includes(k) ? 1 : 0), 0);
+  if (bull > bear) return 'bull';
+  if (bear > bull) return 'bear';
+  return 'neutral';
+}
+
+module.exports = { isMainstream, isDedicated, scoreConfidence, classifyBullBear, lastNameOf, load };

--- a/services/tape/themeExpander.js
+++ b/services/tape/themeExpander.js
@@ -18,7 +18,7 @@ const { printLog } = require('../../constants');
 
 const LLM_ENABLED = process.env.TAPE_THEME_EXPANSION !== 'false';
 const MODEL = process.env.TAPE_THEME_EXPANSION_MODEL || 'gpt-4o-mini';
-const MAX_VARIANTS = 5;
+const MAX_VARIANTS = 7;
 
 // Generic finance framings appended to a topic as a deterministic fallback.
 const TEMPLATE_SUFFIXES = ['outlook', 'forecast', 'price action', 'analysis', 'this week'];
@@ -36,18 +36,30 @@ async function llmVariants(topic, { openai, recordHelperLlmUsage }) {
   try {
     const resp = await openai.chat.completions.create({
       model: MODEL,
-      temperature: 0.3,
-      max_tokens: 200,
+      temperature: 0.2,
+      max_tokens: 220,
       messages: [
         {
           role: 'system',
           content:
-            'You rewrite a finance topic into short phrasings a podcast host or guest would actually say, '
-            + 'for retrieval over transcripts. Output ONLY a JSON array of 3-5 short strings, no prose. '
-            + 'Keep the core subject; vary the framing (outlook, rally, risk, price target, safe haven, etc.). '
-            + 'Do not add tickers or companies not implied by the topic.',
+            'You decompose a finance subject into the distinct ANALYTICAL ANGLES an equity analyst or '
+            + 'macro strategist would actually probe, then phrase each as a short search query a podcast '
+            + 'host/guest would say, for semantic retrieval over transcripts. Output ONLY a JSON array of '
+            + '5-7 strings.\n'
+            + 'RULES:\n'
+            + '- Each phrase 2-5 words, terse and spoken. NOT full sentences. No "the".\n'
+            + '- COVER DISTINCT ANGLES, not rephrasings of the same point. For a COMPANY: profit margins, '
+            + 'revenue growth, competition / moat, customer concentration, valuation, long-term strategy, '
+            + 'guidance / outlook, key risks (e.g. CoreWeave → "CoreWeave profit margins", "CoreWeave '
+            + 'revenue growth", "CoreWeave customer concentration", "CoreWeave debt financing", "CoreWeave '
+            + 'long-term strategy", "CoreWeave valuation", "CoreWeave AI demand"). For a MACRO topic: its '
+            + 'real sub-debates (gold → "gold price target", "gold safe haven", "real rates gold", '
+            + '"central bank gold buying"; AI bubble → "AI capex ROI", "AI valuations bubble", '
+            + '"AI concentration risk", "AI monetization").\n'
+            + '- Lead each phrase with the subject so it stays on-topic. Use real jargon / products / '
+            + 'people / tickers. Stay strictly on the given subject.',
         },
-        { role: 'user', content: `Topic: "${topic}"` },
+        { role: 'user', content: `Subject: "${topic}"\nReturn the JSON array of analyst-angle search phrases.` },
       ],
     });
     const txt = resp?.choices?.[0]?.message?.content || '';

--- a/services/tape/themeExpander.js
+++ b/services/tape/themeExpander.js
@@ -1,0 +1,100 @@
+/**
+ * Theme expansion for topic-quotes (the §4 retrieval side-ask).
+ *
+ * A user-typed topic ("gold prognosis") is often a phrasing nobody says on a
+ * podcast. Before fanning out to search-quotes, expand it into plausible
+ * spoken phrasings ("gold outlook", "gold safe haven", "gold price target", …).
+ *
+ * Two layers:
+ *   1. LLM rewrite (gpt-4o-mini) — best coverage, cached via the topic-quotes
+ *      response so it's paid once per topic. Records helper token usage.
+ *   2. Deterministic template fallback — used when the LLM is disabled, errors,
+ *      or no openai client is available. Cheap synonyms over the head noun.
+ *
+ * Disable the LLM layer with TAPE_THEME_EXPANSION=false (templates still apply).
+ */
+
+const { printLog } = require('../../constants');
+
+const LLM_ENABLED = process.env.TAPE_THEME_EXPANSION !== 'false';
+const MODEL = process.env.TAPE_THEME_EXPANSION_MODEL || 'gpt-4o-mini';
+const MAX_VARIANTS = 5;
+
+// Generic finance framings appended to a topic as a deterministic fallback.
+const TEMPLATE_SUFFIXES = ['outlook', 'forecast', 'price action', 'analysis', 'this week'];
+
+function templateVariants(topic) {
+  const t = String(topic || '').trim();
+  if (!t) return [];
+  // Strip a few weak head words people type but hosts don't say.
+  const cleaned = t.replace(/\b(prognosis|prediction|thoughts|take|vibes)\b/gi, '').replace(/\s+/g, ' ').trim() || t;
+  return TEMPLATE_SUFFIXES.map((s) => `${cleaned} ${s}`);
+}
+
+async function llmVariants(topic, { openai, recordHelperLlmUsage }) {
+  if (!LLM_ENABLED || !openai) return null;
+  try {
+    const resp = await openai.chat.completions.create({
+      model: MODEL,
+      temperature: 0.3,
+      max_tokens: 200,
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You rewrite a finance topic into short phrasings a podcast host or guest would actually say, '
+            + 'for retrieval over transcripts. Output ONLY a JSON array of 3-5 short strings, no prose. '
+            + 'Keep the core subject; vary the framing (outlook, rally, risk, price target, safe haven, etc.). '
+            + 'Do not add tickers or companies not implied by the topic.',
+        },
+        { role: 'user', content: `Topic: "${topic}"` },
+      ],
+    });
+    const txt = resp?.choices?.[0]?.message?.content || '';
+    const usage = resp?.usage;
+    if (usage && typeof recordHelperLlmUsage === 'function') {
+      recordHelperLlmUsage(MODEL, usage.prompt_tokens || 0, usage.completion_tokens || 0);
+    }
+    const match = txt.match(/\[[\s\S]*\]/);
+    if (!match) return null;
+    const arr = JSON.parse(match[0]);
+    if (!Array.isArray(arr)) return null;
+    return arr.map((s) => (typeof s === 'string' ? s.trim() : '')).filter(Boolean);
+  } catch (err) {
+    printLog(`[themeExpander] LLM expansion failed for "${topic}": ${err.message}`);
+    return null;
+  }
+}
+
+/**
+ * Expand a topic into a deduped, capped list of phrasings to fan out over.
+ * Always includes the original `seedThemes` (verbatim, first).
+ *
+ * @param {object} opts
+ * @param {string} opts.topic           the head topic/query
+ * @param {string[]} [opts.seedThemes]  caller-provided themes (kept as-is)
+ * @param {object} opts.deps            { openai, recordHelperLlmUsage }
+ * @returns {Promise<string[]>}
+ */
+async function expandThemes({ topic, seedThemes = [], deps = {} }) {
+  const seen = new Set();
+  const out = [];
+  const push = (s) => {
+    const v = String(s || '').trim();
+    const k = v.toLowerCase();
+    if (v && !seen.has(k)) { seen.add(k); out.push(v); }
+  };
+
+  // 1. Caller-provided themes first (highest intent).
+  seedThemes.forEach(push);
+  if (topic) push(topic);
+
+  // 2. LLM variants, then 3. template fallback (only if LLM gave nothing new).
+  const llm = await llmVariants(topic, deps);
+  if (llm && llm.length) llm.forEach(push);
+  else templateVariants(topic).forEach(push);
+
+  return out.slice(0, Math.max(seedThemes.length, MAX_VARIANTS) + 1);
+}
+
+module.exports = { expandThemes, templateVariants };

--- a/services/tape/tickerExtract.js
+++ b/services/tape/tickerExtract.js
@@ -1,0 +1,55 @@
+/**
+ * Parse the trailing `## TICKERS` block out of a synthesis response, validate
+ * the symbols, and return both the cleaned text (block removed) and the ordered
+ * ticker list. Used by synthesize.js to populate the structured `tickers` field
+ * (the "On the tape" strip) without leaking the block into the rendered text.
+ *
+ * Symbol forms accepted (Yahoo-typed): AAPL, BRK-B, BRK.B, ^TNX, ^GSPC,
+ * DX-Y.NYB, CL=F, BTC-USD, GLD, TM.
+ */
+
+const { TICKERS_MARKER } = require('./tapePrompts');
+
+const HEADER_RE = new RegExp(`^#{1,3}\\s*${TICKERS_MARKER}\\b.*$`, 'im');
+// A single ticker token: optional ^, 1-5 alnum, then up to two .-= suffixes.
+const TICKER_RE = /^\^?[A-Z][A-Z0-9]{0,4}(?:[.\-=][A-Z0-9]{1,4}){0,2}$/;
+const STOPWORDS = new Set(['TICKERS', 'NONE', 'NA', 'N', 'A', 'THE', 'AND', 'ETC', 'TBD']);
+const MAX_TICKERS = 8;
+
+function isTicker(tok) {
+  return TICKER_RE.test(tok) && /[A-Z]/.test(tok) && !STOPWORDS.has(tok);
+}
+
+/**
+ * @param {string} rawText
+ * @returns {{ cleanedText: string, tickers: string[] }}
+ */
+function extractTickers(rawText) {
+  if (typeof rawText !== 'string' || !rawText) return { cleanedText: rawText || '', tickers: [] };
+  const m = rawText.match(HEADER_RE);
+  if (!m || m.index == null) return { cleanedText: rawText, tickers: [] };
+
+  const cleanedText = rawText.slice(0, m.index).replace(/\s+$/, '');
+  const block = rawText.slice(m.index + m[0].length);
+
+  const seen = new Set();
+  const tickers = [];
+  for (const line of block.split('\n')) {
+    // Strip bullet / list punctuation, then scan every token on the line so
+    // both "- AAPL" and "AAPL, MSFT, GOOGL" forms are handled.
+    const cleaned = line.replace(/^[\s\-*•\d.)]+/, '').trim();
+    if (!cleaned) continue;
+    for (const raw of cleaned.split(/[\s,|]+/)) {
+      const tok = raw.toUpperCase().replace(/[.,;]+$/, '');
+      if (isTicker(tok) && !seen.has(tok)) {
+        seen.add(tok);
+        tickers.push(tok);
+        if (tickers.length >= MAX_TICKERS) break;
+      }
+    }
+    if (tickers.length >= MAX_TICKERS) break;
+  }
+  return { cleanedText, tickers };
+}
+
+module.exports = { extractTickers, isTicker };

--- a/services/tape/tickerQuote.js
+++ b/services/tape/tickerQuote.js
@@ -1,0 +1,84 @@
+/**
+ * Ticker quote service (spec §5) — provider-blind.
+ *
+ * Owns caching, market-hours TTL, and the stale-fallback contract; delegates
+ * the actual fetch+parse to the pluggable quote-provider chain (Yahoo default,
+ * Finnhub fallback when FINNHUB_API_KEY is set — see ./quoteProviders).
+ *
+ * Stale-fallback (§10): if every provider throttles/fails, return the last
+ * cached value flagged `stale` rather than failing the request.
+ */
+
+const { getCached, setCached } = require('./tapeStore');
+const { fetchQuoteWithFallback } = require('./quoteProviders');
+const { TIER, quantTtlSec, quantMaxAgeSec, isUsMarketOpen, buildFreshnessMeta } = require('./tapeFreshness');
+const { TapeHttpError } = require('./tapeErrors');
+const { printLog } = require('../../constants');
+
+const cacheKey = (slug) => `tape:q:${slug}`;
+
+function buildBody(quote, source, { cached, cachedAt, fetchedAt, ttl, stale, staleReason }) {
+  return {
+    ...quote,
+    _meta: {
+      source,
+      ...buildFreshnessMeta({
+        tier: TIER.QUANTITATIVE, cached, cachedAt, fetchedAt, ttlSec: ttl, stale, staleReason,
+      }),
+    },
+  };
+}
+
+/**
+ * Get a fully-formed ticker quote response (including `_meta`).
+ * @param {string} slug
+ * @returns {Promise<object>}
+ */
+async function getTickerQuote(slug) {
+  if (!slug || typeof slug !== 'string') {
+    throw new TapeHttpError(400, 'bad-request', 'Bad request', 'slug is required');
+  }
+  const key = cacheKey(slug);
+  const ttl = quantTtlSec({ marketOpen: isUsMarketOpen() });
+
+  // Fresh cache hit?
+  const prior = await getCached(key);
+  if (prior) {
+    const ageSec = (Date.now() - new Date(prior.cachedAt).getTime()) / 1000;
+    if (ageSec < ttl) {
+      return buildBody(prior.value, prior.value._meta?.source || 'cache', {
+        cached: true, cachedAt: prior.cachedAt, fetchedAt: prior.value._meta?.fetchedAt, ttl,
+      });
+    }
+  }
+
+  // Fetch fresh via the provider chain.
+  try {
+    const { quote, source } = await fetchQuoteWithFallback(slug);
+    const fetchedAt = new Date().toISOString();
+    const body = buildBody(quote, source, { cached: false, cachedAt: fetchedAt, fetchedAt, ttl });
+    await setCached(key, body, ttl);
+    return body;
+  } catch (err) {
+    if (err.code === 404) {
+      throw new TapeHttpError(404, 'ticker-not-found', 'Unknown ticker', `No provider returned a result for "${slug}"`);
+    }
+    // Throttled / down: serve last cached value flagged stale (§10).
+    if (prior) {
+      const ageSec = (Date.now() - new Date(prior.cachedAt).getTime()) / 1000;
+      const exceedsCeiling = ageSec > quantMaxAgeSec();
+      printLog(`[tickerQuote] ${slug} all providers failed (${err.message}); serving stale (age=${Math.round(ageSec)}s, exceedsCeiling=${exceedsCeiling})`);
+      return buildBody(prior.value, prior.value._meta?.source || 'cache', {
+        cached: true, cachedAt: prior.cachedAt, fetchedAt: prior.value._meta?.fetchedAt, ttl,
+        stale: true, staleReason: exceedsCeiling ? 'exceeds-quant-freshness' : 'upstream-unavailable',
+      });
+    }
+    if (err.code === 429) {
+      throw new TapeHttpError(429, 'rate-limited', 'Upstream rate limited',
+        'Quote providers are rate limiting; retry shortly.', { creditInfo: { code: 'UPSTREAM_RATE_LIMITED' } });
+    }
+    throw new TapeHttpError(502, 'upstream-failure', 'Upstream failure', `Quote fetch failed: ${err.message}`);
+  }
+}
+
+module.exports = { getTickerQuote };

--- a/services/tape/tickerResolver.js
+++ b/services/tape/tickerResolver.js
@@ -1,0 +1,102 @@
+/**
+ * Ticker → name/alias resolver for Tape retrieval.
+ *
+ * People say or transcribe a company many ways: the ticker (CRWV), the formal
+ * name (CoreWeave Inc), a spaced/camel split (Core Weave), or a nickname /
+ * former name (Atlantic Crypto). This resolver produces the full set of
+ * lowercase match strings for a ticker so retrieval filters (and, later, theme
+ * expansion) can catch any of them.
+ *
+ * Sources, merged:
+ *   1. Curated alias map below (nicknames / pronunciations not derivable from
+ *      the formal name — the only thing that needs hand-maintenance).
+ *   2. The live quote-proxy `name` (Yahoo/Finnhub) — best-effort, async.
+ *   3. Auto-derived variants from whatever name we have (full, significant
+ *      tokens, camelCase-split spaced form).
+ *
+ * Add a ticker to CURATED only when its nicknames can't be derived from the
+ * name (e.g. "atlantic crypto" for CRWV). Everything else falls out for free.
+ */
+
+const { getTickerQuote } = require('./tickerQuote');
+const { printLog } = require('../../constants');
+
+// Hand-maintained nicknames / former names / common pronunciations.
+// `name` is the canonical display name; `aliases` are extra match phrases.
+const CURATED = {
+  CRWV: { name: 'CoreWeave', aliases: ['core weave', 'atlantic crypto'] },
+  ORCL: { name: 'Oracle', aliases: ['oracle cloud', 'oci'] },
+  NVDA: { name: 'NVIDIA', aliases: ['invidia'] },
+  GOOGL: { name: 'Alphabet', aliases: ['google'] },
+  GOOG: { name: 'Alphabet', aliases: ['google'] },
+  META: { name: 'Meta Platforms', aliases: ['facebook', 'instagram'] },
+  TSLA: { name: 'Tesla', aliases: [] },
+  BRKB: { name: 'Berkshire Hathaway', aliases: ['berkshire'] },
+  'BRK.B': { name: 'Berkshire Hathaway', aliases: ['berkshire'] },
+  AMD: { name: 'Advanced Micro Devices', aliases: ['a m d'] },
+  PLTR: { name: 'Palantir', aliases: [] },
+  HOOD: { name: 'Robinhood', aliases: [] },
+  COIN: { name: 'Coinbase', aliases: [] },
+};
+
+const NAME_STOPWORDS = new Set([
+  'inc', 'corp', 'corporation', 'co', 'company', 'group', 'holdings', 'ltd',
+  'plc', 'the', 'sa', 'nv', 'ag', 'class', 'platforms', 'incorporated', 'and',
+]);
+
+/** "CoreWeave" -> "core weave"; "NVIDIA" -> "nvidia" (no-op when no camel hump). */
+function camelSplit(s) {
+  return String(s).replace(/([a-z0-9])([A-Z])/g, '$1 $2').toLowerCase();
+}
+
+function significantTokens(name) {
+  return String(name || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length >= 3 && !NAME_STOPWORDS.has(t));
+}
+
+/**
+ * Build the alias set from a ticker + an optional name (curated or quote-proxy).
+ * Pure (no I/O). Returns { name, aliases } where aliases is a deduped lowercase
+ * array including the ticker, the full name, its spaced/token variants, and any
+ * curated nicknames.
+ */
+function buildAliases(ticker, quoteName) {
+  const tk = String(ticker || '').trim();
+  const curated = CURATED[tk.toUpperCase()];
+  const name = (curated && curated.name) || quoteName || tk;
+
+  const set = new Set();
+  const add = (s) => { const v = String(s || '').trim().toLowerCase(); if (v) set.add(v); };
+
+  add(tk);                       // the ticker itself, e.g. "crwv"
+  add(name);                     // full name, e.g. "coreweave"
+  add(camelSplit(name));         // spaced camel form, e.g. "core weave"
+  significantTokens(name).forEach(add);
+  if (curated) curated.aliases.forEach(add);
+  if (quoteName && quoteName !== name) {
+    add(quoteName);
+    add(camelSplit(quoteName));
+    significantTokens(quoteName).forEach(add);
+  }
+
+  return { name, aliases: [...set] };
+}
+
+/**
+ * Resolve a ticker to { ticker, name, aliases } using curated data + a
+ * best-effort live name lookup via the quote proxy. Never throws.
+ */
+async function resolveTicker(ticker) {
+  let quoteName = null;
+  try {
+    const q = await getTickerQuote(ticker);
+    quoteName = q && q.name && q.name !== ticker ? q.name : null;
+  } catch (_) { /* offline / unknown — fall back to curated/derived */ }
+  const { name, aliases } = buildAliases(ticker, quoteName);
+  printLog(`[tickerResolver] ${ticker} -> "${name}" aliases=[${aliases.join(', ')}]`);
+  return { ticker: String(ticker || '').trim(), name, aliases };
+}
+
+module.exports = { resolveTicker, buildAliases, CURATED };

--- a/services/tape/tickerResolver.js
+++ b/services/tape/tickerResolver.js
@@ -49,6 +49,15 @@ const CURATED = {
 const NAME_STOPWORDS = new Set([
   'inc', 'corp', 'corporation', 'co', 'company', 'group', 'holdings', 'ltd',
   'plc', 'the', 'sa', 'nv', 'ag', 'class', 'platforms', 'incorporated', 'and',
+  // Generic industry/company-type words — distinctive enough to appear in many
+  // off-topic clips, so they must NOT become match aliases (e.g. "Travere
+  // Therapeutics" → "therapeutics" was matching 23andMe / COVID clips as TVTX).
+  'therapeutics', 'therapeutic', 'pharmaceuticals', 'pharmaceutical', 'pharma',
+  'biosciences', 'bioscience', 'biopharmaceutical', 'biopharmaceuticals', 'biotech',
+  'sciences', 'science', 'technologies', 'technology', 'systems', 'solutions',
+  'industries', 'international', 'communications', 'laboratories', 'energy',
+  'financial', 'enterprises', 'resources', 'networks', 'semiconductor',
+  'semiconductors', 'devices', 'partners', 'capital', 'global', 'micro',
 ]);
 
 /** "CoreWeave" -> "core weave"; "NVIDIA" -> "nvidia" (no-op when no camel hump). */

--- a/services/tape/tickerResolver.js
+++ b/services/tape/tickerResolver.js
@@ -37,6 +37,13 @@ const CURATED = {
   PLTR: { name: 'Palantir', aliases: [] },
   HOOD: { name: 'Robinhood', aliases: [] },
   COIN: { name: 'Coinbase', aliases: [] },
+  // Adtech / common short-word tickers that need curation precisely because the
+  // ticker collides with an English word (APP, U) — bare-substring search is
+  // useless for these, so the resolved name is what makes retrieval work.
+  APP: { name: 'AppLovin', aliases: ['app lovin'] },
+  TTD: { name: 'The Trade Desk', aliases: ['trade desk'] },
+  U: { name: 'Unity Software', aliases: ['unity technologies'] },
+  RBLX: { name: 'Roblox', aliases: [] },
 };
 
 const NAME_STOPWORDS = new Set([

--- a/services/tape/topicQuotes.js
+++ b/services/tape/topicQuotes.js
@@ -12,6 +12,8 @@ const { TapeHttpError } = require('./tapeErrors');
 const { candidateFromResult, validateDate } = require('./tapeShared');
 const { resolveTicker } = require('./tickerResolver');
 const { expandThemes } = require('./themeExpander');
+const { resolveHalfLife, rankByRecency, recencyMeta } = require('./recency');
+const { hydrateCandidateDates } = require('./dateHydration');
 const { printLog } = require('../../constants');
 
 const DEFAULTS = {
@@ -130,13 +132,26 @@ async function topicQuotes(input = {}, { openai } = {}) {
       byId.set(cand.pineconeId, cand);
     }
   }
-  let candidates = [...byId.values()].sort((a, b) => (b.spanSec || 0) - (a.spanSec || 0));
+  let candidates = [...byId.values()];
 
-  // Ticker-shaped query → drop company-mismatch noise before capping (§4).
+  // Ticker-shaped query → drop company-mismatch noise before ranking/capping (§4).
   if (TICKER_FILTER_ENABLED && isTickerShaped(topic)) {
     candidates = await filterTickerNoise(topic, candidates, resolved);
   }
-  candidates = candidates.slice(0, f.candidatesLimit);
+
+  // Lazy-fill missing candidate dates from the parent episode before ranking,
+  // so recency decay sees real dates instead of the undated penalty.
+  const dates = await hydrateCandidateDates(candidates);
+
+  // Soft recency weighting: rank by span × exp(-age/half-life) before truncating.
+  // Half-life from the requested kind (brief ~1wk, readin/split 6mo) unless the
+  // caller overrides; Arc-style callers pass disableRecencyWeighting.
+  const recency = resolveHalfLife({
+    kind: input.kind,
+    halfLifeMonths: f.halfLifeMonths,
+    disableRecencyWeighting: f.disableRecencyWeighting,
+  });
+  candidates = rankByRecency(candidates, recency).slice(0, f.candidatesLimit);
 
   // Optional bull/bear tagging on each candidate.
   if (groupBy === 'bull-bear') {
@@ -146,7 +161,7 @@ async function topicQuotes(input = {}, { openai } = {}) {
   const body = {
     query: input.query || themes[0],
     candidates,
-    _meta: { underlying },
+    _meta: { underlying, ...recencyMeta(recency), datesHydrated: dates.hydrated },
   };
 
   // Grouping.

--- a/services/tape/topicQuotes.js
+++ b/services/tape/topicQuotes.js
@@ -310,7 +310,9 @@ async function topicQuotes(input = {}, { openai } = {}) {
   // few clear it, the corpus doesn't cover the topic → empty pool (honest
   // confidence:'empty'). Ticker queries are skipped (the resolver/ticker filter
   // already anchored them on the company name, which won't equal the raw ticker).
-  const terms = isTickerShaped(topic) ? [] : expandTermsWithAliases(topicTerms(topic));
+  // noLiteralAnchor: skip the literal-term gate (used by the industry-fallback
+  // retrieval, which ranks purely on semantic relevance to a broad sector query).
+  const terms = (isTickerShaped(topic) || input.noLiteralAnchor) ? [] : expandTermsWithAliases(topicTerms(topic));
   if (terms.length && candidates.length) {
     const literal = candidates.filter((c) => containsAnyTerm(c.text, terms));
     // Multi-word topics are specific enough that ANY literal coverage is real —

--- a/services/tape/topicQuotes.js
+++ b/services/tape/topicQuotes.js
@@ -31,6 +31,24 @@ const LITERAL_BONUS = parseFloat(process.env.TAPE_LITERAL_BONUS || '0.12');
 // Min literal-matching candidates for a non-ticker topic to be "covered"; below
 // this the pool is emptied (honest confidence:'empty') rather than serving noise.
 const LITERAL_MIN = parseInt(process.env.TAPE_LITERAL_MIN || '3', 10);
+// Drop pure fragments (too short to be a real quote) before ranking/synthesis.
+const MIN_WORDS = parseInt(process.env.TAPE_MIN_WORDS || '6', 10);
+// Source-diversity cap: at most N candidates per creator in the final set, so a
+// single dense show/episode can't dominate (eval: source_diversity 2.2/5,
+// single-publisher Briefs). Overflow is appended after, so the pool never shrinks.
+const PER_CREATOR_MAX = parseInt(process.env.TAPE_PER_CREATOR_MAX || '3', 10);
+function capPerCreator(list, max) {
+  if (!(max > 0)) return list;
+  const counts = new Map();
+  const kept = [];
+  const overflow = [];
+  for (const c of list) {
+    const k = (c.creator || 'unknown').toLowerCase();
+    const n = counts.get(k) || 0;
+    if (n < max) { counts.set(k, n + 1); kept.push(c); } else overflow.push(c);
+  }
+  return kept.concat(overflow); // diverse-first, then the rest (so slice keeps count)
+}
 // Spoken-vs-typed aliases: macro hosts say "BTC" as often as "bitcoin", "eth"
 // for ethereum, "bullion" for gold. Without these the literal anchor rejects a
 // "BTC"-only quote on a "bitcoin" query (and vice-versa). Bidirectional.
@@ -230,6 +248,7 @@ async function topicQuotes(input = {}, { openai } = {}) {
       const cand = candidateFromResult(r);
       if (!cand || !cand.pineconeId || byId.has(cand.pineconeId)) continue;
       if (Number.isFinite(f.minSpan) && cand.spanSec != null && cand.spanSec < f.minSpan) continue;
+      if (String(cand.text || '').trim().split(/\s+/).length < MIN_WORDS) continue; // drop pure fragments
       if (f.mainstream && !taste.isAcceptableSource(cand.creator, { bitcoinMode })) continue;
       byId.set(cand.pineconeId, cand);
     }
@@ -293,6 +312,8 @@ async function topicQuotes(input = {}, { openai } = {}) {
   const terms = isTickerShaped(topic) ? [] : expandTermsWithAliases(topicTerms(topic));
   if (terms.length && candidates.length) {
     const literal = candidates.filter((c) => containsAnyTerm(c.text, terms));
+    // Reverted the multi-word loosening (v5: it traded honest-empty pools for
+    // off-topic filler → more fabrication/off_topic flags). Honest empty is better.
     if (literal.length >= LITERAL_MIN) {
       if (literal.length < candidates.length) printLog(`[topicQuotes] literal-anchor "${topic}" kept ${literal.length}/${candidates.length}`);
       candidates = literal;
@@ -320,7 +341,10 @@ async function topicQuotes(input = {}, { openai } = {}) {
     halfLifeMonths: halfLifeOverride,
     disableRecencyWeighting: f.disableRecencyWeighting,
   });
-  candidates = rankByRecency(candidates, recency, baseScore).slice(0, f.candidatesLimit);
+  // Rank, then apply the per-creator diversity cap before truncating, so a single
+  // dense show can't crowd the final set (improves source diversity / breaks
+  // single-publisher Briefs).
+  candidates = capPerCreator(rankByRecency(candidates, recency, baseScore), PER_CREATOR_MAX).slice(0, f.candidatesLimit);
 
   // Optional bull/bear tagging on each candidate.
   if (groupBy === 'bull-bear') {

--- a/services/tape/topicQuotes.js
+++ b/services/tape/topicQuotes.js
@@ -11,6 +11,7 @@ const taste = require('./tapeTaste');
 const { TapeHttpError } = require('./tapeErrors');
 const { candidateFromResult, validateDate } = require('./tapeShared');
 const { resolveTicker } = require('./tickerResolver');
+const { cardRerankHint } = require('./companyCards');
 const { expandThemes } = require('./themeExpander');
 const { resolveHalfLife, rankByRecency, recencyMeta, defaultRelevance } = require('./recency');
 const { hydrateCandidateDates } = require('./dateHydration');
@@ -274,7 +275,7 @@ async function topicQuotes(input = {}, { openai } = {}) {
       const pool = candidates.length > RERANK_MAX
         ? [...candidates].sort((a, b) => rel(b) - rel(a)).slice(0, RERANK_MAX)
         : candidates;
-      const rr = await rerankClips({ query: searchTopic, clips: pool, openai });
+      const rr = await rerankClips({ query: searchTopic, clips: pool, openai, subjectInfo: isTickerShaped(topic) ? cardRerankHint(topic) : '' });
       if (rr.usage) recordHelperLlmUsage(rr.usage.model, rr.usage.input_tokens, rr.usage.output_tokens);
       underlying.rerankedFrom = pool.length;
       candidates = rr.clips;
@@ -312,13 +313,17 @@ async function topicQuotes(input = {}, { openai } = {}) {
   const terms = isTickerShaped(topic) ? [] : expandTermsWithAliases(topicTerms(topic));
   if (terms.length && candidates.length) {
     const literal = candidates.filter((c) => containsAnyTerm(c.text, terms));
-    // Reverted the multi-word loosening (v5: it traded honest-empty pools for
-    // off-topic filler → more fabrication/off_topic flags). Honest empty is better.
-    if (literal.length >= LITERAL_MIN) {
+    // Multi-word topics are specific enough that ANY literal coverage is real —
+    // only empty on ZERO matches (the strict floor was wrongly emptying covered
+    // topics like Hormuz/energy/gold/oil; v7 had ~8 such false-empties). Single
+    // bare-noun topics keep the stricter floor (a lone "gold" hit is likely noise).
+    // The card-aware reranker now provides the precision the strict floor used to.
+    const floor = terms.length >= 2 ? 1 : LITERAL_MIN;
+    if (literal.length >= floor) {
       if (literal.length < candidates.length) printLog(`[topicQuotes] literal-anchor "${topic}" kept ${literal.length}/${candidates.length}`);
       candidates = literal;
     } else {
-      printLog(`[topicQuotes] "${topic}" — only ${literal.length} literal matches (<${LITERAL_MIN}); treating as uncovered (empty pool)`);
+      printLog(`[topicQuotes] "${topic}" — only ${literal.length} literal matches (<${floor}); treating as uncovered (empty pool)`);
       candidates = [];
     }
   }

--- a/services/tape/topicQuotes.js
+++ b/services/tape/topicQuotes.js
@@ -111,7 +111,7 @@ function escapeRegex(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
  *     case-insensitively.
  * Never reduces a non-empty set to zero. `resolved` is reused if already fetched.
  */
-async function filterTickerNoise(ticker, candidates, resolved) {
+async function filterTickerNoise(ticker, candidates, resolved, opts = {}) {
   if (!candidates.length) return candidates;
   const tk = ticker.trim();
   const r = resolved || await resolveTicker(ticker);
@@ -125,6 +125,15 @@ async function filterTickerNoise(ticker, candidates, resolved) {
   };
   const kept = candidates.filter(matches);
   if (!kept.length) {
+    // Zero clips even name the company. In `strict` mode (read-in pools) that IS the
+    // zero-coverage signal — return empty so runReadin's industry fallback fires
+    // instead of synthesizing a confident read on off-topic noise (e.g. the
+    // Travere↔"TRAVERSE trial" collision). Lenient default keeps the unfiltered set
+    // so an over-strict regex can't accidentally zero a well-covered topic query.
+    if (opts.strict) {
+      printLog(`[topicQuotes] ticker "${tk}" filter matched 0/${candidates.length}; strict → returning empty (no coverage)`);
+      return [];
+    }
     printLog(`[topicQuotes] ticker "${tk}" filter matched 0/${candidates.length}; keeping unfiltered set`);
     return candidates;
   }
@@ -263,7 +272,7 @@ async function topicQuotes(input = {}, { openai } = {}) {
 
   // Ticker-shaped query → drop company-mismatch noise before ranking/capping (§4).
   if (TICKER_FILTER_ENABLED && isTickerShaped(topic)) {
-    candidates = await filterTickerNoise(topic, candidates, resolved);
+    candidates = await filterTickerNoise(topic, candidates, resolved, { strict: input.strictTicker === true });
   }
 
   // Quality gate: reuse the pull path's LLM reranker (utils/clipReranker) to DROP

--- a/services/tape/topicQuotes.js
+++ b/services/tape/topicQuotes.js
@@ -11,6 +11,7 @@ const taste = require('./tapeTaste');
 const { TapeHttpError } = require('./tapeErrors');
 const { candidateFromResult, validateDate } = require('./tapeShared');
 const { resolveTicker } = require('./tickerResolver');
+const { expandThemes } = require('./themeExpander');
 const { printLog } = require('../../constants');
 
 const DEFAULTS = {
@@ -26,27 +27,37 @@ function isTickerShaped(q) {
   return typeof q === 'string' && /^[A-Z]{1,5}$/.test(q.trim());
 }
 
+function escapeRegex(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
+
 /**
- * For ticker-shaped queries (e.g. "CRWV"), drop candidates that don't actually
- * mention the ticker or any resolved name/alias of the company — guards against
- * vector-noise (Crimson Wine "CWGL", leveraged ETFs, similar-letter tickers).
- * Uses the ticker resolver so nicknames / spaced forms ("Core Weave") match too.
- * Never reduces a non-empty set to zero (keeps the original if nothing matches).
+ * For ticker-shaped queries (e.g. "APP"), drop candidates that don't actually
+ * discuss the company. Matching rules avoid the ambiguous-ticker trap (a bare
+ * lowercase "app" substring-matches "happen"/"apple"):
+ *   - the bare ticker matches only as a real symbol — case-sensitive,
+ *     word-bounded (catches "$APP", "NASDAQ: APP", "APP", but not "happen");
+ *   - company name aliases (length ≥ 4, e.g. "applovin", "app lovin") match
+ *     case-insensitively.
+ * Never reduces a non-empty set to zero. `resolved` is reused if already fetched.
  */
-async function filterTickerNoise(ticker, candidates) {
+async function filterTickerNoise(ticker, candidates, resolved) {
   if (!candidates.length) return candidates;
-  const { aliases } = await resolveTicker(ticker);
+  const tk = ticker.trim();
+  const r = resolved || await resolveTicker(ticker);
+  const tickerRe = new RegExp(`(^|[^A-Za-z])${escapeRegex(tk)}([^A-Za-z]|$)`); // case-sensitive
+  const nameAliases = r.aliases.filter((a) => a !== tk.toLowerCase() && a.length >= 4);
   const matches = (c) => {
-    const t = (c.text || '').toLowerCase();
-    return aliases.some((a) => t.includes(a));
+    const text = c.text || '';
+    if (tickerRe.test(text)) return true;
+    const lower = text.toLowerCase();
+    return nameAliases.some((a) => lower.includes(a));
   };
   const kept = candidates.filter(matches);
   if (!kept.length) {
-    printLog(`[topicQuotes] ticker "${ticker}" filter matched 0/${candidates.length}; keeping unfiltered set`);
+    printLog(`[topicQuotes] ticker "${tk}" filter matched 0/${candidates.length}; keeping unfiltered set`);
     return candidates;
   }
   if (kept.length < candidates.length) {
-    printLog(`[topicQuotes] ticker "${ticker}" filter kept ${kept.length}/${candidates.length} (aliases=[${aliases.join(', ')}])`);
+    printLog(`[topicQuotes] ticker "${tk}" filter kept ${kept.length}/${candidates.length} (name="${r.name}")`);
   }
   return kept;
 }
@@ -62,10 +73,13 @@ async function topicQuotes(input = {}, { openai } = {}) {
   const maxDate = validateDate(f.maxDate, 'maxDate');
   const feedIds = Array.isArray(f.feedIds) ? f.feedIds.filter(Boolean) : [];
 
-  const themes = Array.isArray(input.themes) && input.themes.length
+  const seedThemes = Array.isArray(input.themes) && input.themes.length
     ? input.themes.filter((t) => typeof t === 'string' && t.trim())
-    : (typeof input.query === 'string' && input.query.trim() ? [input.query.trim()] : []);
-  if (!themes.length) {
+    : [];
+  const topic = (typeof input.query === 'string' && input.query.trim())
+    ? input.query.trim()
+    : (seedThemes[0] || '');
+  if (!seedThemes.length && !topic) {
     throw new TapeHttpError(400, 'bad-request', 'Bad request', 'query or themes is required');
   }
 
@@ -73,6 +87,27 @@ async function topicQuotes(input = {}, { openai } = {}) {
 
   const underlying = { searchQuotes: 0, helperTokens: 0 };
   const recordHelperLlmUsage = (_m, i = 0, o = 0) => { underlying.helperTokens += (i || 0) + (o || 0); };
+
+  // Ticker-shaped query → resolve to the company and search the NAME, not the
+  // literal ticker. Critical for ambiguous tickers like APP ("app"), U
+  // ("unity") where a bare-string search retrieves noise/nothing.
+  let resolved = null;
+  let searchTopic = topic;
+  if (isTickerShaped(topic)) {
+    resolved = await resolveTicker(topic);
+    if (resolved.name && resolved.name.toLowerCase() !== topic.toLowerCase()) {
+      searchTopic = resolved.name; // e.g. "APP" -> "AppLovin"
+    }
+  }
+
+  // Expand the (resolved) topic into podcast-realistic phrasings before fanning
+  // out, so a user phrasing nobody says ("gold prognosis") or a bare ticker
+  // ("APP") still retrieves. Caller themes are kept verbatim and ranked first.
+  const expand = input.expandThemes !== false;
+  const themes = expand
+    ? await expandThemes({ topic: searchTopic, seedThemes, deps: { openai, recordHelperLlmUsage } })
+    : (seedThemes.length ? seedThemes : [searchTopic]).filter(Boolean);
+  underlying.themes = themes.length;
 
   // Fan out across themes.
   const tasks = themes.map((theme) =>
@@ -98,8 +133,8 @@ async function topicQuotes(input = {}, { openai } = {}) {
   let candidates = [...byId.values()].sort((a, b) => (b.spanSec || 0) - (a.spanSec || 0));
 
   // Ticker-shaped query → drop company-mismatch noise before capping (§4).
-  if (TICKER_FILTER_ENABLED && isTickerShaped(input.query)) {
-    candidates = await filterTickerNoise(input.query, candidates);
+  if (TICKER_FILTER_ENABLED && isTickerShaped(topic)) {
+    candidates = await filterTickerNoise(topic, candidates, resolved);
   }
   candidates = candidates.slice(0, f.candidatesLimit);
 

--- a/services/tape/topicQuotes.js
+++ b/services/tape/topicQuotes.js
@@ -10,6 +10,8 @@ const { searchQuotes } = require('../searchQuotesService');
 const taste = require('./tapeTaste');
 const { TapeHttpError } = require('./tapeErrors');
 const { candidateFromResult, validateDate } = require('./tapeShared');
+const { resolveTicker } = require('./tickerResolver');
+const { printLog } = require('../../constants');
 
 const DEFAULTS = {
   mainstream: true,
@@ -17,6 +19,37 @@ const DEFAULTS = {
   candidatesLimit: 25,
   perThemeLimit: 12,
 };
+
+const TICKER_FILTER_ENABLED = process.env.TAPE_TICKER_FILTER !== 'false';
+
+function isTickerShaped(q) {
+  return typeof q === 'string' && /^[A-Z]{1,5}$/.test(q.trim());
+}
+
+/**
+ * For ticker-shaped queries (e.g. "CRWV"), drop candidates that don't actually
+ * mention the ticker or any resolved name/alias of the company — guards against
+ * vector-noise (Crimson Wine "CWGL", leveraged ETFs, similar-letter tickers).
+ * Uses the ticker resolver so nicknames / spaced forms ("Core Weave") match too.
+ * Never reduces a non-empty set to zero (keeps the original if nothing matches).
+ */
+async function filterTickerNoise(ticker, candidates) {
+  if (!candidates.length) return candidates;
+  const { aliases } = await resolveTicker(ticker);
+  const matches = (c) => {
+    const t = (c.text || '').toLowerCase();
+    return aliases.some((a) => t.includes(a));
+  };
+  const kept = candidates.filter(matches);
+  if (!kept.length) {
+    printLog(`[topicQuotes] ticker "${ticker}" filter matched 0/${candidates.length}; keeping unfiltered set`);
+    return candidates;
+  }
+  if (kept.length < candidates.length) {
+    printLog(`[topicQuotes] ticker "${ticker}" filter kept ${kept.length}/${candidates.length} (aliases=[${aliases.join(', ')}])`);
+  }
+  return kept;
+}
 
 /**
  * @param {object} input
@@ -62,9 +95,13 @@ async function topicQuotes(input = {}, { openai } = {}) {
       byId.set(cand.pineconeId, cand);
     }
   }
-  let candidates = [...byId.values()]
-    .sort((a, b) => (b.spanSec || 0) - (a.spanSec || 0))
-    .slice(0, f.candidatesLimit);
+  let candidates = [...byId.values()].sort((a, b) => (b.spanSec || 0) - (a.spanSec || 0));
+
+  // Ticker-shaped query → drop company-mismatch noise before capping (§4).
+  if (TICKER_FILTER_ENABLED && isTickerShaped(input.query)) {
+    candidates = await filterTickerNoise(input.query, candidates);
+  }
+  candidates = candidates.slice(0, f.candidatesLimit);
 
   // Optional bull/bear tagging on each candidate.
   if (groupBy === 'bull-bear') {

--- a/services/tape/topicQuotes.js
+++ b/services/tape/topicQuotes.js
@@ -29,6 +29,11 @@ const RELEVANCE_FLOOR = parseFloat(process.env.TAPE_RELEVANCE_FLOOR || '0');
 // Soft boost for clips that literally mention a topic noun ("gold") — ranks them
 // above merely-adjacent ones, without hard-filtering proxies (GLD, miners).
 const LITERAL_BONUS = parseFloat(process.env.TAPE_LITERAL_BONUS || '0.12');
+// Soft source preference: allowlisted feeds (feed_allow / mainstream creators) get
+// a ranking BOOST rather than a hard exclude — quality sources float to the top,
+// but non-allowlisted clips still fill the pool when needed (hard-gating Read-in
+// starved its bear side; this favors good sources without the recall hit). 0 = off.
+const SOURCE_BOOST = parseFloat(process.env.TAPE_SOURCE_BOOST || '0.12');
 // Min literal-matching candidates for a non-ticker topic to be "covered"; below
 // this the pool is emptied (honest confidence:'empty') rather than serving noise.
 const LITERAL_MIN = parseInt(process.env.TAPE_LITERAL_MIN || '3', 10);
@@ -250,7 +255,7 @@ async function topicQuotes(input = {}, { openai } = {}) {
       if (!cand || !cand.pineconeId || byId.has(cand.pineconeId)) continue;
       if (Number.isFinite(f.minSpan) && cand.spanSec != null && cand.spanSec < f.minSpan) continue;
       if (String(cand.text || '').trim().split(/\s+/).length < MIN_WORDS) continue; // drop pure fragments
-      if (f.mainstream && !taste.isAcceptableSource(cand.creator, { bitcoinMode })) continue;
+      if (f.mainstream && !taste.isAcceptableSource(cand.creator, { feedId: cand.feedId, bitcoinMode })) continue;
       byId.set(cand.pineconeId, cand);
     }
   }
@@ -332,9 +337,12 @@ async function topicQuotes(input = {}, { openai } = {}) {
 
   // Rank by relevance × recency, span as tiebreaker. (All survivors contain a term
   // after anchoring; the boost only matters for the no-term / ticker fallback.)
+  const srcBoost = SOURCE_BOOST > 0
+    ? (c) => (taste.isAcceptableSource(c.creator, { feedId: c.feedId, bitcoinMode }) ? SOURCE_BOOST : 0)
+    : () => 0;
   const baseScore = terms.length
-    ? (c) => defaultRelevance(c) + (containsAnyTerm(c.text, terms) ? LITERAL_BONUS : 0)
-    : defaultRelevance;
+    ? (c) => defaultRelevance(c) + (containsAnyTerm(c.text, terms) ? LITERAL_BONUS : 0) + srcBoost(c)
+    : (c) => defaultRelevance(c) + srcBoost(c);
 
   // Half-life from the requested kind (brief ~1wk, readin/split 6mo) unless the
   // caller overrides; Arc-style callers pass disableRecencyWeighting. When a Brief

--- a/services/tape/topicQuotes.js
+++ b/services/tape/topicQuotes.js
@@ -14,7 +14,12 @@ const { resolveTicker } = require('./tickerResolver');
 const { expandThemes } = require('./themeExpander');
 const { resolveHalfLife, rankByRecency, recencyMeta, defaultRelevance } = require('./recency');
 const { hydrateCandidateDates } = require('./dateHydration');
+const { getMainstreamFeedIds } = require('./mainstreamFeeds');
+const { rerankClips } = require('../../utils/clipReranker'); // reuse the pull path's quality reranker
 const { printLog } = require('../../constants');
+
+const RERANK_ENABLED = process.env.TAPE_RERANK !== 'false';
+const RERANK_MAX = parseInt(process.env.TAPE_RERANK_MAX || '25', 10); // cap rerank input (scorer token budget)
 
 // Drop vector candidates below this absolute similarity so an uncovered topic
 // returns an empty pool (honest confidence:'empty') instead of adjacent noise.
@@ -26,6 +31,21 @@ const LITERAL_BONUS = parseFloat(process.env.TAPE_LITERAL_BONUS || '0.12');
 // Min literal-matching candidates for a non-ticker topic to be "covered"; below
 // this the pool is emptied (honest confidence:'empty') rather than serving noise.
 const LITERAL_MIN = parseInt(process.env.TAPE_LITERAL_MIN || '3', 10);
+// Spoken-vs-typed aliases: macro hosts say "BTC" as often as "bitcoin", "eth"
+// for ethereum, "bullion" for gold. Without these the literal anchor rejects a
+// "BTC"-only quote on a "bitcoin" query (and vice-versa). Bidirectional.
+const TERM_ALIASES = {
+  bitcoin: ['btc'], btc: ['bitcoin'],
+  ethereum: ['eth'], eth: ['ethereum'],
+  gold: ['bullion'], oil: ['crude', 'wti'],
+  dollar: ['greenback', 'dxy'], treasuries: ['treasury', 'tnx'],
+};
+function expandTermsWithAliases(terms) {
+  const out = new Set(terms);
+  for (const t of terms) (TERM_ALIASES[t] || []).forEach((a) => out.add(a));
+  return [...out];
+}
+
 const TOPIC_STOPWORDS = new Set([
   'the', 'a', 'an', 'and', 'or', 'of', 'for', 'to', 'in', 'on', 'vs', 'this',
   // topic framing words (not the subject)
@@ -126,7 +146,21 @@ async function topicQuotes(input = {}, { openai } = {}) {
   const f = { ...DEFAULTS, ...(input.filters || {}) };
   const minDate = validateDate(f.minDate, 'minDate');
   const maxDate = validateDate(f.maxDate, 'maxDate');
-  const feedIds = Array.isArray(f.feedIds) ? f.feedIds.filter(Boolean) : [];
+  let feedIds = Array.isArray(f.feedIds) ? f.feedIds.filter(Boolean) : [];
+  // Constrain retrieval to allowlisted feeds when mainstream filtering and the
+  // caller didn't pin feeds — otherwise dense niche/denied shows (crypto-native
+  // on a bitcoin query, etc.) crowd mainstream out of the retrieved top-N before
+  // the post-filter runs. Filtering at the source spends the budget on keepers.
+  // Optional (opt-in) feed-constraint: restrict retrieval to allowlisted feeds.
+  // Superseded by the bitcoin-relevance deny-lift below for crowded topics, so
+  // it's OFF by default (it would also exclude the bitcoin_allow shows we now
+  // want to admit). Enable with TAPE_MAINSTREAM_FEED_CONSTRAINT=true.
+  let feedConstraintCount = -1;
+  if (f.mainstream && !feedIds.length && process.env.TAPE_MAINSTREAM_FEED_CONSTRAINT === 'true') {
+    const ms = await getMainstreamFeedIds();
+    feedConstraintCount = ms.length;
+    if (ms.length) feedIds = ms;
+  }
 
   // Brief auto-expanding window: search the WIDEST step up front, then pick the
   // narrowest window that clears the candidate floor (post-fetch, in-memory, so
@@ -153,6 +187,10 @@ async function topicQuotes(input = {}, { openai } = {}) {
 
   const underlying = { searchQuotes: 0, helperTokens: 0 };
   const recordHelperLlmUsage = (_m, i = 0, o = 0) => { underlying.helperTokens += (i || 0) + (o || 0); };
+
+  // Bitcoin/hard-money topics admit the curated bitcoin-native shows (bitcoin_allow)
+  // alongside the mainstream allowlist — for these topics they're the best sources.
+  const bitcoinMode = taste.isBitcoinRelevant(topic);
 
   // Ticker-shaped query → resolve to the company and search the NAME, not the
   // literal ticker. Critical for ambiguous tickers like APP ("app"), U
@@ -192,7 +230,7 @@ async function topicQuotes(input = {}, { openai } = {}) {
       const cand = candidateFromResult(r);
       if (!cand || !cand.pineconeId || byId.has(cand.pineconeId)) continue;
       if (Number.isFinite(f.minSpan) && cand.spanSec != null && cand.spanSec < f.minSpan) continue;
-      if (f.mainstream && !taste.isMainstream(cand.creator)) continue;
+      if (f.mainstream && !taste.isAcceptableSource(cand.creator, { bitcoinMode })) continue;
       byId.set(cand.pineconeId, cand);
     }
   }
@@ -201,6 +239,28 @@ async function topicQuotes(input = {}, { openai } = {}) {
   // Ticker-shaped query → drop company-mismatch noise before ranking/capping (§4).
   if (TICKER_FILTER_ENABLED && isTickerShaped(topic)) {
     candidates = await filterTickerNoise(topic, candidates, resolved);
+  }
+
+  // Quality gate: reuse the pull path's LLM reranker (utils/clipReranker) to DROP
+  // ad reads / sponsor spots (scored 0-1), intros, and shallow clips, and keep
+  // only substantively on-topic quotes (>= minScore). This is what stops a ticker
+  // like CRWV from returning sponsor copy as "analysis". One gpt-4o-mini call,
+  // cached with the response; self-skips when <=2 candidates.
+  if (RERANK_ENABLED && openai && candidates.length > 2) {
+    try {
+      // Cap the rerank input to the top-N by relevance — the scorer's output
+      // budget (~600 tokens) can't score a huge merged pool, and would silently
+      // return it unranked. Pre-sort by similarity so the kept set is the best.
+      const rel = (c) => (Number.isFinite(c.similarity) ? c.similarity : 0.5);
+      const pool = candidates.length > RERANK_MAX
+        ? [...candidates].sort((a, b) => rel(b) - rel(a)).slice(0, RERANK_MAX)
+        : candidates;
+      const rr = await rerankClips({ query: searchTopic, clips: pool, openai });
+      if (rr.usage) recordHelperLlmUsage(rr.usage.model, rr.usage.input_tokens, rr.usage.output_tokens);
+      underlying.rerankedFrom = pool.length;
+      candidates = rr.clips;
+      underlying.rerankedTo = candidates.length;
+    } catch (e) { printLog(`[topicQuotes] rerank skipped: ${e.message}`); }
   }
 
   // Lazy-fill missing candidate dates from the parent episode before window
@@ -230,7 +290,7 @@ async function topicQuotes(input = {}, { openai } = {}) {
   // few clear it, the corpus doesn't cover the topic → empty pool (honest
   // confidence:'empty'). Ticker queries are skipped (the resolver/ticker filter
   // already anchored them on the company name, which won't equal the raw ticker).
-  const terms = isTickerShaped(topic) ? [] : topicTerms(topic);
+  const terms = isTickerShaped(topic) ? [] : expandTermsWithAliases(topicTerms(topic));
   if (terms.length && candidates.length) {
     const literal = candidates.filter((c) => containsAnyTerm(c.text, terms));
     if (literal.length >= LITERAL_MIN) {
@@ -273,6 +333,8 @@ async function topicQuotes(input = {}, { openai } = {}) {
     _meta: {
       underlying, ...recencyMeta(recency), datesHydrated: dates.hydrated,
       ...(autoExpand ? { windowDays, windowExpanded } : {}),
+      mainstreamFeedIds: feedConstraintCount, // telemetry: -1 not attempted, 0 empty, N constrained
+      bitcoinMode, // bitcoin-native shows admitted for this topic
     },
   };
 

--- a/services/tape/topicQuotes.js
+++ b/services/tape/topicQuotes.js
@@ -1,0 +1,98 @@
+/**
+ * topic-quotes recipe (spec §3) — "best quotes ABOUT this topic".
+ *
+ * Powers Brief, Split (camp side), and Read-in's quote layer. Fans out
+ * search-quotes across theme phrasings, dedups, applies the mainstream
+ * allowlist, and optionally groups by creator or bull/bear camp.
+ */
+
+const { searchQuotes } = require('../searchQuotesService');
+const taste = require('./tapeTaste');
+const { TapeHttpError } = require('./tapeErrors');
+const { candidateFromResult, validateDate } = require('./tapeShared');
+
+const DEFAULTS = {
+  mainstream: true,
+  minSpan: 10,
+  candidatesLimit: 25,
+  perThemeLimit: 12,
+};
+
+/**
+ * @param {object} input
+ * @param {object} deps  { openai }
+ * @returns {Promise<{body:object, underlying:object}>}
+ */
+async function topicQuotes(input = {}, { openai } = {}) {
+  const f = { ...DEFAULTS, ...(input.filters || {}) };
+  const minDate = validateDate(f.minDate, 'minDate');
+  const maxDate = validateDate(f.maxDate, 'maxDate');
+  const feedIds = Array.isArray(f.feedIds) ? f.feedIds.filter(Boolean) : [];
+
+  const themes = Array.isArray(input.themes) && input.themes.length
+    ? input.themes.filter((t) => typeof t === 'string' && t.trim())
+    : (typeof input.query === 'string' && input.query.trim() ? [input.query.trim()] : []);
+  if (!themes.length) {
+    throw new TapeHttpError(400, 'bad-request', 'Bad request', 'query or themes is required');
+  }
+
+  const groupBy = input.groupBy === 'creator' || input.groupBy === 'bull-bear' ? input.groupBy : null;
+
+  const underlying = { searchQuotes: 0, helperTokens: 0 };
+  const recordHelperLlmUsage = (_m, i = 0, o = 0) => { underlying.helperTokens += (i || 0) + (o || 0); };
+
+  // Fan out across themes.
+  const tasks = themes.map((theme) =>
+    searchQuotes(
+      { query: theme, feedIds, minDate, maxDate, limit: f.perThemeLimit },
+      { openai, recordHelperLlmUsage },
+    ).then((r) => r.results || []),
+  );
+  const settled = await Promise.all(tasks);
+  underlying.searchQuotes = tasks.length;
+
+  // Dedup, minSpan filter, mainstream allowlist.
+  const byId = new Map();
+  for (const results of settled) {
+    for (const r of results) {
+      const cand = candidateFromResult(r);
+      if (!cand || !cand.pineconeId || byId.has(cand.pineconeId)) continue;
+      if (Number.isFinite(f.minSpan) && cand.spanSec != null && cand.spanSec < f.minSpan) continue;
+      if (f.mainstream && !taste.isMainstream(cand.creator)) continue;
+      byId.set(cand.pineconeId, cand);
+    }
+  }
+  let candidates = [...byId.values()]
+    .sort((a, b) => (b.spanSec || 0) - (a.spanSec || 0))
+    .slice(0, f.candidatesLimit);
+
+  // Optional bull/bear tagging on each candidate.
+  if (groupBy === 'bull-bear') {
+    candidates = candidates.map((c) => ({ ...c, side: taste.classifyBullBear(c.text) }));
+  }
+
+  const body = {
+    query: input.query || themes[0],
+    candidates,
+    _meta: { underlying },
+  };
+
+  // Grouping.
+  if (groupBy === 'creator') {
+    const groups = new Map();
+    for (const c of candidates) {
+      const key = c.creator || 'Unknown';
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key).push(c);
+    }
+    body.groups = [...groups.entries()].map(([key, cands]) => ({ key, candidates: cands }));
+  } else if (groupBy === 'bull-bear') {
+    const groups = { bull: [], bear: [], neutral: [] };
+    for (const c of candidates) groups[c.side].push(c);
+    body.groups = Object.entries(groups).map(([key, cands]) => ({ key, candidates: cands }));
+  }
+
+  return { body, underlying };
+}
+
+module.exports = { topicQuotes, DEFAULTS };

--- a/services/tape/topicQuotes.js
+++ b/services/tape/topicQuotes.js
@@ -12,9 +12,35 @@ const { TapeHttpError } = require('./tapeErrors');
 const { candidateFromResult, validateDate } = require('./tapeShared');
 const { resolveTicker } = require('./tickerResolver');
 const { expandThemes } = require('./themeExpander');
-const { resolveHalfLife, rankByRecency, recencyMeta } = require('./recency');
+const { resolveHalfLife, rankByRecency, recencyMeta, defaultRelevance } = require('./recency');
 const { hydrateCandidateDates } = require('./dateHydration');
 const { printLog } = require('../../constants');
+
+// Drop vector candidates below this absolute similarity so an uncovered topic
+// returns an empty pool (honest confidence:'empty') instead of adjacent noise.
+// Lexical/literal hits (null similarity) bypass. 0 = off; set after calibration.
+const RELEVANCE_FLOOR = parseFloat(process.env.TAPE_RELEVANCE_FLOOR || '0');
+// Soft boost for clips that literally mention a topic noun ("gold") — ranks them
+// above merely-adjacent ones, without hard-filtering proxies (GLD, miners).
+const LITERAL_BONUS = parseFloat(process.env.TAPE_LITERAL_BONUS || '0.12');
+// Min literal-matching candidates for a non-ticker topic to be "covered"; below
+// this the pool is emptied (honest confidence:'empty') rather than serving noise.
+const LITERAL_MIN = parseInt(process.env.TAPE_LITERAL_MIN || '3', 10);
+const TOPIC_STOPWORDS = new Set([
+  'the', 'a', 'an', 'and', 'or', 'of', 'for', 'to', 'in', 'on', 'vs', 'this',
+  // topic framing words (not the subject)
+  'prognosis', 'outlook', 'forecast', 'prediction', 'thoughts', 'take', 'week',
+  'price', 'stock', 'market', 'markets', 'analysis', 'update', 'latest', 'news',
+  // generic ranking/superlative words that match everything
+  'best', 'worst', 'top', 'ranked', 'rankings', 'guide', 'review', 'championship',
+]);
+function topicTerms(topic) {
+  return String(topic || '').toLowerCase().split(/[^a-z0-9]+/).filter((t) => t.length >= 3 && !TOPIC_STOPWORDS.has(t));
+}
+function containsAnyTerm(text, terms) {
+  const t = String(text || '').toLowerCase();
+  return terms.some((term) => t.includes(term));
+}
 
 const DEFAULTS = {
   mainstream: true,
@@ -64,6 +90,33 @@ async function filterTickerNoise(ticker, candidates, resolved) {
   return kept;
 }
 
+const DAY_MS = 86_400_000;
+const BRIEF_WINDOW_STEPS = [7, 30, 90]; // days; widen until >= MIN_BRIEF_CANDIDATES
+const MIN_BRIEF_CANDIDATES = 3;
+const isoDay = (ms) => new Date(ms).toISOString().slice(0, 10);
+
+/**
+ * Brief auto-expanding window: pick the SMALLEST step whose dated candidates
+ * within [asOf - step, asOf] reach MIN_BRIEF_CANDIDATES; else the widest step.
+ * Keeps undated candidates (recency-penalized later). Returns the chosen window
+ * and the filtered set.
+ */
+function selectBriefWindow(candidates, asOfMs, steps = BRIEF_WINDOW_STEPS) {
+  const datedWithin = (days) => candidates.filter((c) => {
+    if (!c.publishedDate) return false;
+    const t = new Date(c.publishedDate).getTime();
+    return Number.isFinite(t) && t >= asOfMs - days * DAY_MS && t <= asOfMs;
+  }).length;
+  let chosen = steps[steps.length - 1];
+  for (const d of steps) { if (datedWithin(d) >= MIN_BRIEF_CANDIDATES) { chosen = d; break; } }
+  const kept = candidates.filter((c) => {
+    if (!c.publishedDate) return true;
+    const t = new Date(c.publishedDate).getTime();
+    return !Number.isFinite(t) || (t >= asOfMs - chosen * DAY_MS && t <= asOfMs);
+  });
+  return { windowDays: chosen, windowExpanded: chosen > steps[0], kept };
+}
+
 /**
  * @param {object} input
  * @param {object} deps  { openai }
@@ -74,6 +127,17 @@ async function topicQuotes(input = {}, { openai } = {}) {
   const minDate = validateDate(f.minDate, 'minDate');
   const maxDate = validateDate(f.maxDate, 'maxDate');
   const feedIds = Array.isArray(f.feedIds) ? f.feedIds.filter(Boolean) : [];
+
+  // Brief auto-expanding window: search the WIDEST step up front, then pick the
+  // narrowest window that clears the candidate floor (post-fetch, in-memory, so
+  // it's one fan-out, not three). Only when kind=brief and the caller didn't pin
+  // an explicit minDate. The asOf (window end) stays fixed; only lookback grows.
+  const autoExpand = input.kind === 'brief' && !f.minDate;
+  const asOfMs = autoExpand
+    ? new Date(input.asOfDate || f.maxDate || Date.now()).getTime()
+    : null;
+  const searchMinDate = autoExpand ? isoDay(asOfMs - BRIEF_WINDOW_STEPS[BRIEF_WINDOW_STEPS.length - 1] * DAY_MS) : minDate;
+  const searchMaxDate = autoExpand ? isoDay(asOfMs) : maxDate;
 
   const seedThemes = Array.isArray(input.themes) && input.themes.length
     ? input.themes.filter((t) => typeof t === 'string' && t.trim())
@@ -114,7 +178,7 @@ async function topicQuotes(input = {}, { openai } = {}) {
   // Fan out across themes.
   const tasks = themes.map((theme) =>
     searchQuotes(
-      { query: theme, feedIds, minDate, maxDate, limit: f.perThemeLimit },
+      { query: theme, feedIds, minDate: searchMinDate, maxDate: searchMaxDate, limit: f.perThemeLimit },
       { openai, recordHelperLlmUsage },
     ).then((r) => r.results || []),
   );
@@ -139,19 +203,64 @@ async function topicQuotes(input = {}, { openai } = {}) {
     candidates = await filterTickerNoise(topic, candidates, resolved);
   }
 
-  // Lazy-fill missing candidate dates from the parent episode before ranking,
-  // so recency decay sees real dates instead of the undated penalty.
+  // Lazy-fill missing candidate dates from the parent episode before window
+  // selection + ranking, so both see real dates instead of the undated penalty.
   const dates = await hydrateCandidateDates(candidates);
 
-  // Soft recency weighting: rank by span × exp(-age/half-life) before truncating.
+  // Brief: narrow to the chosen auto-expand window.
+  let windowDays = null;
+  let windowExpanded = false;
+  if (autoExpand) {
+    const sel = selectBriefWindow(candidates, asOfMs);
+    candidates = sel.kept;
+    windowDays = sel.windowDays;
+    windowExpanded = sel.windowExpanded;
+  }
+
+  // Relevance floor: an uncovered topic should yield an empty pool, not noise.
+  if (RELEVANCE_FLOOR > 0) {
+    const before = candidates.length;
+    candidates = candidates.filter((c) => !Number.isFinite(c.similarity) || c.similarity >= RELEVANCE_FLOOR);
+    if (candidates.length < before) printLog(`[topicQuotes] relevance floor ${RELEVANCE_FLOOR} dropped ${before - candidates.length}/${before} for "${topic}"`);
+  }
+
+  // Literal-term anchoring (the real precision lever — ada-002 similarity is too
+  // compressed to separate covered from uncovered topics). For a non-ticker query
+  // with clear nouns, keep only clips that actually mention a topic term; if too
+  // few clear it, the corpus doesn't cover the topic → empty pool (honest
+  // confidence:'empty'). Ticker queries are skipped (the resolver/ticker filter
+  // already anchored them on the company name, which won't equal the raw ticker).
+  const terms = isTickerShaped(topic) ? [] : topicTerms(topic);
+  if (terms.length && candidates.length) {
+    const literal = candidates.filter((c) => containsAnyTerm(c.text, terms));
+    if (literal.length >= LITERAL_MIN) {
+      if (literal.length < candidates.length) printLog(`[topicQuotes] literal-anchor "${topic}" kept ${literal.length}/${candidates.length}`);
+      candidates = literal;
+    } else {
+      printLog(`[topicQuotes] "${topic}" — only ${literal.length} literal matches (<${LITERAL_MIN}); treating as uncovered (empty pool)`);
+      candidates = [];
+    }
+  }
+
+  // Rank by relevance × recency, span as tiebreaker. (All survivors contain a term
+  // after anchoring; the boost only matters for the no-term / ticker fallback.)
+  const baseScore = terms.length
+    ? (c) => defaultRelevance(c) + (containsAnyTerm(c.text, terms) ? LITERAL_BONUS : 0)
+    : defaultRelevance;
+
   // Half-life from the requested kind (brief ~1wk, readin/split 6mo) unless the
-  // caller overrides; Arc-style callers pass disableRecencyWeighting.
+  // caller overrides; Arc-style callers pass disableRecencyWeighting. When a Brief
+  // auto-expands, COUPLE the half-life to the effective window (~windowDays) —
+  // otherwise the 1-week half-life would decay the widened candidates right back out.
+  const halfLifeOverride = Number.isFinite(f.halfLifeMonths)
+    ? f.halfLifeMonths
+    : (autoExpand ? windowDays / 30.44 : undefined);
   const recency = resolveHalfLife({
     kind: input.kind,
-    halfLifeMonths: f.halfLifeMonths,
+    halfLifeMonths: halfLifeOverride,
     disableRecencyWeighting: f.disableRecencyWeighting,
   });
-  candidates = rankByRecency(candidates, recency).slice(0, f.candidatesLimit);
+  candidates = rankByRecency(candidates, recency, baseScore).slice(0, f.candidatesLimit);
 
   // Optional bull/bear tagging on each candidate.
   if (groupBy === 'bull-bear') {
@@ -161,7 +270,10 @@ async function topicQuotes(input = {}, { openai } = {}) {
   const body = {
     query: input.query || themes[0],
     candidates,
-    _meta: { underlying, ...recencyMeta(recency), datesHydrated: dates.hydrated },
+    _meta: {
+      underlying, ...recencyMeta(recency), datesHydrated: dates.hydrated,
+      ...(autoExpand ? { windowDays, windowExpanded } : {}),
+    },
   };
 
   // Grouping.

--- a/services/tape/warmReadins.js
+++ b/services/tape/warmReadins.js
@@ -1,0 +1,86 @@
+/**
+ * Daily Read-In cache warmer (in-process).
+ *
+ * Walks getWarmTickers() in most-likely-picked order and pre-computes each Read-In
+ * via the SAME computeAndCacheKind() the live request path uses, so a warmed entry
+ * is byte-identical to what a user request would write — the frontend reads its own
+ * cache hit. Warms with refresh:true so it recomputes against new episodes each run.
+ *
+ * IMPORTANT — runs IN the server process. With no Redis the cache is a per-process
+ * Map, so a warmer in a separate process would fill a throwaway cache and exit. The
+ * cron therefore calls warmReadins() in-process (not a spawned child). Under
+ * autoscale each container warms its OWN cache (so we deliberately do NOT take a
+ * distributed lock here — every container must warm itself; cost scales with
+ * container count).
+ *
+ * Budget is bounded by both a $ ceiling and a ticker count; the effective limit is
+ * the smaller of the two. Cost is projected from a per-ticker estimate (predictable
+ * cap) and the actual synth token spend is measured and logged after the run.
+ */
+
+const { getWarmTickers } = require('./warmTickers');
+const { computeAndCacheKind } = require('./tapeEndpoint');
+const { runReadin } = require('./kindOrchestrator');
+const { printLog } = require('../../constants');
+
+const num = (v, d) => { const n = parseFloat(v); return Number.isFinite(n) ? n : d; };
+
+const USD_CAP = num(process.env.TAPE_WARM_USD_CAP, 2);          // $ per warm run
+const MAX_TICKERS = parseInt(process.env.TAPE_WARM_MAX_TICKERS || '150', 10);
+const PER_TICKER = num(process.env.TAPE_WARM_COST_PER_TICKER, 0.0135); // Read-In all-in (Haiku synth + aux LLM), for the cap projection
+const CONCURRENCY = Math.max(1, parseInt(process.env.TAPE_WARM_CONCURRENCY || '3', 10));
+const IN_RATE = num(process.env.TAPE_WARM_IN_RATE, 1);   // $/1M input  (Haiku `fast`)
+const OUT_RATE = num(process.env.TAPE_WARM_OUT_RATE, 5); // $/1M output
+
+/** The number of tickers a run will warm: min(count cap, floor($ cap / per-ticker)). */
+function effectiveLimit() {
+  const byCost = PER_TICKER > 0 ? Math.floor(USD_CAP / PER_TICKER) : MAX_TICKERS;
+  return Math.max(0, Math.min(MAX_TICKERS, byCost));
+}
+
+/**
+ * @param {{ openai: object, log?: (m:string)=>void, limit?: number, only?: string[] }} opts
+ * @returns {Promise<{warmed:number, empty:number, failed:number, synthUsd:number, inTok:number, outTok:number, elapsedSec:number, attempted:number}>}
+ */
+async function warmReadins({ openai, log = printLog, limit, only } = {}) {
+  if (!openai) throw new Error('warmReadins requires an openai client');
+  const all = Array.isArray(only) && only.length ? only.map(String) : getWarmTickers();
+  const cap = Number.isFinite(limit) ? Math.max(0, limit) : effectiveLimit();
+  const tickers = all.slice(0, cap);
+  log(`[TapeWarm] warming ${tickers.length}/${all.length} read-ins (cap $${USD_CAP} / ${MAX_TICKERS} tickers @ ~$${PER_TICKER}/ea; concurrency ${CONCURRENCY})`);
+
+  let warmed = 0; let empty = 0; let failed = 0; let inTok = 0; let outTok = 0;
+  const startedAt = Date.now();
+
+  for (let i = 0; i < tickers.length; i += CONCURRENCY) {
+    const batch = tickers.slice(i, i + CONCURRENCY);
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.all(batch.map(async (ticker) => {
+      const auditId = `warm-readin-${ticker}-${Date.now().toString(36)}`;
+      try {
+        const { out, synthesizedEmpty } = await computeAndCacheKind({
+          kind: 'readin',
+          body: { ticker },
+          run: (b, ctx) => runReadin(b, { ...ctx, openai }),
+          openai,
+          refresh: true,
+          jwtSub: 'warm',
+          auditId,
+        });
+        const tok = out && out._meta && out._meta.tokens;
+        if (tok) { inTok += tok.input || 0; outTok += tok.output || 0; }
+        if (synthesizedEmpty) empty += 1; else warmed += 1;
+      } catch (err) {
+        failed += 1;
+        log(`[TapeWarm] ${ticker} failed: ${err.message}`);
+      }
+    }));
+  }
+
+  const synthUsd = (inTok / 1e6) * IN_RATE + (outTok / 1e6) * OUT_RATE;
+  const elapsedSec = Math.round((Date.now() - startedAt) / 1000);
+  log(`[TapeWarm] done: ${warmed} warmed, ${empty} empty/fallback, ${failed} failed in ${elapsedSec}s; measured synth spend ~$${synthUsd.toFixed(3)} (${inTok} in / ${outTok} out tok; aux LLM not counted)`);
+  return { warmed, empty, failed, synthUsd, inTok, outTok, elapsedSec, attempted: tickers.length };
+}
+
+module.exports = { warmReadins, effectiveLimit, getWarmTickers };

--- a/services/tape/warmReadins.js
+++ b/services/tape/warmReadins.js
@@ -32,6 +32,14 @@ const CONCURRENCY = Math.max(1, parseInt(process.env.TAPE_WARM_CONCURRENCY || '3
 const IN_RATE = num(process.env.TAPE_WARM_IN_RATE, 1);   // $/1M input  (Haiku `fast`)
 const OUT_RATE = num(process.env.TAPE_WARM_OUT_RATE, 5); // $/1M output
 
+// The read-in cache key is ticker-only (see kindCacheKey), so the warmer doesn't
+// need to match the frontend's `model` — it warms with the cheap default model
+// (TAPE_READIN_MODEL, `fast`) by sending only the ticker, and every live read-in
+// request for that ticker (any model) hits this one entry. Cost over fidelity.
+function readinBody(ticker) {
+  return { ticker };
+}
+
 /** The number of tickers a run will warm: min(count cap, floor($ cap / per-ticker)). */
 function effectiveLimit() {
   const byCost = PER_TICKER > 0 ? Math.floor(USD_CAP / PER_TICKER) : MAX_TICKERS;
@@ -60,7 +68,7 @@ async function warmReadins({ openai, log = printLog, limit, only } = {}) {
       try {
         const { out, synthesizedEmpty } = await computeAndCacheKind({
           kind: 'readin',
-          body: { ticker },
+          body: readinBody(ticker),
           run: (b, ctx) => runReadin(b, { ...ctx, openai }),
           openai,
           refresh: true,

--- a/services/tape/warmTickers.js
+++ b/services/tape/warmTickers.js
@@ -1,0 +1,59 @@
+/**
+ * Ticker provider for the daily Read-In cache warmer.
+ *
+ * getWarmTickers() returns an ORDERED list of tickers, most-likely-picked first:
+ *   1. config/tape-hot-tickers.yaml `priority`, in listed order, kept only where a
+ *      company card exists (priority is a preference order, not an allowlist).
+ *   2. the remaining carded tickers by market cap, descending.
+ * Deduped, so each ticker appears once. The warmer slices this to its cost/count cap.
+ *
+ * Tying the universe to the carded set keeps warming to known names (Read-In leans
+ * on card context) and auto-tracks the card list as it grows.
+ *
+ * FUTURE personalization seam (memory project-tape-future-ideas #3): getWarmTickers
+ * accepts an optional `{ userId }`; a per-user watchlist would be prepended ahead of
+ * the generic order here, with no change to the warmer. Generic order stays the
+ * baseline/fallback.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const HOT = path.join(__dirname, '..', '..', 'config', 'tape-hot-tickers.yaml');
+const CARDS = path.join(__dirname, '..', '..', 'config', 'tape-company-cards.yaml');
+
+function loadYaml(p) {
+  try { return yaml.load(fs.readFileSync(p, 'utf8')) || {}; } catch (_) { return {}; }
+}
+
+/**
+ * @param {{ userId?: string }} [opts] reserved for future per-user ordering (unused today)
+ * @returns {string[]} ordered, deduped ticker symbols
+ */
+function getWarmTickers(_opts = {}) {
+  const cards = loadYaml(CARDS);
+  const carded = Object.keys(cards);
+  const cardedSet = new Set(carded);
+
+  const hot = loadYaml(HOT);
+  const priority = Array.isArray(hot.priority) ? hot.priority.map(String) : [];
+
+  const ordered = [];
+  const seen = new Set();
+  const push = (t) => { if (t && cardedSet.has(t) && !seen.has(t)) { seen.add(t); ordered.push(t); } };
+
+  // 1) curated priority, in order (skips any non-carded names)
+  for (const t of priority) push(t);
+
+  // 2) remaining carded tickers by market cap, descending
+  const tail = carded
+    .filter((t) => !seen.has(t))
+    .map((t) => ({ t, mc: Number(cards[t]?.marketCap || cards[t]?.marketcap || 0) }))
+    .sort((a, b) => b.mc - a.mc);
+  for (const { t } of tail) push(t);
+
+  return ordered;
+}
+
+module.exports = { getWarmTickers };

--- a/tests/tape-finnhub-quote.test.js
+++ b/tests/tape-finnhub-quote.test.js
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * Contract suite for the Finnhub quote provider's normalized shape.
+ *
+ *   node tests/tape-finnhub-quote.test.js
+ *
+ * No mocha/jest dependency — pure node assertions. `global.fetch` is stubbed
+ * per scenario so the suite runs offline with no API key and no network.
+ *
+ * Goal: a Finnhub-served quote must be the SAME shape as a Yahoo-served quote
+ * (tape-backend-spec §5) so the frontend can't tell them apart. The sparkline
+ * component renders nothing when spark.length < 2, so the headline guarantee
+ * under test is: spark ALWAYS has >= 2 points, even on the Finnhub free tier
+ * where the historical-candle endpoint 403s.
+ *
+ * A non-zero exit code indicates at least one scenario failed.
+ */
+
+const assert = require('assert');
+
+process.env.FINNHUB_API_KEY = 'test-key'; // make the provider think it's configured
+
+// The provider reads global fetch at call time, so we swap it per scenario.
+let fetchHandler = null;
+global.fetch = async (url) => {
+  if (!fetchHandler) throw new Error('no fetch handler installed');
+  return fetchHandler(String(url));
+};
+
+function jsonResponse(obj, status = 200) {
+  return { ok: status >= 200 && status < 300, status, json: async () => obj };
+}
+function errResponse(status) {
+  return { ok: false, status, json: async () => ({}) };
+}
+
+// The canonical Yahoo-shape keys every provider must emit (provider-blind).
+const REQUIRED_KEYS = ['symbol', 'name', 'price', 'currency', 'dayChangePct', 'spark', 'marketState'];
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+function check(cond, message) {
+  if (cond) { passed++; console.log(`  ✓ ${message}`); }
+  else { failed++; failures.push(message); console.log(`  ✗ ${message}`); }
+}
+
+function assertContractShape(quote, label) {
+  check(REQUIRED_KEYS.every((k) => k in quote), `${label}: has all required keys (${REQUIRED_KEYS.join(', ')})`);
+  check(Array.isArray(quote.spark) && quote.spark.length >= 2,
+    `${label}: spark is an array with >= 2 points (got ${Array.isArray(quote.spark) ? quote.spark.length : typeof quote.spark})`);
+  check(quote.spark.every((v) => Number.isFinite(v)), `${label}: every spark point is a finite number`);
+  check(typeof quote.name === 'string' && quote.name.length > 0, `${label}: name is a non-empty string`);
+  check(typeof quote.symbol === 'string' && quote.symbol.length > 0, `${label}: symbol is a non-empty string`);
+  check(quote.price === null || Number.isFinite(quote.price), `${label}: price is null or finite`);
+  check(quote.currency === 'USD', `${label}: currency is USD`);
+  check(quote.dayChangePct === null || Number.isFinite(quote.dayChangePct), `${label}: dayChangePct is null or finite`);
+  // marketState type must be consistent with Yahoo's enum (string) or null.
+  check(quote.marketState === null || typeof quote.marketState === 'string',
+    `${label}: marketState is a string or null (got ${typeof quote.marketState})`);
+}
+
+// --- Scenario builders -----------------------------------------------------
+
+// Finnhub /quote payload for a healthy symbol (free tier returns these fields).
+const QUOTE_PAYLOAD = { c: 140.85, d: 3.58, dp: 2.61, h: 141.9, l: 137.2, o: 138.0, pc: 137.27, t: 1700000000 };
+
+function freeTierHandler(url) {
+  if (url.includes('/quote?')) return jsonResponse(QUOTE_PAYLOAD);
+  if (url.includes('/stock/candle')) return errResponse(403);   // paid-only on free tier
+  if (url.includes('/stock/profile2')) return jsonResponse({ name: 'United States Oil Fund' });
+  throw new Error(`unexpected url ${url}`);
+}
+
+function freeTierNoProfileHandler(url) {
+  if (url.includes('/quote?')) return jsonResponse(QUOTE_PAYLOAD);
+  if (url.includes('/stock/candle')) return errResponse(403);
+  if (url.includes('/stock/profile2')) return errResponse(403); // profile2 also gated
+  throw new Error(`unexpected url ${url}`);
+}
+
+function paidTierHandler(url) {
+  if (url.includes('/quote?')) return jsonResponse(QUOTE_PAYLOAD);
+  if (url.includes('/stock/candle')) {
+    return jsonResponse({ s: 'ok', c: [130, 131, 132, 133, 134, 135, 136, 137, 138, 139], t: [] });
+  }
+  if (url.includes('/stock/profile2')) return jsonResponse({ name: 'United States Oil Fund' });
+  throw new Error(`unexpected url ${url}`);
+}
+
+async function main() {
+  // Require AFTER the fetch stub + env are in place.
+  const finnhub = require('../services/tape/quoteProviders/finnhub');
+
+  console.log('\nScenario A: free tier (candle 403, profile2 OK)');
+  fetchHandler = freeTierHandler;
+  const a = await finnhub.fetchQuote('USO');
+  assertContractShape(a, 'free-tier');
+  check(a.name === 'United States Oil Fund', `free-tier: name resolved from profile2 (got "${a.name}")`);
+  check(a.spark[a.spark.length - 1] === a.price, 'free-tier: live price is the final spark point');
+
+  console.log('\nScenario B: paid tier (candle returns 10 daily closes)');
+  fetchHandler = paidTierHandler;
+  const b = await finnhub.fetchQuote('USO');
+  assertContractShape(b, 'paid-tier');
+  check(b.spark.length >= 2 && b.spark.length <= 10, `paid-tier: spark has 2..10 points (got ${b.spark.length})`);
+  check(b.spark[b.spark.length - 1] === b.price, 'paid-tier: live price is the final spark point');
+
+  // Use a symbol never resolved above so the name cache can't mask the fallback.
+  console.log('\nScenario C: free tier, profile2 also gated (name must still resolve to symbol)');
+  fetchHandler = freeTierNoProfileHandler;
+  const c = await finnhub.fetchQuote('ZZZZ');
+  assertContractShape(c, 'no-profile');
+  check(c.name === 'ZZZZ', `no-profile: name falls back to symbol (got "${c.name}")`);
+
+  console.log('\nScenario D: resolved name is cached (profile2 hit at most once across calls)');
+  let profileHits = 0;
+  fetchHandler = (url) => {
+    if (url.includes('/stock/profile2')) { profileHits++; return jsonResponse({ name: 'Apple Inc.' }); }
+    if (url.includes('/quote?')) return jsonResponse({ ...QUOTE_PAYLOAD, c: 200, pc: 198, o: 199 });
+    if (url.includes('/stock/candle')) return errResponse(403);
+    throw new Error(`unexpected url ${url}`);
+  };
+  await finnhub.fetchQuote('AAPL');
+  await finnhub.fetchQuote('AAPL');
+  check(profileHits === 1, `name cache: profile2 fetched exactly once for two calls (got ${profileHits})`);
+
+  // --- Report --------------------------------------------------------------
+  console.log(`\n${passed} passed, ${failed} failed`);
+  if (failed) {
+    console.log('\nFailures:');
+    failures.forEach((f) => console.log(`  - ${f}`));
+    process.exit(1);
+  }
+  console.log('All Finnhub quote-shape contract checks passed.');
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/tests/tape-narrative-compliance.test.js
+++ b/tests/tape-narrative-compliance.test.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * Contract suite for the Tape `narrative` kind (synthesize marker contract).
+ *
+ *   node tests/tape-narrative-compliance.test.js
+ *
+ * No mocha/jest dependency — pure node assertions. Exercises the server-side
+ * guardrails directly (validateKindCompliance / hasRequiredMarkers / the prompt
+ * builders) so the marker + signed-sentiment contract is locked without needing
+ * a live LLM or network.
+ *
+ * A non-zero exit code indicates at least one scenario failed.
+ */
+
+const {
+  VALID_KINDS, validateKindCompliance, hasRequiredMarkers,
+  systemPromptFor, buildUserMessage, PROMPT_VERSION,
+} = require('../services/tape/tapePrompts');
+const { resolveHalfLife } = require('../services/tape/recency');
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+function check(cond, message) {
+  if (cond) { passed++; console.log(`  ✓ ${message}`); }
+  else { failed++; failures.push(message); console.log(`  ✗ ${message}`); }
+}
+
+// A well-formed narrative: THESIS + 3 chronological buckets w/ signed sentiment,
+// a sign-flip reversal across zero, plus optional INFLECTION + FORWARD.
+const VALID_NARRATIVE = `## THESIS: The market has swung from pricing aggressive 2026 rate cuts to doubting any at all.
+
+## BUCKET | 2024-01-01 | 2024-06-30 | 4
+Through H1 2024 the prevailing voices were convinced multiple cuts were coming.
+{{clip:abc123}}
+{{clip:def456}}
+
+## BUCKET | 2024-07-01 | 2024-12-31 | 1
+By late 2024 conviction softened to a hedged "maybe one or two."
+{{clip:ghi789}}
+
+## BUCKET | 2025-01-01 | 2025-12-31 | -3
+Sticky inflation flipped the consensus: most now argue cuts are off the table.
+{{clip:jkl012}}
+
+## INFLECTION
+- 2025-Q1: Hot CPI prints broke the rate-cut consensus.
+
+## FORWARD: The debate is drifting toward "higher for longer" as the base case.`;
+
+console.log('\nRegistry');
+check(VALID_KINDS.includes('narrative'), `narrative is a valid kind (VALID_KINDS = ${VALID_KINDS.join(', ')})`);
+check(PROMPT_VERSION !== 'v4', `PROMPT_VERSION bumped past v4 (got ${PROMPT_VERSION})`);
+
+console.log('\nValid narrative');
+const ok = validateKindCompliance('narrative', VALID_NARRATIVE);
+check(ok.ok === true, `well-formed narrative passes compliance (reason: ${ok.reason})`);
+check(hasRequiredMarkers('narrative', VALID_NARRATIVE) === true, 'well-formed narrative has required markers');
+
+console.log('\nRequired-marker failures (→ retry → 502)');
+const noThesis = VALID_NARRATIVE.replace(/## THESIS:.*\n/, '');
+check(!validateKindCompliance('narrative', noThesis).ok, 'missing ## THESIS fails');
+
+const twoBuckets = `## THESIS: x
+## BUCKET | 2024-01-01 | 2024-06-30 | 3
+s
+{{clip:a}}
+## BUCKET | 2024-07-01 | 2024-12-31 | 2
+s
+{{clip:b}}`;
+check(!validateKindCompliance('narrative', twoBuckets).ok, 'fewer than 3 buckets fails');
+
+console.log('\nSentiment validation (the load-bearing field)');
+const missingSentiment = `## THESIS: x
+## BUCKET | 2024-01-01 | 2024-06-30
+s
+{{clip:a}}
+## BUCKET | 2024-07-01 | 2024-12-31 | 2
+s
+{{clip:b}}
+## BUCKET | 2025-01-01 | 2025-12-31 | -1
+s
+{{clip:c}}`;
+check(!validateKindCompliance('narrative', missingSentiment).ok, 'a bucket missing its sentiment field fails');
+
+const outOfRange = VALID_NARRATIVE.replace('| 4\n', '| 7\n');
+check(!validateKindCompliance('narrative', outOfRange).ok, 'sentiment out of -5..+5 range (7) fails');
+
+const nonInteger = VALID_NARRATIVE.replace('| 4\n', '| 3.5\n');
+check(!validateKindCompliance('narrative', nonInteger).ok, 'non-integer sentiment (3.5) fails');
+
+const negativeAndZeroOk = `## THESIS: x
+## BUCKET | 2024-01-01 | 2024-06-30 | -5
+s
+{{clip:a}}
+## BUCKET | 2024-07-01 | 2024-12-31 | 0
+s
+{{clip:b}}
+## BUCKET | 2025-01-01 | 2025-12-31 | +5
+s
+{{clip:c}}`;
+check(validateKindCompliance('narrative', negativeAndZeroOk).ok, 'signed/zero/plus-prefixed integers (-5, 0, +5) all parse');
+
+console.log('\nCross-kind bleed');
+const leakVerdict = VALID_NARRATIVE.replace('## FORWARD:', '## VERDICT: rising\n## FORWARD:');
+const lv = validateKindCompliance('narrative', leakVerdict);
+check(!lv.ok && lv.leaked.includes('## VERDICT:'), 'arc\'s ## VERDICT: leaking into narrative fails');
+
+const leakCall = `${VALID_NARRATIVE}\n## CALL | 2025-01-01 | x | 5 |`;
+check(!validateKindCompliance('narrative', leakCall).ok, 'arc\'s ## CALL leaking into narrative fails');
+
+const leakPublisher = VALID_NARRATIVE.replace('## INFLECTION', '## PUBLISHER: CNBC\n## INFLECTION');
+check(!validateKindCompliance('narrative', leakPublisher).ok, 'brief\'s ## PUBLISHER leaking into narrative fails');
+
+console.log('\nNarrative markers must not leak into OTHER kinds');
+const arcWithBucket = `## THESIS: x
+## VERDICT: y
+## CALL | 2024-01-01 | a | 3 |
+{{clip:a}}
+## CALL | 2024-06-01 | b | 4 |
+{{clip:b}}
+## CALL | 2024-12-01 | c | 5 |
+{{clip:c}}
+## BUCKET | 2024-01-01 | 2024-12-31 | 3
+leaked`;
+const arcLeak = validateKindCompliance('arc', arcWithBucket);
+check(!arcLeak.ok && arcLeak.leaked.includes('## BUCKET |'), 'narrative\'s ## BUCKET | leaking into arc fails');
+
+console.log('\nPrompt construction');
+const sys = systemPromptFor('narrative');
+check(typeof sys === 'string' && sys.includes('## BUCKET |') && sys.includes('SENTIMENT RUBRIC'),
+  'systemPromptFor(narrative) includes the bucket contract + sentiment rubric');
+check(sys.includes('## TICKERS'), 'narrative system prompt still appends the ## TICKERS block');
+
+const userMsg = buildUserMessage({
+  kind: 'narrative',
+  input: { topic: 'the AI bubble', group: 'bears' },
+  candidates: [{ pineconeId: 'abc123', text: 'hi', creator: 'X', publishedDate: '2024-01-01' }],
+});
+check(userMsg.includes('GROUP: bears'), 'buildUserMessage surfaces the GROUP filter');
+check(userMsg.includes('TOPIC: the AI bubble'), 'buildUserMessage surfaces the TOPIC');
+
+console.log('\nRecency weighting bypass (spec §3.2)');
+check(resolveHalfLife({ kind: 'narrative' }).disabled === true, 'narrative kind disables recency weighting by default');
+check(resolveHalfLife({ kind: 'narrative', disableRecencyWeighting: true }).disabled === true, 'explicit disableRecencyWeighting also disables');
+
+// --- Report ----------------------------------------------------------------
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed) {
+  console.log('\nFailures:');
+  failures.forEach((f) => console.log(`  - ${f}`));
+  process.exit(1);
+}
+console.log('All narrative kind-contract checks passed.');

--- a/utils/clipReranker.js
+++ b/utils/clipReranker.js
@@ -15,7 +15,7 @@ const MIN_RELEVANCE_SCORE = 4;
  * @param {string} [options.userMessage] - The original user question (NOT the rewritten search query). When provided, the scorer applies a person-mismatch penalty: clips from episodes whose tagged guests don't include a person the user named score 0-3.
  * @returns {{ clips: Array, usage: { model: string, input_tokens: number, output_tokens: number } }}
  */
-async function rerankClips({ query, clips, openai, minScore = MIN_RELEVANCE_SCORE, userMessage }) {
+async function rerankClips({ query, clips, openai, minScore = MIN_RELEVANCE_SCORE, userMessage, subjectInfo }) {
   const debugPrefix = '[RERANKER]';
 
   if (!clips || clips.length === 0) {
@@ -38,7 +38,14 @@ async function rerankClips({ query, clips, openai, minScore = MIN_RELEVANCE_SCOR
     return `[${i}] (${speaker} — ${episode})${guestStr} "${text}"`;
   });
 
-  const systemPrompt = `You are a relevance scorer for podcast transcript clips. Given the user's question and a numbered list of clips, score each clip 0-10 on how directly relevant and substantive it is to answering the question.
+  // Optional subject identity (e.g. a company card) — lets the scorer DROP a
+  // wrong same-named entity (a clip about "Constellation" Software when the
+  // subject is Constellation ENERGY/CEG) even though the name token matches.
+  const subjectBlock = (typeof subjectInfo === 'string' && subjectInfo.trim())
+    ? `\n\nSUBJECT IDENTITY (the query is about THIS specific entity):\n${subjectInfo.trim()}\nCRITICAL: a clip that matches the name but is clearly about a DIFFERENT company/entity (a same-named but unrelated business, different industry, different people) is OFF-TOPIC — score it 0-2 regardless of keyword overlap.`
+    : '';
+
+  const systemPrompt = `You are a relevance scorer for podcast transcript clips. Given the user's question and a numbered list of clips, score each clip 0-10 on how directly relevant and substantive it is to answering the question.${subjectBlock}
 
 Scoring guide:
 - 0-1: Completely irrelevant, sponsor/ad reads, promo codes, "brought to you by" segments, social media plugs, or intro/outro greetings


### PR DESCRIPTION
## Summary

Self-contained `/api/tape/*` backend for the Tape finance skin, shipping three editorial kinds this release — **Read-In, Brief, Split** — over the existing search/corpus/LLM service layer (retrieve → synthesize → parse → hydrate), with auth, caching, rate limits, editorial taste config, and an LLM-judge eval harness.

## Highlights

**Endpoints & pipeline**
- Kind endpoints (`/readin`, `/brief`, `/split`, plus `/dossier`, `/narrative`), `/topic-quotes`, `/person-quotes`, `/synthesize`, `/quote/:slug`, `/auth`.
- Per-kind model routing; stance gate (LLM bull/bear/neutral) so bear slots are genuinely bearish; company-card grounding for Read-In.

**Retrieval quality**
- feedId-based source gating + soft source-preference demote; analyst-angle theme expansion; ad-read reranker; literal-anchor tuning.
- **Thin-ticker fix:** zero-coverage tickers route to an industry fallback instead of fabricating on off-topic noise (thin-cohort eval 5/12 → 11/12).

**Caching & cost**
- In-memory store (Redis-optional) with a bounded LRU (`TAPE_CACHE_MAX_ENTRIES`, default 2000); semantic cache; content-addressed synthesis.
- **Read-In cache keyed on ticker alone** so one cheap (`fast`) warmed entry serves every request regardless of `model`.
- **Daily Read-In cache warmer** — in-process cron (env-overridable schedule, default 8 AM CT), generic hot-ticker list + pluggable provider, `$2`/150-ticker caps.
- **`POST /api/tape/warm`** — `SHARED_HMAC_SECRET`-gated route to arm the warm in-process (rebuild the live cache without a restart), with a free `dryRun` mode.

**Company cards & crons**
- 232-ticker card set (Finnhub backbone + LLM facts), staleness hydration job, daily 10 AM CT hydrate cron.

**Eval**
- LLM-judge harness (`scripts/tape-eval*.js`) — deterministic gate → Sonnet judge → quality/flags/cost, with a thin-coverage cohort.

## Testing
- Eval harness journey 19% → 65% pass; thin cohort 11/12.
- Cache verified locally: cold miss → warm hit (~5ms); cross-model hit (fast warm served to a `quality` request); `/warm` auth (401 wrong / 200 dryRun, zero tokens).

## Notes / follow-ups
- No Redis ⇒ cache is per-process and resets on restart/redeploy; the `/warm` route + daily cron mitigate this. Redis would make warmth durable across deploys + instances.
- Future ideas parked: web-search gap-fill, search history, conversational watchlist, email alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)