### PR TITLE
fix(nostr-bot): give Nostr agent replies a 5-minute budget (was 180s)

### DIFF
--- a/scripts/nostr-agent-budget-probe.js
+++ b/scripts/nostr-agent-budget-probe.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Live probe: run the real /api/pull agent twice for the query that was
+ * timing out on Nostr (Michael Saylor "we are never selling"), using the
+ * same 5-minute budget the Nostr reply worker now passes, and assert
+ * both runs succeed with non-empty text.
+ *
+ *   node scripts/nostr-agent-budget-probe.js
+ *
+ * NOTE: this hits live services (MongoDB, Pinecone, LLM providers) and
+ * costs two real agent runs. It is a manual validation probe, not part
+ * of the unit suite. Exits non-zero if either run fails.
+ *
+ * Reproduces the mention that failed in prod with attemptCount=3 /
+ * "agent timeout" (eventId 1d166b0d…), minus the entitlement/zap and
+ * relay-publish legs — exactly the agent call in NostrBotReplyService.
+ */
+
+require('dotenv').config();
+const assert = require('assert');
+const mongoose = require('mongoose');
+const { runPull } = require('../services/agentPullService');
+const { NOSTR_AGENT_TIMEOUT_MS } = require('../utils/NostrBotReplyService');
+
+// The user's note content after the reply worker strips the
+// `nostr:npub1…` mention and collapses whitespace.
+const QUERY = 'Hey Did when did Micheal Saylor say "we are never selling"';
+const AUTHOR_PUBKEY = '59a98c047944f65ea40f3765555ee589bf50363f4f7dcf5594c3584bbb13ff66';
+const RUNS = 2;
+
+(async () => {
+  const uri = process.env.DEBUG_MODE === 'true' ? process.env.MONGO_DEBUG_URI : process.env.MONGO_URI;
+  assert(uri, 'MONGO_URI (or MONGO_DEBUG_URI) must be set in env');
+
+  await mongoose.connect(uri, { useNewUrlParser: true, useUnifiedTopology: true });
+  console.log(`[probe] connected to mongo; agent budget = ${NOSTR_AGENT_TIMEOUT_MS}ms (${NOSTR_AGENT_TIMEOUT_MS / 60000}min)`);
+  console.log(`[probe] query: ${QUERY}\n`);
+
+  let failures = 0;
+  for (let i = 1; i <= RUNS; i++) {
+    const started = Date.now();
+    let result;
+    try {
+      result = await runPull({
+        message: QUERY,
+        identity: {
+          tier: 'subscriber',
+          identifier: AUTHOR_PUBKEY,
+          identifierType: 'npub',
+          user: null,
+          provider: 'nostr',
+          email: null,
+        },
+        timeoutMs: NOSTR_AGENT_TIMEOUT_MS,
+      });
+    } catch (err) {
+      result = { ok: false, error: err.message };
+    }
+    const ms = Date.now() - started;
+    const text = result && typeof result.text === 'string' ? result.text : '';
+    const ok = !!(result && result.ok && text.trim().length > 0);
+
+    console.log(
+      `[probe] run ${i}/${RUNS}: ok=${ok} elapsed=${(ms / 1000).toFixed(1)}s ` +
+      `status=${result && result.status ? result.status : 'n/a'} ` +
+      `textLen=${text.length} err=${result && result.error ? result.error : 'none'}`,
+    );
+    if (ok) {
+      console.log(`           preview: ${text.slice(0, 180).replace(/\s+/g, ' ')}…\n`);
+    } else {
+      failures++;
+      console.log('');
+    }
+  }
+
+  await mongoose.connection.close();
+
+  if (failures > 0) {
+    console.error(`[probe] FAIL: ${failures}/${RUNS} runs failed`);
+    process.exit(1);
+  }
+  console.log(`[probe] PASS: ${RUNS}/${RUNS} runs succeeded with non-empty answers`);
+  process.exit(0);
+})().catch((err) => {
+  console.error('[probe] fatal:', err);
+  process.exit(1);
+});

--- a/utils/NostrBotReplyService.js
+++ b/utils/NostrBotReplyService.js
@@ -38,12 +38,24 @@ const { ENTITLEMENT_TYPES } = require('../constants/entitlementTypes');
 
 const DEFAULT_BATCH_SIZE = 10;
 const MAX_ATTEMPTS_PER_MENTION = 3;
