### PR TITLE
Guarantee cached audio host: global response filter for all audioUrl fields

### DIFF
--- a/server.js
+++ b/server.js
@@ -26,7 +26,7 @@ const callIngestor = require('./utils/callIngestor');
 const path = require('path');
 const {DEBUG_MODE, SCHEDULER_ENABLED, SCHEDULED_INGESTOR_TIMES, printLog} = require('./constants.js')
 const ClipUtils = require('./utils/ClipUtils');
-const { AUDIO_EXTENSIONS, storageKeyFromUrl } = require('./utils/audioFormat');
+const { AUDIO_EXTENSIONS, storageKeyFromUrl, rewriteAudioUrlsDeep } = require('./utils/audioFormat');
 const { getPodcastFeed } = require('./utils/LandingPageService');
 const {WorkProductV2, calculateLookupHash} = require('./models/WorkProductV2')
 const QueueJob = require('./models/QueueJob');
@@ -227,6 +227,16 @@ app.use(cors(corsOptions));
 app.enable('trust proxy');
 app.set('trust proxy', true);
 app.use(express.json());
+
+// Rewrite any audioUrl in JSON responses to the Cloudflare-cached host, so no
+// endpoint — including ones that dump raw metadataRaw — hands agents/clients the
+// raw DigitalOcean origin (which bypasses the cache). Idempotent; no-ops on
+// non-bucket URLs. SSE endpoints use res.write and are unaffected.
+app.use((req, res, next) => {
+  const sendJson = res.json.bind(res);
+  res.json = (body) => sendJson(rewriteAudioUrlsDeep(body));
+  next();
+});
 app.use(cookieParser()); // Add this line before session middleware
 
 // Add session middleware

--- a/utils/audioFormat.js
+++ b/utils/audioFormat.js
@@ -49,4 +49,30 @@ function publicAudioUrl(url) {
   return url.replace(SPACES_AUDIO_HOST_RE, PUBLIC_AUDIO_HOST);
 }
 
-module.exports = { AUDIO_EXTENSIONS, storageKeyFromUrl, publicAudioUrl, PUBLIC_AUDIO_HOST };
+/**
+ * Recursively rewrite every `audioUrl` string field within a value (in place) to
+ * the public Cloudflare host. Catches audioUrl carried inside dumped `metadataRaw`
+ * objects / arrays that per-call-site wrapping misses. No-ops on non-bucket URLs
+ * and non-string values, so it's safe to run over any JSON response body.
+ *
+ * @param {*} value
+ * @returns {*} the same value, mutated in place
+ */
+function rewriteAudioUrlsDeep(value) {
+  if (!value || typeof value !== 'object') return value;
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) rewriteAudioUrlsDeep(value[i]);
+    return value;
+  }
+  for (const key of Object.keys(value)) {
+    const v = value[key];
+    if (key === 'audioUrl' && typeof v === 'string') {
+      value[key] = publicAudioUrl(v);
+    } else if (v && typeof v === 'object') {
+      rewriteAudioUrlsDeep(v);
+    }
+  }
+  return value;
+}
+
+module.exports = { AUDIO_EXTENSIONS, storageKeyFromUrl, publicAudioUrl, PUBLIC_AUDIO_HOST, rewriteAudioUrlsDeep };


### PR DESCRIPTION
## Why
Follow-up to #133 / #134. Those wrapped explicit `audioUrl:` fields, but several
agent-facing endpoints return `audioUrl` **inside a dumped `metadataRaw` object**,
which per-key wrapping can't catch. Confirmed live — these still served the raw
DigitalOcean origin (cache bypass):

- `GET /api/episode-with-chapters/:guid` → `episode.metadata.audioUrl` (raw)
- `GET /api/fetch-adjacent-paragraphs` → raw
- plus 5 more `metadata: doc.metadataRaw` dump sites in `jamieExploreRoutes` /
  `researchSessions`

An agent using any of these pulls audio from outside the Cloudflare cache.

## Change
Add a **global response filter** so no endpoint — current or future — can hand out
the raw host:

- `utils/audioFormat.js`: `rewriteAudioUrlsDeep(value)` — recursively rewrites
  every `audioUrl` string field (in arrays, nested `metadata`, chapters, etc.) to
  the cached host. Idempotent; no-ops on non-bucket URLs and non-strings.
- `server.js`: a small middleware (right after `express.json()`) that wraps
  `res.json` to run `rewriteAudioUrlsDeep` over every JSON body.

This is the backstop that guarantees the invariant "`audioUrl` is always the
cached host." The per-call-site wraps from #133/#134 remain as idempotent no-ops.
SSE endpoints use `res.write` (not `res.json`) and only carry clip IDs, so they're
unaffected.

## Blast radius
Only string values under a key literally named `audioUrl`, and only the `cascdr-…`
audio-bucket host → `audio.pullthatupjamie.ai`. Podcaster-hosted RSS URLs,
already-cached URLs, non-audio URLs (video/images), and nulls are untouched.

## Tests
- `node --check` clean on `server.js` + `utils/audioFormat.js`.
- Unit: deep rewrite over a structure mirroring the `episode-with-chapters` dump —
  verifies nested `metadata`, chapter arrays, both raw host forms (`.cdn.` +
  direct), podcaster-host pass-through, already-cached no-op, and `null`
  preservation.
- Pre-fix live audit confirmed the raw-host leak on the endpoints above; this
  filter closes them all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
