### PR TITLE
Serve audio playback through the Cloudflare-cached host (audio.pullthatupjamie.ai)

### DIFF
--- a/agent-tools/pineconeTools.js
+++ b/agent-tools/pineconeTools.js
@@ -8,6 +8,7 @@ const TfIdf = natural.TfIdf;
 const JamieVectorMetadata = require('../models/JamieVectorMetadata');
 const { printLog } = require('../constants.js');
 const { ensureFeedLanguages, getFeedLanguageSync } = require('../utils/feedLanguage');
+const { publicAudioUrl } = require('../utils/audioFormat');
 
 const PINECONE_API_KEY = process.env.PINECONE_API_KEY;
 const PINECONE_INDEX = process.env.PINECONE_INDEX;
@@ -269,7 +270,7 @@ const pineconeTools = {
                 // in. Callers that can await should call ensureFeedLanguages()
                 // first; otherwise a cold cache safely falls back to "en".
                 language: getFeedLanguageSync(match.metadata.feedId),
-                audioUrl: match.metadata.audioUrl || "URL unavailable",
+                audioUrl: publicAudioUrl(match.metadata.audioUrl) || "URL unavailable",
                 episodeImage: match.metadata.episodeImage || "Image unavailable",
                 date: match.metadata.publishedDate || "Date not provided",
                 published: match.metadata.publishedDate || match.metadata.publishedTimestamp || null,
@@ -625,7 +626,7 @@ const pineconeTools = {
                 publishedDate: metadata.publishedDate || metadata.published_date || null,
                 creator: metadata.creator || "Unknown Creator",
                 feedId: metadata.feedId || null,
-                audioUrl: metadata.audioUrl || null,
+                audioUrl: publicAudioUrl(metadata.audioUrl) || null,
                 episodeImage: metadata.episodeImage 
                               || metadata.image 
                               || metadata.imageUrl 

--- a/services/searchQuotesService.js
+++ b/services/searchQuotesService.js
@@ -12,6 +12,7 @@
 
 const { printLog } = require('../constants.js');
 const { findSimilarDiscussions } = require('../agent-tools/pineconeTools.js');
+const { publicAudioUrl } = require('../utils/audioFormat.js');
 const { triageQuery } = require('../utils/queryTriage');
 const { isProperNounShaped } = require('../utils/properNounDetector');
 const { atlasTextSearch } = require('./atlasTextSearch');
@@ -284,7 +285,7 @@ async function searchQuotes(params, { openai, recordHelperLlmUsage }) {
         // answer language ("translated from German").
         sourceLanguage: getFeedLanguageSync(metadata.feedId),
         feedId: metadata.feedId != null ? String(metadata.feedId) : null,
-        audioUrl: metadata.audioUrl || 'URL unavailable',
+        audioUrl: publicAudioUrl(metadata.audioUrl) || 'URL unavailable',
         episodeImage: metadata.episodeImage || 'Image unavailable',
         listenLink: metadata.listenLink || '',
         date: metadata.publishedDate || 'Date not provided',

--- a/utils/audioFormat.js
+++ b/utils/audioFormat.js
@@ -27,4 +27,26 @@ function storageKeyFromUrl(url) {
   }
 }
 
-module.exports = { AUDIO_EXTENSIONS, storageKeyFromUrl };
+// User-facing audio host. Public audioUrls are rewritten to this Cloudflare-
+// fronted hostname so repeat playback is served from Cloudflare's cache instead
+// of billing DigitalOcean egress. The path (feedId/guid.ext) is unchanged; a
+// Cloudflare Worker on this host maps requests back to the raw Spaces origin.
+const PUBLIC_AUDIO_HOST = 'audio.pullthatupjamie.ai';
+
+// Our Spaces audio bucket host, in either the CDN or direct form.
+const SPACES_AUDIO_HOST_RE = /cascdr-chads-stay-winning\.nyc3\.(?:cdn\.)?digitaloceanspaces\.com/i;
+
+/**
+ * Rewrite a stored DigitalOcean Spaces audio URL to the public Cloudflare host.
+ * No-ops for empty/non-string values and for URLs that don't point at our audio
+ * bucket (e.g. original RSS enclosures hosted on the podcaster's own domain).
+ *
+ * @param {string} url
+ * @returns {string} the rewritten URL, or the input unchanged
+ */
+function publicAudioUrl(url) {
+  if (!url || typeof url !== 'string') return url;
+  return url.replace(SPACES_AUDIO_HOST_RE, PUBLIC_AUDIO_HOST);
+}
+
+module.exports = { AUDIO_EXTENSIONS, storageKeyFromUrl, publicAudioUrl, PUBLIC_AUDIO_HOST };


### PR DESCRIPTION
## Why
Repeat audio playback was billing DigitalOcean Spaces egress on every play.
`audio.pullthatupjamie.ai` is now a Cloudflare Worker fronting the bucket with a
30-day edge cache (verified live: `MISS`→`HIT`, range/`206` supported). This
routes user-facing playback through that cached host, so DO only serves cache
misses.

## Change (surgical)
- **`utils/audioFormat.js`**: add `publicAudioUrl()` — rewrites our Spaces audio
  host (`cascdr-…[.cdn].digitaloceanspaces.com`) → `audio.pullthatupjamie.ai`,
  path unchanged. No-ops for empty/non-string values and for URLs that aren't our
  bucket (e.g. original RSS enclosures on a podcaster's own host).
- Wrapped `audioUrl` at the three browser-facing emit sites:
  - `pineconeTools.formatResults` — covers semantic search results **and** the
    share page `/api/clip/:id` (which resolves via `getClipById` → `formatResults`)
  - `pineconeTools` episode-metadata formatter
  - `searchQuotesService`

## Tests (local)
- `node --check` clean on all three changed files.
- Unit: `publicAudioUrl` rewrites CDN + direct Spaces hosts, and leaves
  podcaster hosts / the `"URL unavailable"` sentinel / `null` / `undefined` / `""`
  untouched.
- E2E: the helper's output URL serves `HTTP/2 200` `audio/mp4` through the Worker
  with `cf-cache-status: HIT` and `x-audio-proxy: cf-worker`.

## Notes
- No env flag — always on, per request.
- Server-side code that reads `metadata.audioUrl` directly is unchanged. Clip
  extraction that receives a rewritten URL still works (the Worker supports range
  requests — verified).
- A few lower-traffic / agent-facing emit sites (tape, workflow, research, neo4j,
  explore) still return the raw URL; they can be wrapped later if we want those on
  the cached host too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
