### PR TITLE
perf(corpus): index-back person-name lookups (92s → ~1s)

### DIFF
--- a/models/JamieVectorMetadata.js
+++ b/models/JamieVectorMetadata.js
@@ -87,6 +87,30 @@ JamieVectorMetadataSchema.index({ type: 1, guid: 1, start_time: 1, end_time: 1 }
 JamieVectorMetadataSchema.index({ type: 1, 'metadataRaw.guests': 1 });
 JamieVectorMetadataSchema.index({ type: 1, 'metadataRaw.keywords': 1 });
 
+// Case-insensitive person-name lookups (find_person / get_person_episodes).
+// A plain index can't serve a case-insensitive $regex, so name lookups used
+// to fall back to a full scan of all ~128k episode docs (90s+ in prod). These
+// collation indexes (strength:2 = case-insensitive) let equality matches with
+// the same collation seek directly. Partial on type:'episode' so the index
+// only covers episode docs, keeping the build small and fast. Query side must
+// pass `.collation({ locale: 'en', strength: 2 })` to use them.
+JamieVectorMetadataSchema.index(
+  { 'metadataRaw.guests': 1 },
+  {
+    name: 'guests_ci',
+    collation: { locale: 'en', strength: 2 },
+    partialFilterExpression: { type: 'episode' },
+  }
+);
+JamieVectorMetadataSchema.index(
+  { 'metadataRaw.creator': 1 },
+  {
+    name: 'creator_ci',
+    collation: { locale: 'en', strength: 2 },
+    partialFilterExpression: { type: 'episode' },
+  }
+);
+
 // Enforce single canonical episode doc per guid (still one collection)
 JamieVectorMetadataSchema.index(
   // Use different key order than the non-unique index to avoid duplicate-index warnings in mongoose

--- a/services/corpusService.js
+++ b/services/corpusService.js
@@ -10,6 +10,31 @@ const JamieVectorMetadata = require('../models/JamieVectorMetadata');
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
 
+// Person lookups (find_person / get_person_episodes) run case-insensitive
+// $regex scans over the episode docs — regex isn't btree-indexable, so these
+// are collection scans. On a loaded DB one scan can take 90s+, which used to
+// hang the agent loop until its outer timeout. We hard-bound every person
+// query with maxTimeMS so a slow scan fails fast and the agent moves on with
+// whatever the other (faster) scans returned, instead of stalling the turn.
+const PERSON_QUERY_MAX_TIME_MS = (() => {
+  const raw = parseInt(process.env.CORPUS_PERSON_QUERY_MAX_TIME_MS, 10);
+  if (Number.isFinite(raw) && raw >= 1000) return raw;
+  return 15000; // default: 15s per scan
+})();
+
+// Case-insensitive collation. Querying name fields with equality + this
+// collation lets the planner use the guests_ci / creator_ci indexes
+// (JamieVectorMetadata) instead of an unindexable case-insensitive $regex,
+// turning a 90s scan into a millisecond seek. strength:2 = case-insensitive,
+// accent-sensitive.
+const PERSON_CI_COLLATION = { locale: 'en', strength: 2 };
+
+// MongoDB raises code 50 / "MaxTimeMSExpired" when a query exceeds maxTimeMS.
+function isMaxTimeExpired(err) {
+  return !!err && (err.code === 50 || err.codeName === 'MaxTimeMSExpired'
+    || /maxtimems/i.test(err.message || ''));
+}
+
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
@@ -136,24 +161,14 @@ async function listChapters({ guids, feedIds, limit: rawLimit }) {
   return { data: chapters.map(formatChapter) };
 }
 
-async function findPeople({ guestsOnly, search, feedId, limit, page }) {
-  const pag = clampPagination({ limit, page });
-  const excludeCreators = guestsOnly === 'true' || guestsOnly === true;
-
-  const pipelines = [];
-
-  // Guest pipeline
-  const guestMatch = { type: 'episode', 'metadataRaw.guests': { $exists: true, $ne: [] } };
-  if (feedId) guestMatch.feedId = feedId;
-
-  const guestPipeline = [
-    { $match: guestMatch },
-    { $unwind: '$metadataRaw.guests' },
-    ...(search ? [{ $match: { 'metadataRaw.guests': { $regex: search, $options: 'i' } } }] : []),
+// $group + $project tail shared by the guest and creator pipelines. `role`
+// distinguishes the two in the output.
+function personGroupAndProject(role) {
+  return [
     {
       $group: {
-        _id: { $toLower: '$metadataRaw.guests' },
-        name: { $first: '$metadataRaw.guests' },
+        _id: { $toLower: `$metadataRaw.${role === 'guest' ? 'guests' : 'creator'}` },
+        name: { $first: `$metadataRaw.${role === 'guest' ? 'guests' : 'creator'}` },
         appearances: { $sum: 1 },
         feeds: { $addToSet: { feedId: '$feedId', title: '$metadataRaw.feedTitle' } },
         recentEpisodes: {
@@ -168,7 +183,7 @@ async function findPeople({ guestsOnly, search, feedId, limit, page }) {
     },
     {
       $project: {
-        _id: 0, name: 1, role: { $literal: 'guest' }, appearances: 1,
+        _id: 0, name: 1, role: { $literal: role }, appearances: 1,
         feeds: { $slice: ['$feeds', 5] },
         recentEpisodes: {
           $slice: [{ $sortArray: { input: '$recentEpisodes', sortBy: { publishedTimestamp: -1 } } }, 3],
@@ -176,45 +191,69 @@ async function findPeople({ guestsOnly, search, feedId, limit, page }) {
       },
     },
   ];
-  pipelines.push(JamieVectorMetadata.aggregate(guestPipeline));
+}
+
+// Run the guest + creator aggregations for one match mode, time-bounded and
+// independently recoverable (a slow/failed pipeline degrades to []). When
+// `useCollation` is set, equality $matches ride the case-insensitive collation
+// indexes (guests_ci / creator_ci) — the fast path. The regex mode is the
+// substring fallback and cannot use an index (it scans, hence maxTimeMS).
+async function runPeoplePipelines({ search, feedId, excludeCreators, useCollation }) {
+  const eq = (field) => (useCollation
+    ? { [field]: search }
+    : { [field]: { $regex: search, $options: 'i' } });
+
+  const guestBase = useCollation
+    ? { type: 'episode', ...eq('metadataRaw.guests') }
+    : { type: 'episode', 'metadataRaw.guests': { $exists: true, $ne: [] } };
+  if (feedId) guestBase.feedId = feedId;
+
+  const guestPipeline = [
+    { $match: guestBase },
+    ...(useCollation ? [] : (search ? [{ $match: eq('metadataRaw.guests') }] : [])),
+    { $unwind: '$metadataRaw.guests' },
+    ...(search ? [{ $match: eq('metadataRaw.guests') }] : []),
+    ...personGroupAndProject('guest'),
+  ];
+
+  const aggs = [guestPipeline];
 
   if (!excludeCreators) {
-    const creatorMatch = { type: 'episode', 'metadataRaw.creator': { $exists: true, $ne: null, $ne: '' } };
-    if (feedId) creatorMatch.feedId = feedId;
+    const creatorBase = useCollation
+      ? { type: 'episode', ...eq('metadataRaw.creator') }
+      : { type: 'episode', 'metadataRaw.creator': { $exists: true, $ne: null, $ne: '' } };
+    if (feedId) creatorBase.feedId = feedId;
 
     const creatorPipeline = [
-      { $match: creatorMatch },
-      ...(search ? [{ $match: { 'metadataRaw.creator': { $regex: search, $options: 'i' } } }] : []),
-      {
-        $group: {
-          _id: { $toLower: '$metadataRaw.creator' },
-          name: { $first: '$metadataRaw.creator' },
-          appearances: { $sum: 1 },
-          feeds: { $addToSet: { feedId: '$feedId', title: '$metadataRaw.feedTitle' } },
-          recentEpisodes: {
-            $push: {
-              guid: '$guid',
-              title: '$metadataRaw.title',
-              publishedDate: '$metadataRaw.publishedDate',
-              publishedTimestamp: '$publishedTimestamp',
-            },
-          },
-        },
-      },
-      {
-        $project: {
-          _id: 0, name: 1, role: { $literal: 'creator' }, appearances: 1,
-          feeds: { $slice: ['$feeds', 5] },
-          recentEpisodes: {
-            $slice: [{ $sortArray: { input: '$recentEpisodes', sortBy: { publishedTimestamp: -1 } } }, 3],
-          },
-        },
-      },
+      { $match: creatorBase },
+      ...(useCollation ? [] : (search ? [{ $match: eq('metadataRaw.creator') }] : [])),
+      ...personGroupAndProject('creator'),
     ];
-    pipelines.push(JamieVectorMetadata.aggregate(creatorPipeline));
+    aggs.push(creatorPipeline);
   }
 
-  // Feed-hosts pipeline: find feeds where the person is a tagged host
+  const settled = await Promise.allSettled(aggs.map((pipeline) => {
+    let agg = JamieVectorMetadata.aggregate(pipeline).option({ maxTimeMS: PERSON_QUERY_MAX_TIME_MS });
+    if (useCollation) agg = agg.collation(PERSON_CI_COLLATION);
+    return agg.exec();
+  }));
+
+  return settled.map((r) => {
+    if (r.status === 'fulfilled') return r.value;
+    if (isMaxTimeExpired(r.reason)) {
+      console.warn(`[corpusService.findPeople] a ${useCollation ? 'exact' : 'regex'} person scan exceeded ${PERSON_QUERY_MAX_TIME_MS}ms for search="${search || ''}" — returning partial results`);
+      return [];
+    }
+    throw r.reason;
+  }).flat();
+}
+
+async function findPeople({ guestsOnly, search, feedId, limit, page }) {
+  const pag = clampPagination({ limit, page });
+  const excludeCreators = guestsOnly === 'true' || guestsOnly === true;
+
+  // Feed-hosts lookup: only 352 feed docs, so a regex scan here is sub-ms and
+  // not worth indexing. Runs in parallel with the people lookup.
   let feedHostsPromise = Promise.resolve([]);
   if (search) {
     feedHostsPromise = JamieVectorMetadata.find({
@@ -222,16 +261,29 @@ async function findPeople({ guestsOnly, search, feedId, limit, page }) {
       'metadataRaw.hosts': { $elemMatch: { $regex: search, $options: 'i' } },
     })
       .select('feedId metadataRaw')
+      .maxTimeMS(PERSON_QUERY_MAX_TIME_MS)
       .lean()
-      .then(docs => docs.map(formatFeed));
+      .then(docs => docs.map(formatFeed))
+      .catch((err) => {
+        if (isMaxTimeExpired(err)) {
+          console.warn(`[corpusService.findPeople] feed-hosts scan exceeded ${PERSON_QUERY_MAX_TIME_MS}ms for search="${search}" — returning none`);
+          return [];
+        }
+        throw err;
+      });
   }
 
-  const [peopleResults, hostedFeeds] = await Promise.all([
-    Promise.all(pipelines),
-    feedHostsPromise,
-  ]);
+  // Fast path: index-backed case-insensitive EXACT match (the agent almost
+  // always passes a full name like "Michael Saylor"). Falls back to the
+  // bounded substring regex scan only when exact finds nobody, so partial-name
+  // discovery still works without paying the scan cost on every call.
+  let peopleResults = await runPeoplePipelines({ search, feedId, excludeCreators, useCollation: !!search });
+  if (search && peopleResults.length === 0) {
+    peopleResults = await runPeoplePipelines({ search, feedId, excludeCreators, useCollation: false });
+  }
+  const hostedFeeds = await feedHostsPromise;
 
-  let allPeople = peopleResults.flat()
+  let allPeople = peopleResults
     .map(p => ({
       ...p,
       feeds: (p.feeds || []).filter(f => f.feedId && f.title),
@@ -261,24 +313,48 @@ async function getPersonEpisodes({ name, guestsOnly = false, feedId, limit, page
   const searchName = name.trim();
   const excludeCreators = guestsOnly === true || guestsOnly === 'true';
 
+  // Case-insensitive EXACT match via collation (index-backed through
+  // guests_ci / creator_ci) — replaces the unindexable `^name$` regex while
+  // preserving exact-match semantics.
   const orConditions = [
-    { 'metadataRaw.guests': { $regex: `^${searchName}$`, $options: 'i' } },
+    { 'metadataRaw.guests': searchName },
   ];
   if (!excludeCreators) {
-    orConditions.push({ 'metadataRaw.creator': { $regex: `^${searchName}$`, $options: 'i' } });
+    orConditions.push({ 'metadataRaw.creator': searchName });
   }
 
   const query = { type: 'episode', $or: orConditions };
   if (feedId) query.feedId = feedId;
 
-  const totalCount = await JamieVectorMetadata.countDocuments(query);
-
-  const episodes = await JamieVectorMetadata.find(query)
-    .select('guid feedId publishedDate publishedTimestamp metadataRaw')
-    .sort({ publishedTimestamp: -1 })
-    .skip(pag.skip)
-    .limit(pag.limit)
-    .lean();
+  // maxTimeMS guard as a backstop. On timeout we surface an explicit error
+  // the agent can act on rather than hanging the turn.
+  let totalCount;
+  let episodes;
+  try {
+    totalCount = await JamieVectorMetadata.countDocuments(query)
+      .collation(PERSON_CI_COLLATION)
+      .maxTimeMS(PERSON_QUERY_MAX_TIME_MS);
+    episodes = await JamieVectorMetadata.find(query)
+      .select('guid feedId publishedDate publishedTimestamp metadataRaw')
+      .sort({ publishedTimestamp: -1 })
+      .skip(pag.skip)
+      .limit(pag.limit)
+      .collation(PERSON_CI_COLLATION)
+      .maxTimeMS(PERSON_QUERY_MAX_TIME_MS)
+      .lean();
+  } catch (err) {
+    if (isMaxTimeExpired(err)) {
+      console.warn(`[corpusService.getPersonEpisodes] scan exceeded ${PERSON_QUERY_MAX_TIME_MS}ms for name="${searchName}"`);
+      return {
+        error: `Lookup for "${searchName}" timed out after ${PERSON_QUERY_MAX_TIME_MS}ms`,
+        status: 504,
+        data: [],
+        pagination: buildPagination(pag.page, pag.limit, 0),
+        query: { name: searchName, guestsOnly: excludeCreators, feedId: feedId || null },
+      };
+    }
+    throw err;
+  }
 
   const formatted = episodes.map(doc => {
     const meta = doc.metadataRaw || {};


### PR DESCRIPTION
## Problem

A Nostr mention timed out because `find_person("Michael Saylor")` took **92 seconds** in one agent round (and `get_person_episodes` similarly stalled). Root cause: both matched person names with a **case-insensitive `$regex`** (`$options: 'i'`). A case-insensitive regex can't use a btree index, so MongoDB fell back to scanning **all ~128k episode docs** on every name lookup. One slow tool call ate the whole agent budget.

## Fix

Make the lookups index-backed by querying with **equality + a case-insensitive collation** instead of regex.

- **New partial collation indexes** `guests_ci` / `creator_ci` on `JamieVectorMetadata` (`strength: 2` = case-insensitive; `partialFilterExpression: { type: 'episode' }` to keep the index small). Query side passes the matching `.collation({ locale: 'en', strength: 2 })`.
- **`get_person_episodes`**: swap `^name$` regex for collation equality — identical exact-match semantics, now a millisecond seek.
- **`find_person`**: index-backed exact match as the fast path, falling back to the bounded substring regex **only when exact finds nobody**, so partial-name discovery still works without paying the scan cost on every call.
- **`maxTimeMS` backstop** on every person query — on timeout we degrade to partial/empty results instead of hanging the turn.
- Left the feed-hosts lookup as a regex scan — it's only 352 feed docs (sub-ms), not worth indexing.

## Validation (live, prod, after building the indexes)

| Query | Before | After |
|---|---|---|
| `find_person("Michael Saylor")` | ~92s / timeout | **1.33s** cold, **0.18s** warm |
| `get_person_episodes("Michael Saylor")` | 15s timeout | **0.29s** |
| `find_person("Chris Williamson")` | slow | **1.37s** |

Correctness held: returns `Michael Saylor / guest / 274 appearances`, and lowercase `"michael saylor"` returns the **same** person — confirming the collation index.

## Deploy note

Building these indexes scans the full **~26M-doc** collection once (~14 min, **background / non-blocking**). `autoIndex` will trigger that build on first deploy boot — expect elevated DB load for ~15 min. The indexes are **already built on prod** (built during validation), so the deploy build will be a fast no-op confirmation.

## Related
- Companion to #129 (5-minute Nostr agent budget). Split out because this is a DB-performance concern, not a bot-timeout concern. Together they fix the same incident from both ends: the agent has more time *and* the slow tool is no longer slow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