+// Agent wall-clock budget for a Nostr reply. Nostr replies are async —
+// there's no user holding a connection open — so we can afford a much
+// longer budget than the interactive /api/pull default (180s), letting
+// the agent finish multi-round research (e.g. specific quote-attribution
+// lookups) instead of getting hard-killed mid-flight with no answer. The
+// agent's own guards (maxToolRounds, cost cap) still bound the work;
+// this just stops the outer timer from cutting a healthy run short.
+const NOSTR_AGENT_TIMEOUT_MS = (() => {
+  const raw = parseInt(process.env.NOSTR_AGENT_TIMEOUT_MS, 10);
+  if (Number.isFinite(raw) && raw >= 30_000) return raw;
+  return 5 * 60 * 1000; // default: 5 minutes
+})();
 // A mention claimed (status → processing) but not resolved within this
 // window is considered orphaned — the worker that claimed it crashed,
 // was killed, deployed over, or timed out mid-agent. The next tick
-// reclaims it. Must exceed the agent timeout (180s in agentPullService)
-// with headroom so we never reclaim a row that's still legitimately
-// being worked. 10 minutes gives ~3x the agent timeout.
+// reclaims it. Must exceed NOSTR_AGENT_TIMEOUT_MS with headroom so we
+// never reclaim a row that's still legitimately being worked. 10 minutes
+// gives 2x the 5-minute agent budget.
 const PROCESSING_LEASE_SECONDS = 10 * 60;
 const MENTION_AGE_LIMIT_SECONDS = 24 * 3600; // ignore mentions older than 24h on first ingest
 const RATE_LIMIT_WINDOW_SECONDS = 3600;        // 1h sliding window
@@ -246,6 +258,7 @@ class NostrBotReplyService {
           provider: 'nostr',
           email: null,
         },
+        timeoutMs: NOSTR_AGENT_TIMEOUT_MS,
       });
     } catch (err) {
       await this._refund(entitlement._id, costMicroUsd);
@@ -391,5 +404,6 @@ class NostrBotReplyService {
 module.exports = NostrBotReplyService;
 module.exports.MAX_ATTEMPTS_PER_MENTION = MAX_ATTEMPTS_PER_MENTION;
 module.exports.PROCESSING_LEASE_SECONDS = PROCESSING_LEASE_SECONDS;
+module.exports.NOSTR_AGENT_TIMEOUT_MS = NOSTR_AGENT_TIMEOUT_MS;
 module.exports.RATE_LIMIT_WINDOW_SECONDS = RATE_LIMIT_WINDOW_SECONDS;
 module.exports.RATE_LIMIT_MAX_REPLIES_PER_NPUB = RATE_LIMIT_MAX_REPLIES_PER_NPUB;


### PR DESCRIPTION
## Problem

A Nostr mention asking *"when did Michael Saylor say 'we are never selling'"* failed in prod with `attemptCount: 3` / `errorMessage: "agent timeout"` — all three retries (the retry logic from #127) hit the same wall.

Root cause: the reply worker called `runPull()` with the **default 180s** timeout. That outer timer is the binding constraint — the DEFAULT execution profile's internal latency caps are diagnostic blow-outs (`latencyBudgetHardMs: 1_000_000` ≈ 16.7min), so they never fire. When the 180s timer trips it calls `res.emit('close')` → sets `_aborted = true`, which **also skips the forced synthesis-on-exit** ([agentChatRoutes.js:1712](routes/agentChatRoutes.js#L1712) requires `!_aborted`). So a slow query returns **no answer at all**, and the mention fails — even though the agent had gathered evidence.

## Change

Nostr replies are async — no user is holding a connection open — so latency is cheap. Give Nostr agent calls a **5-minute budget** (env-overridable via `NOSTR_AGENT_TIMEOUT_MS`).

- The agent's own guards (`maxToolRounds: 6`, cost cap) still bound the work and trigger synthesis; this just stops the outer timer from killing a healthy run before it composes its answer.
- The 10-minute processing lease from #127 still gives **2× headroom** over the new 5-min budget, so orphan-reclaim semantics are unchanged.

## Validation

New `scripts/nostr-agent-budget-probe.js` — a live probe (hits real Mongo/Pinecone/LLM, not part of the unit suite) that runs the **exact failing query twice** through `runPull` with the production timeout constant, asserting both succeed with non-empty text.

```
[probe] run 1/2: ok=true elapsed=47.9s  textLen=1183
[probe] run 2/2: ok=true elapsed=181.6s textLen=1811
[probe] PASS: 2/2 runs succeeded with non-empty answers
```

**Run 2 took 181.6s** — just over the old 180s ceiling. It would have failed before this change and now completes via `max_rounds` synthesis. That single data point is the whole bug in miniature.

## Notes / follow-up
- Branches off `master` (includes #127).
- Deeper latent issue, **not** fixed here: a run that exceeds even the 5-min budget still returns empty because the abort path skips synthesis. Worth a follow-up to let the outer timeout trigger a best-effort synthesis instead of a hard kill. Flagging, not doing it in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
